### PR TITLE
Corrected date-based tests

### DIFF
--- a/internal/service/base/data_source_agreement_test.go
+++ b/internal/service/base/data_source_agreement_test.go
@@ -103,7 +103,7 @@ func TestAccAgreementDataSource_NotFound(t *testing.T) {
 }
 
 func testAccAgreementDataSourceConfig_ByNameFull(resourceName, name string) string {
-	date := time.Now().Local().Add(time.Hour * time.Duration(1))
+	date := time.Now().In(time.UTC).Add(time.Hour * time.Duration(1))
 
 	return fmt.Sprintf(`
 	%[1]s
@@ -158,7 +158,7 @@ data "pingone_agreement" "%[2]s" {
 }
 
 func testAccAgreementDataSourceConfig_ByIDFull(resourceName, name string) string {
-	date := time.Now().Local().Add(time.Hour * time.Duration(1))
+	date := time.Now().In(time.UTC).Add(time.Hour * time.Duration(1))
 
 	return fmt.Sprintf(`
 	%[1]s

--- a/internal/service/base/resource_agreement_localization_revision_test.go
+++ b/internal/service/base/resource_agreement_localization_revision_test.go
@@ -83,7 +83,7 @@ func TestAccAgreementLocalizationRevision_Full(t *testing.T) {
 
 	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
-	dateVariant2 := time.Now().Local().Add(time.Hour * time.Duration(2))
+	dateVariant2 := time.Now().In(time.UTC).Add(time.Hour * time.Duration(2))
 
 	variant1 := resource.ComposeTestCheckFunc(
 		resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),

--- a/internal/service/risk/resource_risk_predictor_test.go
+++ b/internal/service/risk/resource_risk_predictor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -801,12 +802,15 @@ func TestAccRiskPredictor_NewDevice(t *testing.T) {
 
 	name := resourceName
 
+	year, month, day := time.Now().Local().Date()
+	activationAt := time.Date(year, month, day, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -1).Format(time.RFC3339)
+
 	fullCheck := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceFullName, "type", "DEVICE"),
 		resource.TestCheckResourceAttr(resourceFullName, "deletable", "true"),
 		resource.TestCheckResourceAttr(resourceFullName, "default.result.level", "MEDIUM"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.detect", "NEW_DEVICE"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.activation_at", "2023-05-02T00:00:00Z"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.activation_at", activationAt),
 	)
 
 	minimalCheck := resource.ComposeTestCheckFunc(
@@ -825,11 +829,11 @@ func TestAccRiskPredictor_NewDevice(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Full
 			{
-				Config: testAccRiskPredictorConfig_NewDevice_Full(resourceName, name),
+				Config: testAccRiskPredictorConfig_NewDevice_Full(resourceName, name, activationAt),
 				Check:  fullCheck,
 			},
 			{
-				Config:  testAccRiskPredictorConfig_NewDevice_Full(resourceName, name),
+				Config:  testAccRiskPredictorConfig_NewDevice_Full(resourceName, name, activationAt),
 				Destroy: true,
 			},
 			// Minimal
@@ -843,7 +847,7 @@ func TestAccRiskPredictor_NewDevice(t *testing.T) {
 			},
 			// Change
 			{
-				Config: testAccRiskPredictorConfig_NewDevice_Full(resourceName, name),
+				Config: testAccRiskPredictorConfig_NewDevice_Full(resourceName, name, activationAt),
 				Check:  fullCheck,
 			},
 			{
@@ -851,7 +855,7 @@ func TestAccRiskPredictor_NewDevice(t *testing.T) {
 				Check:  minimalCheck,
 			},
 			{
-				Config: testAccRiskPredictorConfig_NewDevice_Full(resourceName, name),
+				Config: testAccRiskPredictorConfig_NewDevice_Full(resourceName, name, activationAt),
 				Check:  fullCheck,
 			},
 		},
@@ -867,6 +871,9 @@ func TestAccRiskPredictor_NewDevice_OverwriteUndeletable(t *testing.T) {
 	name := resourceName
 	compactName := "newDevice"
 
+	year, month, day := time.Now().Local().Date()
+	activationAt := time.Date(year, month, day, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -1).Format(time.RFC3339)
+
 	fullCheck := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceFullName, "name", name),
 		resource.TestCheckResourceAttr(resourceFullName, "compact_name", "newDevice"),
@@ -874,7 +881,7 @@ func TestAccRiskPredictor_NewDevice_OverwriteUndeletable(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "deletable", "false"),
 		resource.TestCheckResourceAttr(resourceFullName, "default.result.level", "MEDIUM"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.detect", "NEW_DEVICE"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.activation_at", "2023-05-02T00:00:00Z"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.activation_at", activationAt),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -885,7 +892,7 @@ func TestAccRiskPredictor_NewDevice_OverwriteUndeletable(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Full
 			{
-				Config: testAccRiskPredictorConfig_NewDevice_OverwriteUndeletable(resourceName, name, compactName),
+				Config: testAccRiskPredictorConfig_NewDevice_OverwriteUndeletable(resourceName, name, compactName, activationAt),
 				Check:  fullCheck,
 			},
 		},
@@ -1868,7 +1875,7 @@ resource "pingone_risk_predictor" "%[2]s" {
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccRiskPredictorConfig_NewDevice_Full(resourceName, name string) string {
+func testAccRiskPredictorConfig_NewDevice_Full(resourceName, name, activationAt string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
@@ -1887,9 +1894,9 @@ resource "pingone_risk_predictor" "%[2]s" {
 
   predictor_device = {
     detect        = "NEW_DEVICE"
-    activation_at = "2023-05-02T00:00:00Z"
+    activation_at = "%[4]s"
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name, activationAt)
 }
 
 func testAccRiskPredictorConfig_NewDevice_Minimal(resourceName, name string) string {
@@ -1906,7 +1913,7 @@ resource "pingone_risk_predictor" "%[2]s" {
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccRiskPredictorConfig_NewDevice_OverwriteUndeletable(resourceName, name, compactName string) string {
+func testAccRiskPredictorConfig_NewDevice_OverwriteUndeletable(resourceName, name, compactName, activationAt string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
@@ -1924,9 +1931,9 @@ resource "pingone_risk_predictor" "%[2]s" {
 
   predictor_device = {
     detect        = "NEW_DEVICE"
-    activation_at = "2023-05-02T00:00:00Z"
+    activation_at = "%[5]s"
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name, compactName)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name, compactName, activationAt)
 }
 
 func testAccRiskPredictorConfig_UserLocationAnomaly_Full(resourceName, name string) string {


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

### Testing Results - Agreements
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccAgreement github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccAgreementLocalizationDataSource_ByNameFull
=== PAUSE TestAccAgreementLocalizationDataSource_ByNameFull
=== RUN   TestAccAgreementLocalizationDataSource_ByLocaleFull
=== PAUSE TestAccAgreementLocalizationDataSource_ByLocaleFull
=== RUN   TestAccAgreementLocalizationDataSource_ByIDFull
=== PAUSE TestAccAgreementLocalizationDataSource_ByIDFull
=== RUN   TestAccAgreementLocalizationDataSource_NotFound
=== PAUSE TestAccAgreementLocalizationDataSource_NotFound
=== RUN   TestAccAgreementDataSource_ByNameFull
=== PAUSE TestAccAgreementDataSource_ByNameFull
=== RUN   TestAccAgreementDataSource_ByIDFull
=== PAUSE TestAccAgreementDataSource_ByIDFull
=== RUN   TestAccAgreementDataSource_NotFound
=== PAUSE TestAccAgreementDataSource_NotFound
=== RUN   TestAccAgreementEnable_Full
=== PAUSE TestAccAgreementEnable_Full
=== RUN   TestAccAgreementLocalizationEnable_Full
=== PAUSE TestAccAgreementLocalizationEnable_Full
=== RUN   TestAccAgreementLocalizationRevision_Full
=== PAUSE TestAccAgreementLocalizationRevision_Full
=== RUN   TestAccAgreementLocalization_Full
=== PAUSE TestAccAgreementLocalization_Full
=== RUN   TestAccAgreement_NewEnv
=== PAUSE TestAccAgreement_NewEnv
=== RUN   TestAccAgreement_Full
=== PAUSE TestAccAgreement_Full
=== CONT  TestAccAgreementLocalizationDataSource_ByNameFull
=== CONT  TestAccAgreementEnable_Full
=== CONT  TestAccAgreementDataSource_ByNameFull
=== CONT  TestAccAgreementLocalizationDataSource_ByIDFull
=== CONT  TestAccAgreementLocalizationDataSource_ByLocaleFull
=== CONT  TestAccAgreementDataSource_NotFound
=== CONT  TestAccAgreementDataSource_ByIDFull
=== CONT  TestAccAgreement_Full
=== CONT  TestAccAgreement_NewEnv
=== CONT  TestAccAgreementLocalizationDataSource_NotFound
=== CONT  TestAccAgreementLocalizationEnable_Full
=== CONT  TestAccAgreementLocalization_Full
=== CONT  TestAccAgreementLocalizationRevision_Full
--- PASS: TestAccAgreementDataSource_NotFound (3.77s)
--- PASS: TestAccAgreementLocalizationDataSource_NotFound (8.33s)
--- PASS: TestAccAgreement_NewEnv (11.06s)
--- PASS: TestAccAgreementDataSource_ByIDFull (13.51s)
--- PASS: TestAccAgreementDataSource_ByNameFull (13.58s)
--- PASS: TestAccAgreementLocalizationDataSource_ByLocaleFull (13.65s)
--- PASS: TestAccAgreementLocalizationDataSource_ByIDFull (13.85s)
--- PASS: TestAccAgreementLocalizationDataSource_ByNameFull (14.00s)
--- PASS: TestAccAgreement_Full (47.40s)
--- PASS: TestAccAgreementEnable_Full (52.97s)
--- PASS: TestAccAgreementLocalizationRevision_Full (56.58s)
--- PASS: TestAccAgreementLocalizationEnable_Full (58.10s)
--- PASS: TestAccAgreementLocalization_Full (59.10s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        59.540s
```

### Testing Results - Risk Predictors
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run TestAccRiskPredictor_NewDevice github.com/pingidentity/terraform-provider-pingone/internal/service/risk
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccRiskPredictor_NewDevice
=== PAUSE TestAccRiskPredictor_NewDevice
=== RUN   TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_NewDevice
=== CONT  TestAccRiskPredictor_NewDevice_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_NewDevice_OverwriteUndeletable (10.68s)
--- PASS: TestAccRiskPredictor_NewDevice (56.81s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/risk        57.207s
```