### PR TITLE
`pingone_application`: Fix unexpected replacement plan when specifying a mobile native application without configuring deprecated attributes `oidc_options.bundle_id` or `oidc_options.package_name`.

### DIFF
--- a/.changelog/365.txt
+++ b/.changelog/365.txt
@@ -1,0 +1,7 @@
+```release-note:note
+`pingone_application`: Updated Native mobile example in registry documentation to remove deprecated attributes.
+```
+
+```release-note:bug
+`pingone_application`: Fix unexpected replacement plan when specifying a mobile native application without configuring deprecated attributes `oidc_options.bundle_id` or `oidc_options.package_name`.
+```

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -125,9 +125,6 @@ resource "pingone_application" "my_awesome_native_app" {
         }
       }
     }
-
-    bundle_id    = var.apple_bundle_id
-    package_name = var.android_package_name
   }
 }
 ```
@@ -260,11 +257,11 @@ Required:
 
 Optional:
 
-- `bundle_id` (String) A string that specifies the bundle associated with the application, for push notifications in native apps. The value of the `bundle_id` property is unique per environment, and once defined, is immutable.  this setting overrides the top-level `bundle_id` field
-- `huawei_app_id` (String) The unique identifier for the app on the device and in the Huawei Mobile Service AppGallery. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_package_name`.
-- `huawei_package_name` (String) The package name associated with the application, for push notifications in native apps. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_app_id`.
+- `bundle_id` (String) A string that specifies the bundle associated with the application, for push notifications in native apps. The value of the `bundle_id` property is unique per environment, and once defined, is immutable.  Changing this value will trigger a replacement plan of this resource.
+- `huawei_app_id` (String) The unique identifier for the app on the device and in the Huawei Mobile Service AppGallery. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_package_name`.  Changing this value will trigger a replacement plan of this resource.
+- `huawei_package_name` (String) The package name associated with the application, for push notifications in native apps. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_app_id`.  Changing this value will trigger a replacement plan of this resource.
 - `integrity_detection` (Block List, Max: 1) Mobile application integrity detection settings. (see [below for nested schema](#nestedblock--oidc_options--mobile_app--integrity_detection))
-- `package_name` (String) A string that specifies the package name associated with the application, for push notifications in native apps. The value of the `package_name` property is unique per environment, and once defined, is immutable.  this setting overrides the top-level `package_name` field.
+- `package_name` (String) A string that specifies the package name associated with the application, for push notifications in native apps. The value of the `package_name` property is unique per environment, and once defined, is immutable.  Changing this value will trigger a replacement plan of this resource.
 - `passcode_refresh_seconds` (Number) The amount of time a passcode should be displayed before being replaced with a new passcode - must be between 30 and 60. Defaults to `30`.
 - `universal_app_link` (String) A string that specifies a URI prefix that enables direct triggering of the mobile application when scanning a QR code. The URI prefix can be set to a universal link with a valid value (which can be a URL address that starts with `HTTP://` or `HTTPS://`, such as `https://www.bxretail.org`), or an app schema, which is just a string and requires no special validation.
 

--- a/examples/resources/pingone_application/resource-native-mobile.tf
+++ b/examples/resources/pingone_application/resource-native-mobile.tf
@@ -39,8 +39,5 @@ resource "pingone_application" "my_awesome_native_app" {
         }
       }
     }
