### PR TITLE
set products on environment creation

### DIFF
--- a/.changelog/57.txt
+++ b/.changelog/57.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/pingone_environment: Now sets the services (bill of materials) at the point of environment creation
+```


### PR DESCRIPTION
To prevent environments being created with all products enabled (where API changes may conflict with the SDK), products (the bill of materials) is set at the same time as environment creation