### PR TITLE
Remove deprecated attributes from examples

### DIFF
--- a/.changelog/372.txt
+++ b/.changelog/372.txt
@@ -1,0 +1,7 @@
+```release-note:note
+`resource/pingone_mfa_application_push_credential`: Documentation: Remove deprecated attributes from example HCL.
+```
+
+```release-note:note
+`resource/pingone_mfa_policy`: Documentation: Remove deprecated attributes from example HCL.
+```

--- a/docs/resources/mfa_application_push_credential.md
+++ b/docs/resources/mfa_application_push_credential.md
@@ -40,9 +40,6 @@ resource "pingone_application" "my_application" {
       huawei_app_id       = "12345679"
       huawei_package_name = "org.bxretail.huaweipackage"
     }
-
-    bundle_id    = "org.bxretail.mybundle"
-    package_name = "org.bxretail.mypackage"
   }
 }
 

--- a/docs/resources/mfa_policy.md
+++ b/docs/resources/mfa_policy.md
@@ -94,9 +94,6 @@ resource "pingone_application" "my_mobile_application" {
         }
       }
     }
-
-    bundle_id    = "org.bxretail.mobileapp"
-    package_name = "org.bxretail.mobileapp"
   }
 }
 

--- a/examples/resources/pingone_mfa_application_push_credential/resource.tf
+++ b/examples/resources/pingone_mfa_application_push_credential/resource.tf
@@ -26,9 +26,6 @@ resource "pingone_application" "my_application" {
       huawei_app_id       = "12345679"
       huawei_package_name = "org.bxretail.huaweipackage"
     }
-
-    bundle_id    = "org.bxretail.mybundle"
-    package_name = "org.bxretail.mypackage"
   }
 }
 

--- a/examples/resources/pingone_mfa_policy/resource-mobile-authenticator.tf
+++ b/examples/resources/pingone_mfa_policy/resource-mobile-authenticator.tf
@@ -34,9 +34,6 @@ resource "pingone_application" "my_mobile_application" {
         }
       }
     }
-
-    bundle_id    = "org.bxretail.mobileapp"
-    package_name = "org.bxretail.mobileapp"
   }
 }
 


### PR DESCRIPTION
Documentation: Remove deprecated attributes from example HCL

- `resource/pingone_mfa_application_push_credential` 
- `resource/pingone_mfa_policy`