-
-    bundle_id    = var.apple_bundle_id
-    package_name = var.android_package_name
   }
 }

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -298,25 +298,45 @@ func ResourceApplication() *schema.Resource {
 							Type:        schema.TypeList,
 							MaxItems:    1,
 							Optional:    true,
-							Computed:    true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// If we have an app configured, then we need to compute the diff.
+								if _, ok := d.GetOk("oidc_options.0.mobile_app.0.bundle_id"); ok {
+									return false
+								}
+
+								if _, ok := d.GetOk("oidc_options.0.mobile_app.0.package_name"); ok {
+									return false
+								}
+
+								if _, ok := d.GetOk("oidc_options.0.mobile_app.0.huawei_app_id"); ok {
+									return false
+								}
+
+								if _, ok := d.GetOk("oidc_options.0.mobile_app.0.huawei_package_name"); ok {
+									return false
+								}
+
+								// If no app configured, we can suppress the diff.
+								return true
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"bundle_id": {
-										Description:      "A string that specifies the bundle associated with the application, for push notifications in native apps. The value of the `bundle_id` property is unique per environment, and once defined, is immutable.  this setting overrides the top-level `bundle_id` field",
+										Description:      "A string that specifies the bundle associated with the application, for push notifications in native apps. The value of the `bundle_id` property is unique per environment, and once defined, is immutable.  Changing this value will trigger a replacement plan of this resource.",
 										Type:             schema.TypeString,
 										Optional:         true,
 										ForceNew:         true,
 										ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 									},
 									"package_name": {
-										Description:      "A string that specifies the package name associated with the application, for push notifications in native apps. The value of the `package_name` property is unique per environment, and once defined, is immutable.  this setting overrides the top-level `package_name` field.",
+										Description:      "A string that specifies the package name associated with the application, for push notifications in native apps. The value of the `package_name` property is unique per environment, and once defined, is immutable.  Changing this value will trigger a replacement plan of this resource.",
 										Type:             schema.TypeString,
 										Optional:         true,
 										ForceNew:         true,
 										ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 									},
 									"huawei_app_id": {
-										Description:      "The unique identifier for the app on the device and in the Huawei Mobile Service AppGallery. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_package_name`.",
+										Description:      "The unique identifier for the app on the device and in the Huawei Mobile Service AppGallery. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_package_name`.  Changing this value will trigger a replacement plan of this resource.",
 										Type:             schema.TypeString,
 										Optional:         true,
 										ForceNew:         true,
@@ -324,7 +344,7 @@ func ResourceApplication() *schema.Resource {
 										ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 									},
 									"huawei_package_name": {
-										Description:      "The package name associated with the application, for push notifications in native apps. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_app_id`.",
+										Description:      "The package name associated with the application, for push notifications in native apps. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_app_id`.  Changing this value will trigger a replacement plan of this resource.",
 										Type:             schema.TypeString,
 										Optional:         true,
 										ForceNew:         true,
@@ -447,7 +467,7 @@ func ResourceApplication() *schema.Resource {
 							Description:      "**Deprecation Notice** This field is deprecated and will be removed in a future release. Use `oidc_options.mobile_app.bundle_id` instead. A string that specifies the bundle associated with the application, for push notifications in native apps. The value of the `bundle_id` property is unique per environment, and once defined, is immutable; any change will force recreation of the application resource.",
 							Type:             schema.TypeString,
 							Optional:         true,
-							ForceNew:         true,
+							Computed:         true,
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 							Deprecated:       "This field is deprecated and will be removed in a future release. Use `oidc_options.mobile_app.bundle_id` instead.",
 						},
@@ -455,7 +475,7 @@ func ResourceApplication() *schema.Resource {
 							Description:      "**Deprecation Notice** This field is deprecated and will be removed in a future release. Use `oidc_options.mobile_app.package_name` instead. A string that specifies the package name associated with the application, for push notifications in native apps. The value of the `package_name` property is unique per environment, and once defined, is immutable; any change will force recreation of the application resource.",
 							Type:             schema.TypeString,
 							Optional:         true,
-							ForceNew:         true,
+							Computed:         true,
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 							Deprecated:       "This field is deprecated and will be removed in a future release. Use `oidc_options.mobile_app.package_name` instead.",
 						},

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -2834,9 +2834,6 @@ resource "pingone_application" "%[2]s" {
         }
       }
     }
-
-    bundle_id    = "com.%[2]s.bundle"
-    package_name = "com.%[2]s.package"
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name, image)
@@ -3003,9 +3000,6 @@ resource "pingone_application" "%[2]s" {
         }
       }
     }
-
-    bundle_id    = "com.%[2]s.bundle"
-    package_name = "com.%[2]s.package"
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name)
@@ -3072,9 +3066,6 @@ resource "pingone_application" "%[2]s" {
         }
       }
     }
-
-    bundle_id    = "com.%[2]s.bundle"
-    package_name = "com.%[2]s.package"
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name)
@@ -3117,9 +3108,6 @@ resource "pingone_application" "%[2]s" {
         }
       }
     }
-
-    bundle_id    = "com.%[2]s.bundle"
-    package_name = "com.%[2]s.package"
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name, googleJsonKey)
@@ -3159,9 +3147,6 @@ resource "pingone_application" "%[2]s" {
         excluded_platforms = ["GOOGLE"]
       }
     }
-
-    bundle_id    = "com.%[2]s.bundle"
-    package_name = "com.%[2]s.package"
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name)
@@ -3207,9 +3192,6 @@ resource "pingone_application" "%[2]s" {
         }
       }
     }
-
-    bundle_id    = "com.%[2]s.bundle"
-    package_name = "com.%[2]s.package"
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name)


### PR DESCRIPTION
```release-note:note
`pingone_application`: Updated Native mobile example in registry documentation to remove deprecated attributes.
```

```release-note:bug
`pingone_application`: Fix unexpected replacement plan when specifying a mobile native application without configuring deprecated attributes `oidc_options.bundle_id` or `oidc_options.package_name`.
```

## Testing Results - OIDC Native Mobile apps
### Command

```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccApplication_NativeMobile github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Results

```shell
=== RUN   TestAccApplication_NativeMobile
=== PAUSE TestAccApplication_NativeMobile
=== RUN   TestAccApplication_NativeMobile_IntegrityDetection
=== PAUSE TestAccApplication_NativeMobile_IntegrityDetection
=== CONT  TestAccApplication_NativeMobile
=== CONT  TestAccApplication_NativeMobile_IntegrityDetection
--- PASS: TestAccApplication_NativeMobile (48.30s)
--- PASS: TestAccApplication_NativeMobile_IntegrityDetection (77.32s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 78.018s
```

## Testing Results - OIDC Native (Generic) apps
### Command

```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccApplication_OIDCNative github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Results

```shell
=== RUN   TestAccApplication_OIDCNativeUpdate
=== PAUSE TestAccApplication_OIDCNativeUpdate
=== CONT  TestAccApplication_OIDCNativeUpdate
--- PASS: TestAccApplication_OIDCNativeUpdate (22.78s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 23.186s
```