### PR TITLE
Improvements to credential type documentation and validation bug fix.

### DIFF
--- a/docs/resources/credential_type.md
+++ b/docs/resources/credential_type.md
@@ -93,7 +93,7 @@ resource "pingone_credential_type" "verifiedemployee" {
 - `card_design_template` (String) An SVG formatted image containing placeholders for the credentials fields that need to be displayed in the image.
 - `environment_id` (String) PingOne environment identifier (UUID) in which the credential type exists.
 - `metadata` (Attributes) Contains the names, data types, and other metadata related to the credential. (see [below for nested schema](#nestedatt--metadata))
-- `title` (String) Title of the credential. Verification sites are expected to be able to request the issued credential from the compatible wallet app using the title.  This value aligns to `${cardTItle}` in the `card_design_template`.
+- `title` (String) Title of the credential. Verification sites are expected to be able to request the issued credential from the compatible wallet app using the title.  This value aligns to `${cardTitle}` in the `card_design_template`.
 
 ### Optional
 

--- a/docs/resources/credential_type.md
+++ b/docs/resources/credential_type.md
@@ -2,15 +2,15 @@
 page_title: "pingone_credential_type Resource - terraform-provider-pingone"
 subcategory: "Neo (Verifiable Credentials)"
 description: |-
-  Resource to create, read, and update the credential types used by compatible wallet applications.
-  ~> You must ensure that any fields used in the cardDesignTemplate are defined appropriately in metadata.fields or errors occur when you attempt to create a credential of that type.
+  Resource to create and manage the credential types used by compatible wallet applications.
+  ~> You must ensure that any fields used in the carddesigntemplate are defined appropriately in metadata.fields or errors occur when you attempt to create a credential of that type.
 ---
 
 # pingone_credential_type (Resource)
 
-Resource to create, read, and update the credential types used by compatible wallet applications.
+Resource to create and manage the credential types used by compatible wallet applications.
 
-~> You must ensure that any fields used in the cardDesignTemplate are defined appropriately in metadata.fields or errors occur when you attempt to create a credential of that type.
+~> You must ensure that any fields used in the card_design_template are defined appropriately in metadata.fields or errors occur when you attempt to create a credential of that type.
 
 ## Example Usage
 
@@ -93,12 +93,12 @@ resource "pingone_credential_type" "verifiedemployee" {
 - `card_design_template` (String) An SVG formatted image containing placeholders for the credentials fields that need to be displayed in the image.
 - `environment_id` (String) PingOne environment identifier (UUID) in which the credential type exists.
 - `metadata` (Attributes) Contains the names, data types, and other metadata related to the credential. (see [below for nested schema](#nestedatt--metadata))
-- `title` (String) Title of the credential. Verification sites are expected to be able to request the issued credential from the compatible wallet app using the title.
+- `title` (String) Title of the credential. Verification sites are expected to be able to request the issued credential from the compatible wallet app using the title.  This value aligns to `${cardTItle}` in the `card_design_template`.
 
 ### Optional
 
 - `card_type` (String) A descriptor of the credential type. Can be non-identity types such as proof of employment or proof of insurance.
-- `description` (String) A description of the credential type.
+- `description` (String) A description of the credential type. This value aligns to `${cardSubtitle}` in the `card_design_template`.
 
 ### Read-Only
 

--- a/internal/service/credentials/resource_credential_type.go
+++ b/internal/service/credentials/resource_credential_type.go
@@ -119,7 +119,7 @@ func (r *CredentialTypeResource) Schema(ctx context.Context, req resource.Schema
 	const imageMaxSize = 50000
 
 	titleDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"Title of the credential. Verification sites are expected to be able to request the issued credential from the compatible wallet app using the title.  This value aligns to `${cardTItle}` in the `card_design_template`.",
+		"Title of the credential. Verification sites are expected to be able to request the issued credential from the compatible wallet app using the title.  This value aligns to `${cardTitle}` in the `card_design_template`.",
 	)
 
 	credentialDescription := framework.SchemaAttributeDescriptionFromMarkdown(

--- a/internal/service/credentials/resource_credential_type_test.go
+++ b/internal/service/credentials/resource_credential_type_test.go
@@ -166,7 +166,7 @@ func TestAccCredentialType_Full(t *testing.T) {
 	// Note: If template is defined directly in HCL, the ${variableName} variables are escaped with $$, such as $${variableName}.
 	// The HCL in the test case has the escaped variable name.  The test value does not ensuring it is saved to, and returned from, state properly.
 	// Future: Move the design template to a test asset file.
-	updatedCardDesignTemplate := "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"\"></line><text fill=\"\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">${cardTitle}</text></svg>"
+	updatedCardDesignTemplate := "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"\"></line><text fill=\"\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">${cardTitle}</text><text font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">${cardSubtitle}</text></svg>"
 
 	minimalStep := resource.TestStep{
 		Config: testAccCredentialTypeConfig_Minimal(resourceName, updatedName),
@@ -345,8 +345,7 @@ resource "pingone_credential_type" "%[3]s" {
   title                = "%[4]s"
   description          = "%[4]s"
   card_type            = "DemonstrationCard"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"\"></line><text fill=\"\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text></svg>"
-
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"\"></line><text fill=\"\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
   metadata = {
     name = "%[4]s"
 
@@ -441,7 +440,7 @@ resource "pingone_credential_type" "%[2]s" {
   title                = "%[3]s"
   description          = "%[3]s Example Description"
   card_type            = "DemonstrationCard"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"\"></line><text fill=\"\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text></svg>"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"\"></line><text fill=\"\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
 
   metadata = {
     name = "%[3]s"


### PR DESCRIPTION
### Change Description
Clarified the `title` and `description` fields in the credential type align to the ${cardTitle} and ${cardSubtitle} fields in the card_design_template.  Previously, the documentation incorrectly stated the `metadata.name` and `metadata.description` fields aligned to those card values.

Corrected the validation rules and test cases to align to the above also.

### Testing Results
All tests within the test suite passed.  Focus on the credential type tests also passed.
--- PASS: TestAccCredentialType_MetaData (0.64s)
=== CONT  TestAccCredentialTypeDataSource_NotFound
--- PASS: TestAccCredentialTypeDataSource_NotFound (0.73s)
=== CONT  TestAccCredentialTypeDataSource_ByIDFull
--- PASS: TestAccCredentialTypesDataSource_NotFound (6.80s)

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG=WARN TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
% TF_LOG=DEBUG TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
=== RUN   TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== PAUSE TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== RUN   TestAccCredentialIssuanceRuleDataSource_NotFound
=== PAUSE TestAccCredentialIssuanceRuleDataSource_NotFound
=== RUN   TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== PAUSE TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== RUN   TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
=== PAUSE TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
=== RUN   TestAccCredentialIssuerProfileDataSource_NotFound
=== PAUSE TestAccCredentialIssuerProfileDataSource_NotFound
=== RUN   TestAccCredentialTypeDataSource_ByIDFull
=== PAUSE TestAccCredentialTypeDataSource_ByIDFull
=== RUN   TestAccCredentialTypeDataSource_NotFound
=== PAUSE TestAccCredentialTypeDataSource_NotFound
=== RUN   TestAccCredentialTypeDataSource_InvalidConfig
=== PAUSE TestAccCredentialTypeDataSource_InvalidConfig
=== RUN   TestAccCredentialTypesDataSource_NoFilter
=== PAUSE TestAccCredentialTypesDataSource_NoFilter
=== RUN   TestAccCredentialTypesDataSource_NotFound
=== PAUSE TestAccCredentialTypesDataSource_NotFound
=== RUN   TestAccDigitalWalletApplicationDataSource_ByIDFull
=== PAUSE TestAccDigitalWalletApplicationDataSource_ByIDFull
=== RUN   TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull
=== PAUSE TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull
=== RUN   TestAccDigitalWalletApplicationDataSource_ByNameFull
=== PAUSE TestAccDigitalWalletApplicationDataSource_ByNameFull
=== RUN   TestAccDigitalWalletApplicationDataSource_NotFound
=== PAUSE TestAccDigitalWalletApplicationDataSource_NotFound
=== RUN   TestAccDigitalWalletApplicationsDataSource_NoFilter
=== PAUSE TestAccDigitalWalletApplicationsDataSource_NoFilter
=== RUN   TestAccDigitalWalletApplicationsDataSource_NotFound
=== PAUSE TestAccDigitalWalletApplicationsDataSource_NotFound
=== RUN   TestAccCredentialIssuanceRule_Full
=== PAUSE TestAccCredentialIssuanceRule_Full
=== RUN   TestAccCredentialIssuanceRule_InvalidConfigs
=== PAUSE TestAccCredentialIssuanceRule_InvalidConfigs
=== RUN   TestAccCredentialIssuerProfile_Full
=== PAUSE TestAccCredentialIssuerProfile_Full
=== RUN   TestAccCredentialIssuerProfile_InvalidConfig
=== PAUSE TestAccCredentialIssuerProfile_InvalidConfig
=== RUN   TestAccCredentialType_NewEnv
=== PAUSE TestAccCredentialType_NewEnv
=== RUN   TestAccCredentialType_Full
=== PAUSE TestAccCredentialType_Full
=== RUN   TestAccCredentialType_MetaData
=== PAUSE TestAccCredentialType_MetaData
=== RUN   TestAccCredentialType_CardDesignTemplate
=== PAUSE TestAccCredentialType_CardDesignTemplate
=== RUN   TestAccDigitalWalletApplication_NewEnv
=== PAUSE TestAccDigitalWalletApplication_NewEnv
=== RUN   TestAccDigitalWalletApplication_Full
=== PAUSE TestAccDigitalWalletApplication_Full
=== RUN   TestAccDigitalWalletApplication_InvalidNativeApplication
=== PAUSE TestAccDigitalWalletApplication_InvalidNativeApplication
=== RUN   TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== PAUSE TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== CONT  TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== CONT  TestAccDigitalWalletApplicationsDataSource_NoFilter
=== CONT  TestAccCredentialTypeDataSource_InvalidConfig
=== CONT  TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull
=== CONT  TestAccDigitalWalletApplicationDataSource_NotFound
=== CONT  TestAccCredentialTypesDataSource_NotFound
=== CONT  TestAccCredentialType_Full
=== CONT  TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== CONT  TestAccDigitalWalletApplication_InvalidNativeApplication
=== CONT  TestAccDigitalWalletApplication_Full
=== CONT  TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== CONT  TestAccDigitalWalletApplicationsDataSource_NoFilter
=== CONT  TestAccCredentialTypeDataSource_InvalidConfig
=== CONT  TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull
=== CONT  TestAccDigitalWalletApplicationDataSource_NotFound
=== CONT  TestAccCredentialTypesDataSource_NotFound
=== CONT  TestAccCredentialType_Full
=== CONT  TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== CONT  TestAccDigitalWalletApplication_InvalidNativeApplication
=== CONT  TestAccDigitalWalletApplication_Full
--- PASS: TestAccCredentialTypeDataSource_InvalidConfig (0.34s)
=== CONT  TestAccDigitalWalletApplication_NewEnv
--- PASS: TestAccDigitalWalletApplication_InvalidAppOpenUrl (3.17s)
=== CONT  TestAccCredentialType_CardDesignTemplate
--- PASS: TestAccCredentialType_CardDesignTemplate (0.49s)
=== CONT  TestAccCredentialType_MetaData
--- PASS: TestAccDigitalWalletApplicationDataSource_NotFound (4.07s)
=== CONT  TestAccCredentialIssuerProfileDataSource_NotFound
--- PASS: TestAccCredentialType_MetaData (0.64s)
=== CONT  TestAccCredentialTypeDataSource_NotFound
--- PASS: TestAccCredentialTypeDataSource_NotFound (0.73s)
=== CONT  TestAccCredentialTypeDataSource_ByIDFull
--- PASS: TestAccCredentialTypesDataSource_NotFound (6.80s)
=== CONT  TestAccDigitalWalletApplicationDataSource_ByNameFull
--- PASS: TestAccCredentialIssuanceRuleDataSource_ByIDFull (7.12s)
=== CONT  TestAccDigitalWalletApplicationDataSource_ByIDFull
--- PASS: TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull (7.17s)
=== CONT  TestAccCredentialIssuanceRuleDataSource_InvalidConfig
--- PASS: TestAccCredentialIssuanceRuleDataSource_InvalidConfig (0.28s)
=== CONT  TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
--- PASS: TestAccCredentialIssuerProfileDataSource_NotFound (4.47s)
=== CONT  TestAccCredentialIssuanceRuleDataSource_NotFound
--- PASS: TestAccDigitalWalletApplication_NewEnv (8.23s)
=== CONT  TestAccCredentialIssuerProfile_Full
--- PASS: TestAccDigitalWalletApplication_InvalidNativeApplication (8.85s)
=== CONT  TestAccCredentialType_NewEnv
--- PASS: TestAccCredentialIssuanceRuleDataSource_NotFound (2.50s)
=== CONT  TestAccCredentialIssuerProfile_InvalidConfig
--- PASS: TestAccCredentialIssuerProfile_InvalidConfig (0.25s)
=== CONT  TestAccCredentialIssuanceRule_Full
--- PASS: TestAccDigitalWalletApplicationsDataSource_NoFilter (11.78s)
=== CONT  TestAccCredentialIssuanceRule_InvalidConfigs
--- PASS: TestAccDigitalWalletApplicationDataSource_ByNameFull (5.84s)
=== CONT  TestAccDigitalWalletApplicationsDataSource_NotFound
--- PASS: TestAccCredentialIssuanceRule_InvalidConfigs (0.95s)
=== CONT  TestAccCredentialTypesDataSource_NoFilter
--- PASS: TestAccCredentialTypeDataSource_ByIDFull (7.74s)
--- PASS: TestAccDigitalWalletApplicationDataSource_ByIDFull (6.28s)
--- PASS: TestAccCredentialType_NewEnv (7.39s)
--- PASS: TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull (9.41s)
--- PASS: TestAccDigitalWalletApplicationsDataSource_NotFound (7.28s)
--- PASS: TestAccCredentialTypesDataSource_NoFilter (9.73s)
--- PASS: TestAccDigitalWalletApplication_Full (29.92s)
--- PASS: TestAccCredentialType_Full (32.57s)
--- PASS: TestAccCredentialIssuerProfile_Full (35.28s)
--- PASS: TestAccCredentialIssuanceRule_Full (55.28s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 66.921s
```