### PR TITLE
`pingone_mfa_policy`: Support new schema attributes and enable the new `fido2` device type

### DIFF
--- a/.changelog/399.txt
+++ b/.changelog/399.txt
@@ -1,0 +1,7 @@
+```release-note:note
+`resource/pingone_mfa_policy`: Migrated to plugin framework.
+```
+
+```release-note:enhancement
+`resource/pingone_mfa_policy`: Supports the ability to define the pairing key lifetime and push limit for mobile applications.
+```

--- a/docs/resources/mfa_policy.md
+++ b/docs/resources/mfa_policy.md
@@ -178,19 +178,19 @@ resource "pingone_mfa_policy" "my_awesome_mfa_policy" {
 
 ### Required
 
-- `email` (Block List, Min: 1, Max: 1) Email OTP authentication policy settings. (see [below for nested schema](#nestedblock--email))
-- `environment_id` (String) The ID of the environment to create the sign on policy in.
-- `mobile` (Block List, Min: 1, Max: 1) Mobile authenticator device policy settings.  This factor requires embedding the PingOne MFA SDK into a customer facing mobile application, and configuring as a Native application using the `pingone_application` resource. (see [below for nested schema](#nestedblock--mobile))
+- `environment_id` (String) The ID of the environment to create the MFA policy in.
 - `name` (String) A string that specifies the MFA policy's name.
-- `platform` (Block List, Min: 1, Max: 1) Platform biometrics authentication policy settings. (see [below for nested schema](#nestedblock--platform))
-- `security_key` (Block List, Min: 1, Max: 1) Security key (FIDO2) authentication policy settings. (see [below for nested schema](#nestedblock--security_key))
-- `sms` (Block List, Min: 1, Max: 1) SMS OTP authentication policy settings. (see [below for nested schema](#nestedblock--sms))
-- `totp` (Block List, Min: 1, Max: 1) TOTP authenticator policy settings. (see [below for nested schema](#nestedblock--totp))
-- `voice` (Block List, Min: 1, Max: 1) Voice OTP authentication policy settings. (see [below for nested schema](#nestedblock--voice))
 
 ### Optional
 
-- `device_selection` (String) A string that defines the device selection method. Options are `DEFAULT_TO_FIRST` (this is the default setting for new environments), `PROMPT_TO_SELECT` and `ALWAYS_PROMPT_TO_SELECT`. Defaults to `DEFAULT_TO_FIRST`.
+- `device_selection` (String) A string that defines the device selection method.  Options are `ALWAYS_PROMPT_TO_SELECT`, `DEFAULT_TO_FIRST`, `PROMPT_TO_SELECT`.  Defaults to `DEFAULT_TO_FIRST`.
+- `email` (Block List) Email OTP authentication policy settings.  At least one of the following must be defined: `sms`, `voice`, `email`, `mobile`, `totp`, `security_key`, `platform`. (see [below for nested schema](#nestedblock--email))
+- `mobile` (Block List) Mobile authenticator device policy settings.  This factor requires embedding the PingOne MFA SDK into a customer facing mobile application, and configuring as a Native application using the `pingone_application` resource.  At least one of the following must be defined: `sms`, `voice`, `email`, `mobile`, `totp`, `security_key`, `platform`. (see [below for nested schema](#nestedblock--mobile))
+- `platform` (Block List) Platform biometrics authentication policy settings.  At least one of the following must be defined: `sms`, `voice`, `email`, `mobile`, `totp`, `security_key`, `platform`. (see [below for nested schema](#nestedblock--platform))
+- `security_key` (Block List) Security key (FIDO2) authentication policy settings.  At least one of the following must be defined: `sms`, `voice`, `email`, `mobile`, `totp`, `security_key`, `platform`. (see [below for nested schema](#nestedblock--security_key))
+- `sms` (Block List) SMS OTP authentication policy settings.  At least one of the following must be defined: `sms`, `voice`, `email`, `mobile`, `totp`, `security_key`, `platform`. (see [below for nested schema](#nestedblock--sms))
+- `totp` (Block List) TOTP authenticator policy settings.  At least one of the following must be defined: `sms`, `voice`, `email`, `mobile`, `totp`, `security_key`, `platform`. (see [below for nested schema](#nestedblock--totp))
+- `voice` (Block List) Voice OTP authentication policy settings.  At least one of the following must be defined: `sms`, `voice`, `email`, `mobile`, `totp`, `security_key`, `platform`. (see [below for nested schema](#nestedblock--voice))
 
 ### Read-Only
 
@@ -205,11 +205,11 @@ Required:
 
 Optional:
 
-- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the "onetime authentication" feature, the user is not blocked after the maximum number of failures even if you specified a block duration. Defaults to `0`.
-- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
-- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Defaults to `3`.
-- `otp_lifetime_duration` (Number) An integer that defines turation (number of time units) that the passcode is valid before it expires. Defaults to `30`.
-- `otp_lifetime_timeunit` (String) The type of time unit for `otp_lifetime_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
+- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the "onetime authentication" feature, the user is not blocked after the maximum number of failures even if you specified a block duration.  Defaults to `0`.
+- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.  Defaults to `3`.
+- `otp_lifetime_duration` (Number) An integer that defines duration (number of time units) that the passcode is valid before it expires.  Defaults to `30`.
+- `otp_lifetime_timeunit` (String) The type of time unit for `otp_lifetime_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 <a id="nestedblock--mobile"></a>
@@ -222,9 +222,9 @@ Required:
 Optional:
 
 - `application` (Block Set) Settings for a configured Mobile Application. (see [below for nested schema](#nestedblock--mobile--application))
-- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Defaults to `2`.
-- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
-- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Defaults to `3`.
+- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.  Defaults to `2`.
+- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.  Defaults to `3`.
 
 <a id="nestedblock--mobile--application"></a>
 ### Nested Schema for `mobile.application`
@@ -239,13 +239,25 @@ Optional:
 
 - `auto_enrollment_enabled` (Boolean) Set to `true` if you want the application to allow Auto Enrollment. Auto Enrollment means that the user can authenticate for the first time from an unpaired device, and the successful authentication will result in the pairing of the device for MFA.
 - `device_authorization_enabled` (Boolean) Specifies the enabled or disabled state of automatic MFA for native devices paired with the user, for the specified application.
-- `device_authorization_extra_verification` (String) Specifies the level of further verification when `device_authorization_enabled` is true. The PingOne platform performs an extra verification check by sending a "silent" push notification to the customer native application, and receives a confirmation in return.  Extra verification can be one of the following levels: `permissive`: The PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as successfully completed.  `restrictive`: The PingOne platform performs the extra verification check.The PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as failed.
-- `integrity_detection` (String) Controls how authentication or registration attempts should proceed if a device integrity check does not receive a response. Set the value to `permissive` if you want to allow the process to continue. Set the value to `restrictive` if you want to block the user in such situations.
-- `push_timeout_duration` (Number) An integer that defines the amount of time (in seconds) a user has to respond to a push notification before it expires. Minimum is 40 seconds and maximum is 150 seconds. If this parameter is not provided, the duration is set to 40 seconds. Defaults to `40`.
-
-Read-Only:
-
+- `device_authorization_extra_verification` (String) Specifies the level of further verification when `device_authorization_enabled` is true. The PingOne platform performs an extra verification check by sending a "silent" push notification to the customer native application, and receives a confirmation in return.  Options are `permissive` (the PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as successfully completed), `restrictive` (the PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as failed).
+- `integrity_detection` (String) Controls how authentication or registration attempts should proceed if a device integrity check does not receive a response.  Options are `permissive` (if you want to allow the process to continue), `restrictive` (if you want to block the user in such situations).
+- `pairing_key_lifetime_duration` (Number) The amount of time an issued pairing key can be used until it expires. Minimum is `1` minute and maximum is `48` hours.  Defaults to `10`.
+- `pairing_key_lifetime_timeunit` (String) The time unit for the `pairing_key_lifetime_duration` parameter.  Options are `HOURS`, `MINUTES`.  Defaults to `MINUTES`.
+- `push_limit` (Block List) A single block that describes mobile application push limit settings. (see [below for nested schema](#nestedblock--mobile--application--push_limit))
+- `push_timeout_duration` (Number) An integer that defines the amount of time (in seconds) a user has to respond to a push notification before it expires. Minimum is `40` seconds and maximum is `150` seconds.  Defaults to `40`.
 - `push_timeout_timeunit` (String) The time unit for the `push_timeout_duration` parameter. Currently, the only permitted value is `SECONDS`.
+
+<a id="nestedblock--mobile--application--push_limit"></a>
+### Nested Schema for `mobile.application.push_limit`
+
+Optional:
+
+- `count` (Number) The number of consecutive push notifications that can be ignored or rejected by a user within a defined period before push notifications are blocked for the application. The minimum value is `1` and the maximum value is `50`.  Defaults to `5`.
+- `lock_duration_duration` (Number) The length of time that push notifications should be blocked for the application if the defined limit has been reached. The minimum value is `1` minute and the maximum value is `120` minutes.  Defaults to `30`.
+- `lock_duration_timeunit` (String) The time unit for the `lock_duration_duration` parameter.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+- `time_period_duration` (Number) The time period in which the push notifications are counted towards the defined limit. The minimum value is `1` minute and the maximum value is `120` minutes.  Defaults to `10`.
+- `time_period_timeunit` (String) The time unit for the `time_period_duration` parameter.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+
 
 
 
@@ -282,11 +294,11 @@ Required:
 
 Optional:
 
-- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the "onetime authentication" feature, the user is not blocked after the maximum number of failures even if you specified a block duration. Defaults to `0`.
-- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
-- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Defaults to `3`.
-- `otp_lifetime_duration` (Number) An integer that defines turation (number of time units) that the passcode is valid before it expires. Defaults to `30`.
-- `otp_lifetime_timeunit` (String) The type of time unit for `otp_lifetime_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
+- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the "onetime authentication" feature, the user is not blocked after the maximum number of failures even if you specified a block duration.  Defaults to `0`.
+- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.  Defaults to `3`.
+- `otp_lifetime_duration` (Number) An integer that defines duration (number of time units) that the passcode is valid before it expires.  Defaults to `30`.
+- `otp_lifetime_timeunit` (String) The type of time unit for `otp_lifetime_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 <a id="nestedblock--totp"></a>
@@ -298,9 +310,9 @@ Required:
 
 Optional:
 
-- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Defaults to `2`.
-- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
-- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Defaults to `3`.
+- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.  Defaults to `2`.
+- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.  Defaults to `3`.
 
 
 <a id="nestedblock--voice"></a>
@@ -312,11 +324,11 @@ Required:
 
 Optional:
 
-- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the "onetime authentication" feature, the user is not blocked after the maximum number of failures even if you specified a block duration. Defaults to `0`.
-- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
-- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Defaults to `3`.
-- `otp_lifetime_duration` (Number) An integer that defines turation (number of time units) that the passcode is valid before it expires. Defaults to `30`.
-- `otp_lifetime_timeunit` (String) The type of time unit for `otp_lifetime_duration`.  Options are `MINUTES` or `SECONDS`. Defaults to `MINUTES`.
+- `otp_failure_cooldown_duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the "onetime authentication" feature, the user is not blocked after the maximum number of failures even if you specified a block duration.  Defaults to `0`.
+- `otp_failure_cooldown_timeunit` (String) The type of time unit for `otp_failure_cooldown_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+- `otp_failure_count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.  Defaults to `3`.
+- `otp_lifetime_duration` (Number) An integer that defines duration (number of time units) that the passcode is valid before it expires.  Defaults to `30`.
+- `otp_lifetime_timeunit` (String) The type of time unit for `otp_lifetime_duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 ## Import
 

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -131,7 +131,6 @@ func New(version string) func() *schema.Provider {
 
 				"pingone_mfa_application_push_credential": mfa.ResourceApplicationPushCredential(),
 				"pingone_mfa_fido_policy":                 mfa.ResourceFIDOPolicy(),
-				"pingone_mfa_policy":                      mfa.ResourceMFAPolicy(),
 				"pingone_mfa_settings":                    mfa.ResourceMFASettings(),
 			},
 		}

--- a/internal/service/mfa/resource_mfa_policy.go
+++ b/internal/service/mfa/resource_mfa_policy.go
@@ -6,541 +6,1269 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/patrickcping/pingone-go-sdk-v2/mfa"
-	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
+	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
+	"github.com/pingidentity/terraform-provider-pingone/internal/utils"
 	"github.com/pingidentity/terraform-provider-pingone/internal/verify"
 )
 
-func ResourceMFAPolicy() *schema.Resource {
-	return &schema.Resource{
+// Types
+type MFAPolicyResource struct {
+	client     *mfa.APIClient
+	mgmtClient *management.APIClient
+	region     model.RegionMapping
+}
 
+type mfaPolicyResourceModel struct {
+	Id              types.String `tfsdk:"id"`
+	EnvironmentId   types.String `tfsdk:"environment_id"`
+	Name            types.String `tfsdk:"name"`
+	DeviceSelection types.String `tfsdk:"device_selection"`
+	SMS             types.List   `tfsdk:"sms"`
+	Voice           types.List   `tfsdk:"voice"`
+	Email           types.List   `tfsdk:"email"`
+	Mobile          types.List   `tfsdk:"mobile"`
+	Totp            types.List   `tfsdk:"totp"`
+	SecurityKey     types.List   `tfsdk:"security_key"`
+	Platform        types.List   `tfsdk:"platform"`
+}
+
+type mfaPolicyResourceOfflineDeviceModel struct {
+	Enabled                    types.Bool   `tfsdk:"enabled"`
+	OTPLifetimeDuration        types.Int64  `tfsdk:"otp_lifetime_duration"`
+	OTPLifetimeTimeunit        types.String `tfsdk:"otp_lifetime_timeunit"`
+	OTPFailureCount            types.Int64  `tfsdk:"otp_failure_count"`
+	OTPFailureCooldownDuration types.Int64  `tfsdk:"otp_failure_cooldown_duration"`
+	OTPFailureCooldownTimeunit types.String `tfsdk:"otp_failure_cooldown_timeunit"`
+}
+
+type mfaPolicyResourceMobileModel struct {
+	Enabled                    types.Bool   `tfsdk:"enabled"`
+	OTPFailureCount            types.Int64  `tfsdk:"otp_failure_count"`
+	OTPFailureCooldownDuration types.Int64  `tfsdk:"otp_failure_cooldown_duration"`
+	OTPFailureCooldownTimeunit types.String `tfsdk:"otp_failure_cooldown_timeunit"`
+	Application                types.Set    `tfsdk:"application"`
+}
+
+type mfaPolicyResourceMobileApplicationModel struct {
+	Id                                   types.String `tfsdk:"id"`
+	PushEnabled                          types.Bool   `tfsdk:"push_enabled"`
+	PushTimeoutDuration                  types.Int64  `tfsdk:"push_timeout_duration"`
+	PushTimeoutTimeunit                  types.String `tfsdk:"push_timeout_timeunit"`
+	OTPEnabled                           types.Bool   `tfsdk:"otp_enabled"`
+	DeviceAuthorizationEnabled           types.Bool   `tfsdk:"device_authorization_enabled"`
+	DeviceAuthorizationExtraVerification types.String `tfsdk:"device_authorization_extra_verification"`
+	AutoEnrollmentEnabled                types.Bool   `tfsdk:"auto_enrollment_enabled"`
+	IntegrityDetection                   types.String `tfsdk:"integrity_detection"`
+	PairingKeyLifetimeDuration           types.Int64  `tfsdk:"pairing_key_lifetime_duration"`
+	PairingKeyLifetimeTimeunit           types.String `tfsdk:"pairing_key_lifetime_timeunit"`
+	PushLimit                            types.List   `tfsdk:"push_limit"`
+}
+
+type mfaPolicyResourceMobileApplicationPushLimitModel struct {
+	Count                types.Int64  `tfsdk:"count"`
+	LockDurationDuration types.Int64  `tfsdk:"lock_duration_duration"`
+	LockDurationTimeunit types.String `tfsdk:"lock_duration_timeunit"`
+	TimePeriodDuration   types.Int64  `tfsdk:"time_period_duration"`
+	TimePeriodTimeunit   types.String `tfsdk:"time_period_timeunit"`
+}
+
+type mfaPolicyResourceTotpModel struct {
+	Enabled                    types.Bool   `tfsdk:"enabled"`
+	OTPFailureCount            types.Int64  `tfsdk:"otp_failure_count"`
+	OTPFailureCooldownDuration types.Int64  `tfsdk:"otp_failure_cooldown_duration"`
+	OTPFailureCooldownTimeunit types.String `tfsdk:"otp_failure_cooldown_timeunit"`
+}
+
+type mfaPolicyResourceFidoDeviceModel struct {
+	Enabled      types.Bool   `tfsdk:"enabled"`
+	FIDOPolicyID types.String `tfsdk:"fido_policy_id"`
+}
+
+var (
+	mfaPolicyOfflineDeviceTFObjectTypes = map[string]attr.Type{
+		"enabled":                       types.BoolType,
+		"otp_lifetime_duration":         types.Int64Type,
+		"otp_lifetime_timeunit":         types.StringType,
+		"otp_failure_count":             types.Int64Type,
+		"otp_failure_cooldown_duration": types.Int64Type,
+		"otp_failure_cooldown_timeunit": types.StringType,
+	}
+
+	mfaPolicyMobileTFObjectTypes = map[string]attr.Type{
+		"enabled":                       types.BoolType,
+		"otp_failure_count":             types.Int64Type,
+		"otp_failure_cooldown_duration": types.Int64Type,
+		"otp_failure_cooldown_timeunit": types.StringType,
+		"application":                   types.SetType{ElemType: types.ObjectType{AttrTypes: mfaPolicyMobileApplicationTFObjectTypes}},
+	}
+
+	mfaPolicyMobileApplicationTFObjectTypes = map[string]attr.Type{
+		"id":                           types.StringType,
+		"push_enabled":                 types.BoolType,
+		"push_timeout_duration":        types.Int64Type,
+		"push_timeout_timeunit":        types.StringType,
+		"otp_enabled":                  types.BoolType,
+		"device_authorization_enabled": types.BoolType,
+		"device_authorization_extra_verification": types.StringType,
+		"auto_enrollment_enabled":                 types.BoolType,
+		"integrity_detection":                     types.StringType,
+		"pairing_key_lifetime_duration":           types.Int64Type,
+		"pairing_key_lifetime_timeunit":           types.StringType,
+		"push_limit":                              types.ListType{ElemType: types.ObjectType{AttrTypes: mfaPolicyMobileApplicationPushLimitTFObjectTypes}},
+	}
+
+	mfaPolicyMobileApplicationPushLimitTFObjectTypes = map[string]attr.Type{
+		"count":                  types.Int64Type,
+		"lock_duration_duration": types.Int64Type,
+		"lock_duration_timeunit": types.StringType,
+		"time_period_duration":   types.Int64Type,
+		"time_period_timeunit":   types.StringType,
+	}
+
+	mfaPolicyTotpTFObjectTypes = map[string]attr.Type{
+		"enabled":                       types.BoolType,
+		"otp_failure_count":             types.Int64Type,
+		"otp_failure_cooldown_duration": types.Int64Type,
+		"otp_failure_cooldown_timeunit": types.StringType,
+	}
+
+	mfaPolicyFidoDeviceTFObjectTypes = map[string]attr.Type{
+		"enabled":        types.BoolType,
+		"fido_policy_id": types.StringType,
+	}
+)
+
+// Framework interfaces
+var (
+	_ resource.Resource                = &MFAPolicyResource{}
+	_ resource.ResourceWithConfigure   = &MFAPolicyResource{}
+	_ resource.ResourceWithImportState = &MFAPolicyResource{}
+)
+
+// New Object
+func NewMFAPolicyResource() resource.Resource {
+	return &MFAPolicyResource{}
+}
+
+// Metadata
+func (r *MFAPolicyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_mfa_policy"
+}
+
+// Schema.
+func (r *MFAPolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+
+	const attrMinLength = 1
+
+	const mobileOtpFailureCountDefault = 3
+
+	const mobileOtpFailureCooldownDurationDefault = 2
+
+	const totpOtpFailureCountDefault = 3
+
+	const totpOtpFailureCooldownDurationDefault = 2
+
+	const mobileApplicationPushTimeoutDurationDefault = 40
+	const mobileApplicationPushTimeoutDurationMin = 40
+	const mobileApplicationPushTimeoutDurationMax = 150
+
+	const mobileApplicationPairingKeyLifetimeDurationDefault = 10
+	const mobileApplicationPairingKeyLifetimeDurationMin = 1
+
+	const mobileApplicationPushLimitCountDefault = 5
+	const mobileApplicationPushLimitCountMin = 1
+	const mobileApplicationPushLimitCountMax = 50
+
+	const mobileApplicationPushLimitLockDurationDurationDefault = 30
+
+	const mobileApplicationPushLimitTimePeriodDurationDefault = 10
+
+	deviceSelectionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A string that defines the device selection method.",
+	).AllowedValuesEnum(mfa.AllowedEnumMFADevicePolicySelectionEnumValues).DefaultValue(string(mfa.ENUMMFADEVICEPOLICYSELECTION_DEFAULT_TO_FIRST))
+
+	authenticatorPaths := []string{"sms", "voice", "email", "mobile", "totp", "security_key", "platform"}
+
+	// SMS
+	smsDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"SMS OTP authentication policy settings.",
+	).ExactlyOneOf(authenticatorPaths)
+
+	// Voice
+	voiceDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Voice OTP authentication policy settings.",
+	).ExactlyOneOf(authenticatorPaths)
+
+	// Email
+	emailDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Email OTP authentication policy settings.",
+	).ExactlyOneOf(authenticatorPaths)
+
+	// Mobile
+	mobileDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Mobile authenticator device policy settings.  This factor requires embedding the PingOne MFA SDK into a customer facing mobile application, and configuring as a Native application using the `pingone_application` resource.",
+	).ExactlyOneOf(authenticatorPaths)
+
+	mobileOtpFailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.",
+	).DefaultValue(fmt.Sprintf("%d", mobileOtpFailureCountDefault))
+
+	mobileOtpFailureCooldownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.",
+	).DefaultValue(fmt.Sprintf("%d", mobileOtpFailureCooldownDurationDefault))
+
+	mobileOtpFailureCooldownTimeunitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The type of time unit for `otp_failure_cooldown_duration`.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
+
+	mobileApplicationPushTimeoutDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines the amount of time (in seconds) a user has to respond to a push notification before it expires. Minimum is `40` seconds and maximum is `150` seconds.",
+	).DefaultValue(fmt.Sprintf("%d", mobileApplicationPushTimeoutDurationDefault))
+
+	mobileApplicationPushTimoutTimeunitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The time unit for the `push_timeout_duration` parameter. Currently, the only permitted value is `SECONDS`.",
+	)
+
+	mobileApplicationDeviceAuthorizationExtraVerificationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Specifies the level of further verification when `device_authorization_enabled` is true. The PingOne platform performs an extra verification check by sending a \"silent\" push notification to the customer native application, and receives a confirmation in return.",
+	).AllowedValuesComplex(map[string]string{
+		"permissive":  "the PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as successfully completed",
+		"restrictive": "the PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as failed",
+	})
+
+	mobileApplicationAutoEnrollmentEnabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Set to `true` if you want the application to allow Auto Enrollment. Auto Enrollment means that the user can authenticate for the first time from an unpaired device, and the successful authentication will result in the pairing of the device for MFA.",
+	)
+
+	mobileApplicationIntegrityDetectionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Controls how authentication or registration attempts should proceed if a device integrity check does not receive a response.",
+	).AllowedValuesComplex(map[string]string{
+		"permissive":  "if you want to allow the process to continue",
+		"restrictive": "if you want to block the user in such situations",
+	})
+
+	mobileApplicationPairingKeyLifetimeDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The amount of time an issued pairing key can be used until it expires. Minimum is `1` minute and maximum is `48` hours.",
+	).DefaultValue(fmt.Sprintf("%d", mobileApplicationPairingKeyLifetimeDurationDefault))
+
+	mobileApplicationPairingKeyLifetimeTimeunit := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The time unit for the `pairing_key_lifetime_duration` parameter.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitPairingKeyLifetimeEnumValues).DefaultValue(string(mfa.ENUMTIMEUNITPAIRINGKEYLIFETIME_MINUTES))
+
+	mobileApplicationPushLimitCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The number of consecutive push notifications that can be ignored or rejected by a user within a defined period before push notifications are blocked for the application. The minimum value is `1` and the maximum value is `50`.",
+	).DefaultValue(fmt.Sprintf("%d", mobileApplicationPushLimitCountDefault))
+
+	mobileApplicationPushLimitLockDurationDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The length of time that push notifications should be blocked for the application if the defined limit has been reached. The minimum value is `1` minute and the maximum value is `120` minutes.",
+	).DefaultValue(fmt.Sprintf("%d", mobileApplicationPushLimitLockDurationDurationDefault))
+
+	mobileApplicationPushLimitLockDurationTimeunitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The time unit for the `lock_duration_duration` parameter.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
+
+	mobileApplicationPushLimitTimePeriodDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The time period in which the push notifications are counted towards the defined limit. The minimum value is `1` minute and the maximum value is `120` minutes.",
+	).DefaultValue(fmt.Sprintf("%d", mobileApplicationPushLimitTimePeriodDurationDefault))
+
+	mobileApplicationPushLimitTimePeriodTimeunitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The time unit for the `time_period_duration` parameter.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
+
+	// TOTP
+	totpDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"TOTP authenticator policy settings.",
+	).ExactlyOneOf(authenticatorPaths)
+
+	totpOtpFailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.",
+	).DefaultValue(fmt.Sprintf("%d", totpOtpFailureCountDefault))
+
+	totpOtpFailureCooldownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.",
+	).DefaultValue(fmt.Sprintf("%d", totpOtpFailureCooldownDurationDefault))
+
+	totpOtpFailureCooldownTimeunitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The type of time unit for `otp_failure_cooldown_duration`.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
+
+	// Security Key
+	securityKeyDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Security key (FIDO2) authentication policy settings.",
+	).ExactlyOneOf(authenticatorPaths)
+
+	// Platform
+	platformDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Platform biometrics authentication policy settings.",
+	).ExactlyOneOf(authenticatorPaths)
+
+	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		Description: "Resource to create and manage MFA Policies in a PingOne Environment.",
 
-		CreateContext: resourceMFAPolicyCreate,
-		ReadContext:   resourceMFAPolicyRead,
-		UpdateContext: resourceMFAPolicyUpdate,
-		DeleteContext: resourceMFAPolicyDelete,
+		Attributes: map[string]schema.Attribute{
+			"id": framework.Attr_ID(),
 
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceMFAPolicyImport,
+			"environment_id": framework.Attr_LinkID(
+				framework.SchemaAttributeDescriptionFromMarkdown("The ID of the environment to create the MFA policy in."),
+			),
+
+			"name": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the MFA policy's name.").Description,
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(attrMinLength),
+				},
+			},
+
+			"device_selection": schema.StringAttribute{
+				Description:         deviceSelectionDescription.Description,
+				MarkdownDescription: deviceSelectionDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: stringdefault.StaticString(string(mfa.ENUMMFADEVICEPOLICYSELECTION_DEFAULT_TO_FIRST)),
+
+				Validators: []validator.String{
+					stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumMFADevicePolicySelectionEnumValues)...),
+				},
+			},
 		},
 
-		Schema: map[string]*schema.Schema{
-			"environment_id": {
-				Description:      "The ID of the environment to create the sign on policy in.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
+		Blocks: map[string]schema.Block{
+
+			"sms": schema.ListNestedBlock{
+				Description:         smsDescription.Description,
+				MarkdownDescription: smsDescription.MarkdownDescription,
+
+				NestedObject: offlineDeviceResourceSchema(),
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("sms"),
+						path.MatchRoot("voice"),
+						path.MatchRoot("email"),
+						path.MatchRoot("mobile"),
+						path.MatchRoot("totp"),
+						path.MatchRoot("security_key"),
+						path.MatchRoot("platform"),
+					),
+				},
 			},
-			"name": {
-				Description:      "A string that specifies the MFA policy's name.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+
+			"voice": schema.ListNestedBlock{
+				Description:         voiceDescription.Description,
+				MarkdownDescription: voiceDescription.MarkdownDescription,
+
+				NestedObject: offlineDeviceResourceSchema(),
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("sms"),
+						path.MatchRoot("voice"),
+						path.MatchRoot("email"),
+						path.MatchRoot("mobile"),
+						path.MatchRoot("totp"),
+						path.MatchRoot("security_key"),
+						path.MatchRoot("platform"),
+					),
+				},
 			},
-			"device_selection": {
-				Description:      fmt.Sprintf("A string that defines the device selection method. Options are `%s` (this is the default setting for new environments), `%s` and `%s`.", string(mfa.ENUMMFADEVICEPOLICYSELECTION_DEFAULT_TO_FIRST), string(mfa.ENUMMFADEVICEPOLICYSELECTION_PROMPT_TO_SELECT), string(mfa.ENUMMFADEVICEPOLICYSELECTION_ALWAYS_PROMPT_TO_SELECT)),
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          string(mfa.ENUMMFADEVICEPOLICYSELECTION_DEFAULT_TO_FIRST),
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(mfa.ENUMMFADEVICEPOLICYSELECTION_DEFAULT_TO_FIRST), string(mfa.ENUMMFASETTINGSDEVICESELECTION_PROMPT_TO_SELECT), string(mfa.ENUMMFADEVICEPOLICYSELECTION_ALWAYS_PROMPT_TO_SELECT)}, false)),
+
+			"email": schema.ListNestedBlock{
+				Description:         emailDescription.Description,
+				MarkdownDescription: emailDescription.MarkdownDescription,
+
+				NestedObject: offlineDeviceResourceSchema(),
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("sms"),
+						path.MatchRoot("voice"),
+						path.MatchRoot("email"),
+						path.MatchRoot("mobile"),
+						path.MatchRoot("totp"),
+						path.MatchRoot("security_key"),
+						path.MatchRoot("platform"),
+					),
+				},
 			},
-			"sms": {
-				Description: "SMS OTP authentication policy settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem:        offlineDeviceResourceSchema("sms.0"),
-			},
-			"voice": {
-				Description: "Voice OTP authentication policy settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem:        offlineDeviceResourceSchema("voice.0"),
-			},
-			"email": {
-				Description: "Email OTP authentication policy settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem:        offlineDeviceResourceSchema("email.0"),
-			},
-			"mobile": {
-				Description: "Mobile authenticator device policy settings.  This factor requires embedding the PingOne MFA SDK into a customer facing mobile application, and configuring as a Native application using the `pingone_application` resource.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Description: "Enabled or disabled in the policy.",
-							Type:        schema.TypeBool,
+
+			"mobile": schema.ListNestedBlock{
+				Description:         mobileDescription.Description,
+				MarkdownDescription: mobileDescription.MarkdownDescription,
+
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Description: framework.SchemaAttributeDescriptionFromMarkdown("Enabled or disabled in the policy.").Description,
 							Required:    true,
 						},
-						"otp_failure_count": {
-							Description: "An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.",
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     3,
+
+						"otp_failure_count": schema.Int64Attribute{
+							Description:         mobileOtpFailureCountDescription.Description,
+							MarkdownDescription: mobileOtpFailureCountDescription.MarkdownDescription,
+							Optional:            true,
+							Computed:            true,
+
+							Default: int64default.StaticInt64(int64(mobileOtpFailureCountDefault)),
 						},
-						"otp_failure_cooldown_duration": {
-							Description: "An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.",
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     2,
+
+						"otp_failure_cooldown_duration": schema.Int64Attribute{
+							Description:         mobileOtpFailureCooldownDurationDescription.Description,
+							MarkdownDescription: mobileOtpFailureCooldownDurationDescription.MarkdownDescription,
+							Optional:            true,
+							Computed:            true,
+
+							Default: int64default.StaticInt64(int64(mobileOtpFailureCooldownDurationDefault)),
 						},
-						"otp_failure_cooldown_timeunit": {
-							Description:      fmt.Sprintf("The type of time unit for `otp_failure_cooldown_duration`.  Options are `%s` or `%s`.", string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)),
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          string(mfa.ENUMTIMEUNIT_MINUTES),
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)}, false)),
+
+						"otp_failure_cooldown_timeunit": schema.StringAttribute{
+							Description:         mobileOtpFailureCooldownTimeunitDescription.Description,
+							MarkdownDescription: mobileOtpFailureCooldownTimeunitDescription.MarkdownDescription,
+							Optional:            true,
+							Computed:            true,
+
+							Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNIT_MINUTES)),
+
+							Validators: []validator.String{
+								stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("otp_failure_cooldown_duration")),
+							},
 						},
-						"application": {
-							Description: "Settings for a configured Mobile Application.",
-							Type:        schema.TypeSet,
-							Optional:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"id": {
-										Description:      "The mobile application's ID.  Mobile applications are configured with the `pingone_application` resource, as an OIDC `NATIVE` type.",
-										Type:             schema.TypeString,
-										Required:         true,
-										ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
-									},
-									"push_enabled": {
-										Description: "Specifies whether push notification is enabled or disabled for the policy.",
-										Type:        schema.TypeBool,
+					},
+
+					Blocks: map[string]schema.Block{
+						"application": schema.SetNestedBlock{
+							Description: framework.SchemaAttributeDescriptionFromMarkdown("Settings for a configured Mobile Application.").Description,
+
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"id": framework.Attr_LinkID(
+										framework.SchemaAttributeDescriptionFromMarkdown("The mobile application's ID.  Mobile applications are configured with the `pingone_application` resource, as an OIDC `NATIVE` type."),
+									),
+
+									"push_enabled": schema.BoolAttribute{
+										Description: framework.SchemaAttributeDescriptionFromMarkdown("Specifies whether push notification is enabled or disabled for the policy.").Description,
 										Required:    true,
 									},
-									"push_timeout_duration": {
-										Description:      "An integer that defines the amount of time (in seconds) a user has to respond to a push notification before it expires. Minimum is 40 seconds and maximum is 150 seconds. If this parameter is not provided, the duration is set to 40 seconds.",
-										Type:             schema.TypeInt,
-										Optional:         true,
-										Default:          40,
-										ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(40, 150)),
+
+									"push_timeout_duration": schema.Int64Attribute{
+										Description:         mobileApplicationPushTimeoutDurationDescription.Description,
+										MarkdownDescription: mobileApplicationPushTimeoutDurationDescription.MarkdownDescription,
+										Optional:            true,
+										Computed:            true,
+
+										Default: int64default.StaticInt64(int64(mobileApplicationPushTimeoutDurationDefault)),
+
+										Validators: []validator.Int64{
+											int64validator.AtLeast(int64(mobileApplicationPushTimeoutDurationMin)),
+											int64validator.AtMost(int64(mobileApplicationPushTimeoutDurationMax)),
+										},
 									},
-									"push_timeout_timeunit": {
-										Description: "The time unit for the `push_timeout_duration` parameter. Currently, the only permitted value is `SECONDS`.",
-										Type:        schema.TypeString,
-										Computed:    true,
+
+									"push_timeout_timeunit": schema.StringAttribute{
+										Description:         mobileApplicationPushTimoutTimeunitDescription.Description,
+										MarkdownDescription: mobileApplicationPushTimoutTimeunitDescription.MarkdownDescription,
+										Optional:            true,
+										Computed:            true,
+
+										Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNIT_SECONDS)),
+
+										Validators: []validator.String{
+											stringvalidator.OneOf(string(mfa.ENUMTIMEUNIT_SECONDS)),
+											stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("push_timeout_duration")),
+										},
 									},
-									"otp_enabled": {
-										Description: "Specifies whether OTP authentication is enabled or disabled for the policy.",
-										Type:        schema.TypeBool,
+
+									"otp_enabled": schema.BoolAttribute{
+										Description: framework.SchemaAttributeDescriptionFromMarkdown("Specifies whether OTP authentication is enabled or disabled for the policy.").Description,
 										Required:    true,
 									},
-									"device_authorization_enabled": {
-										Description: "Specifies the enabled or disabled state of automatic MFA for native devices paired with the user, for the specified application.",
-										Type:        schema.TypeBool,
+
+									"device_authorization_enabled": schema.BoolAttribute{
+										Description: framework.SchemaAttributeDescriptionFromMarkdown("Specifies the enabled or disabled state of automatic MFA for native devices paired with the user, for the specified application.").Description,
 										Optional:    true,
 									},
-									"device_authorization_extra_verification": {
-										Description:      "Specifies the level of further verification when `device_authorization_enabled` is true. The PingOne platform performs an extra verification check by sending a \"silent\" push notification to the customer native application, and receives a confirmation in return.  Extra verification can be one of the following levels: `permissive`: The PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as successfully completed.  `restrictive`: The PingOne platform performs the extra verification check.The PingOne platform performs the extra verification check. Upon timeout or failure to get a response from the native app, the MFA step is treated as failed.",
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"permissive", "restrictive"}, false)),
+
+									"device_authorization_extra_verification": schema.StringAttribute{
+										Description:         mobileApplicationDeviceAuthorizationExtraVerificationDescription.Description,
+										MarkdownDescription: mobileApplicationDeviceAuthorizationExtraVerificationDescription.MarkdownDescription,
+										Optional:            true,
+
+										Validators: []validator.String{
+											stringvalidator.OneOf("permissive", "restrictive"),
+										},
 									},
-									"auto_enrollment_enabled": {
-										Description: "Set to `true` if you want the application to allow Auto Enrollment. Auto Enrollment means that the user can authenticate for the first time from an unpaired device, and the successful authentication will result in the pairing of the device for MFA.",
-										Type:        schema.TypeBool,
-										Optional:    true,
+
+									"auto_enrollment_enabled": schema.BoolAttribute{
+										Description:         mobileApplicationAutoEnrollmentEnabledDescription.Description,
+										MarkdownDescription: mobileApplicationAutoEnrollmentEnabledDescription.MarkdownDescription,
+										Optional:            true,
 									},
-									"integrity_detection": {
-										Description:      "Controls how authentication or registration attempts should proceed if a device integrity check does not receive a response. Set the value to `permissive` if you want to allow the process to continue. Set the value to `restrictive` if you want to block the user in such situations.",
-										Type:             schema.TypeString,
-										Optional:         true,
-										ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"permissive", "restrictive"}, false)),
+
+									"integrity_detection": schema.StringAttribute{
+										Description:         mobileApplicationIntegrityDetectionDescription.Description,
+										MarkdownDescription: mobileApplicationIntegrityDetectionDescription.MarkdownDescription,
+										Optional:            true,
+
+										Validators: []validator.String{
+											stringvalidator.OneOf("permissive", "restrictive"),
+										},
+									},
+
+									"pairing_key_lifetime_duration": schema.Int64Attribute{
+										Description:         mobileApplicationPairingKeyLifetimeDurationDescription.Description,
+										MarkdownDescription: mobileApplicationPairingKeyLifetimeDurationDescription.MarkdownDescription,
+										Optional:            true,
+										Computed:            true,
+
+										Default: int64default.StaticInt64(int64(mobileApplicationPairingKeyLifetimeDurationDefault)),
+
+										Validators: []validator.Int64{
+											int64validator.AtLeast(int64(mobileApplicationPairingKeyLifetimeDurationMin)),
+										},
+									},
+
+									"pairing_key_lifetime_timeunit": schema.StringAttribute{
+										Description:         mobileApplicationPairingKeyLifetimeTimeunit.Description,
+										MarkdownDescription: mobileApplicationPairingKeyLifetimeTimeunit.MarkdownDescription,
+										Optional:            true,
+										Computed:            true,
+
+										Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNITPAIRINGKEYLIFETIME_MINUTES)),
+
+										Validators: []validator.String{
+											stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitPairingKeyLifetimeEnumValues)...),
+											stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("pairing_key_lifetime_duration")),
+										},
+									},
+								},
+
+								Blocks: map[string]schema.Block{
+									"push_limit": schema.ListNestedBlock{
+										Description: "A single block that describes mobile application push limit settings.",
+
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"count": schema.Int64Attribute{
+													Description:         mobileApplicationPushLimitCountDescription.Description,
+													MarkdownDescription: mobileApplicationPushLimitCountDescription.MarkdownDescription,
+													Optional:            true,
+													Computed:            true,
+
+													Default: int64default.StaticInt64(int64(mobileApplicationPushLimitCountDefault)),
+
+													Validators: []validator.Int64{
+														int64validator.AtLeast(int64(mobileApplicationPushLimitCountMin)),
+														int64validator.AtMost(int64(mobileApplicationPushLimitCountMax)),
+													},
+												},
+
+												"lock_duration_duration": schema.Int64Attribute{
+													Description:         mobileApplicationPushLimitLockDurationDurationDescription.Description,
+													MarkdownDescription: mobileApplicationPushLimitLockDurationDurationDescription.MarkdownDescription,
+													Optional:            true,
+													Computed:            true,
+
+													Default: int64default.StaticInt64(int64(mobileApplicationPushLimitLockDurationDurationDefault)),
+												},
+
+												"lock_duration_timeunit": schema.StringAttribute{
+													Description:         mobileApplicationPushLimitLockDurationTimeunitDescription.Description,
+													MarkdownDescription: mobileApplicationPushLimitLockDurationTimeunitDescription.MarkdownDescription,
+													Optional:            true,
+													Computed:            true,
+
+													Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNIT_MINUTES)),
+
+													Validators: []validator.String{
+														stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+														stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("lock_duration_duration")),
+													},
+												},
+
+												"time_period_duration": schema.Int64Attribute{
+													Description:         mobileApplicationPushLimitTimePeriodDurationDescription.Description,
+													MarkdownDescription: mobileApplicationPushLimitTimePeriodDurationDescription.MarkdownDescription,
+													Optional:            true,
+													Computed:            true,
+
+													Default: int64default.StaticInt64(int64(mobileApplicationPushLimitTimePeriodDurationDefault)),
+												},
+
+												"time_period_timeunit": schema.StringAttribute{
+													Description:         mobileApplicationPushLimitTimePeriodTimeunitDescription.Description,
+													MarkdownDescription: mobileApplicationPushLimitTimePeriodTimeunitDescription.MarkdownDescription,
+													Optional:            true,
+													Computed:            true,
+
+													Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNIT_MINUTES)),
+
+													Validators: []validator.String{
+														stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+														stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("time_period_duration")),
+													},
+												},
+											},
+										},
+
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
 									},
 								},
 							},
 						},
 					},
 				},
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("sms"),
+						path.MatchRoot("voice"),
+						path.MatchRoot("email"),
+						path.MatchRoot("mobile"),
+						path.MatchRoot("totp"),
+						path.MatchRoot("security_key"),
+						path.MatchRoot("platform"),
+					),
+				},
 			},
-			"totp": {
-				Description: "TOTP authenticator policy settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Description: "Enabled or disabled in the policy.",
-							Type:        schema.TypeBool,
+
+			"totp": schema.ListNestedBlock{
+				Description:         totpDescription.Description,
+				MarkdownDescription: totpDescription.MarkdownDescription,
+
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"enabled": schema.BoolAttribute{
+							Description: framework.SchemaAttributeDescriptionFromMarkdown("Enabled or disabled in the policy.").Description,
 							Required:    true,
 						},
-						"otp_failure_count": {
-							Description: "An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.",
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     3,
+
+						"otp_failure_count": schema.Int64Attribute{
+							Description:         totpOtpFailureCountDescription.Description,
+							MarkdownDescription: totpOtpFailureCountDescription.MarkdownDescription,
+							Optional:            true,
+							Computed:            true,
+
+							Default: int64default.StaticInt64(int64(totpOtpFailureCountDefault)),
 						},
-						"otp_failure_cooldown_duration": {
-							Description: "An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.",
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Default:     2,
+
+						"otp_failure_cooldown_duration": schema.Int64Attribute{
+							Description:         totpOtpFailureCooldownDurationDescription.Description,
+							MarkdownDescription: totpOtpFailureCooldownDurationDescription.MarkdownDescription,
+							Optional:            true,
+							Computed:            true,
+
+							Default: int64default.StaticInt64(int64(totpOtpFailureCooldownDurationDefault)),
 						},
-						"otp_failure_cooldown_timeunit": {
-							Description:      fmt.Sprintf("The type of time unit for `otp_failure_cooldown_duration`.  Options are `%s` or `%s`.", string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)),
-							Type:             schema.TypeString,
-							Optional:         true,
-							Default:          string(mfa.ENUMTIMEUNIT_MINUTES),
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)}, false)),
+
+						"otp_failure_cooldown_timeunit": schema.StringAttribute{
+							Description:         totpOtpFailureCooldownTimeunitDescription.Description,
+							MarkdownDescription: totpOtpFailureCooldownTimeunitDescription.MarkdownDescription,
+							Optional:            true,
+							Computed:            true,
+
+							Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNIT_MINUTES)),
+
+							Validators: []validator.String{
+								stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+								stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("otp_failure_cooldown_duration")),
+							},
 						},
 					},
 				},
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("sms"),
+						path.MatchRoot("voice"),
+						path.MatchRoot("email"),
+						path.MatchRoot("mobile"),
+						path.MatchRoot("totp"),
+						path.MatchRoot("security_key"),
+						path.MatchRoot("platform"),
+					),
+				},
 			},
-			"security_key": {
-				Description: "Security key (FIDO2) authentication policy settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem:        fidoDeviceResourceSchema(),
+
+			"security_key": schema.ListNestedBlock{
+				Description:         securityKeyDescription.Description,
+				MarkdownDescription: securityKeyDescription.MarkdownDescription,
+
+				NestedObject: fidoDeviceResourceSchema(),
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("sms"),
+						path.MatchRoot("voice"),
+						path.MatchRoot("email"),
+						path.MatchRoot("mobile"),
+						path.MatchRoot("totp"),
+						path.MatchRoot("security_key"),
+						path.MatchRoot("platform"),
+					),
+				},
 			},
-			"platform": {
-				Description: "Platform biometrics authentication policy settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem:        fidoDeviceResourceSchema(),
+
+			"platform": schema.ListNestedBlock{
+				Description:         platformDescription.Description,
+				MarkdownDescription: platformDescription.MarkdownDescription,
+
+				NestedObject: fidoDeviceResourceSchema(),
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.AtLeastOneOf(
+						path.MatchRoot("sms"),
+						path.MatchRoot("voice"),
+						path.MatchRoot("email"),
+						path.MatchRoot("mobile"),
+						path.MatchRoot("totp"),
+						path.MatchRoot("security_key"),
+						path.MatchRoot("platform"),
+					),
+				},
 			},
 		},
 	}
 }
 
-func offlineDeviceResourceSchema(resourcePrefix string) *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"enabled": {
-				Description: "Enabled or disabled in the policy.",
-				Type:        schema.TypeBool,
+func offlineDeviceResourceSchema() schema.NestedBlockObject {
+
+	const otpLifetimeDefault = 30
+	const otpFailureDefault = 3
+	const otpFailureCooldownDefault = 0
+
+	otpLifetimeDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines duration (number of time units) that the passcode is valid before it expires.",
+	).DefaultValue(fmt.Sprintf("%d", otpLifetimeDefault))
+
+	otpLifetimeTimeunitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The type of time unit for `otp_lifetime_duration`.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
+
+	otpFailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.",
+	).DefaultValue(fmt.Sprintf("%d", otpFailureDefault))
+
+	otpFailureCooldownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the \"onetime authentication\" feature, the user is not blocked after the maximum number of failures even if you specified a block duration.",
+	).DefaultValue(fmt.Sprintf("%d", otpFailureCooldownDefault))
+
+	otpFailureCooldownTimeunitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The type of time unit for `otp_failure_cooldown_duration`.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
+
+	return schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("Enabled or disabled in the policy.").Description,
 				Required:    true,
 			},
-			"otp_lifetime_duration": {
-				Description: "An integer that defines turation (number of time units) that the passcode is valid before it expires.",
-				Type:        schema.TypeInt,
+
+			"otp_lifetime_duration": schema.Int64Attribute{
+				Description:         otpLifetimeDurationDescription.Description,
+				MarkdownDescription: otpLifetimeDurationDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: int64default.StaticInt64(int64(otpLifetimeDefault)),
+			},
+
+			"otp_lifetime_timeunit": schema.StringAttribute{
+				Description:         otpLifetimeTimeunitDescription.Description,
+				MarkdownDescription: otpLifetimeTimeunitDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNIT_MINUTES)),
+
+				Validators: []validator.String{
+					stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+					stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("otp_lifetime_duration")),
+				},
+			},
+
+			"otp_failure_count": schema.Int64Attribute{
+				Description:         otpFailureCountDescription.Description,
+				MarkdownDescription: otpFailureCountDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: int64default.StaticInt64(int64(otpFailureDefault)),
+			},
+
+			"otp_failure_cooldown_duration": schema.Int64Attribute{
+				Description:         otpFailureCooldownDurationDescription.Description,
+				MarkdownDescription: otpFailureCooldownDurationDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: int64default.StaticInt64(int64(otpFailureCooldownDefault)),
+			},
+
+			"otp_failure_cooldown_timeunit": schema.StringAttribute{
+				Description:         otpFailureCooldownTimeunitDescription.Description,
+				MarkdownDescription: otpFailureCooldownTimeunitDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: stringdefault.StaticString(string(mfa.ENUMTIMEUNIT_MINUTES)),
+
+				Validators: []validator.String{
+					stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+					stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("otp_failure_cooldown_duration")),
+				},
+			},
+		},
+	}
+}
+
+func fidoDeviceResourceSchema() schema.NestedBlockObject {
+
+	return schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("Enabled or disabled in the policy.").Description,
+				Required:    true,
+			},
+
+			"fido_policy_id": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("Specifies the FIDO policy ID. This property can be null. When null, the environment's default FIDO Policy is used.").Description,
 				Optional:    true,
-				Default:     30,
-			},
-			"otp_lifetime_timeunit": {
-				Description:      fmt.Sprintf("The type of time unit for `otp_lifetime_duration`.  Options are `%s` or `%s`.", string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)),
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          string(mfa.ENUMTIMEUNIT_MINUTES),
-				RequiredWith:     []string{fmt.Sprintf("%s.otp_lifetime_duration", resourcePrefix), fmt.Sprintf("%s.otp_lifetime_timeunit", resourcePrefix)},
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)}, false)),
-			},
-			"otp_failure_count": {
-				Description: "An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.",
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     3,
-			},
-			"otp_failure_cooldown_duration": {
-				Description:  "An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Note that when using the \"onetime authentication\" feature, the user is not blocked after the maximum number of failures even if you specified a block duration.",
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      0,
-				RequiredWith: []string{fmt.Sprintf("%s.otp_failure_cooldown_duration", resourcePrefix), fmt.Sprintf("%s.otp_failure_cooldown_timeunit", resourcePrefix)},
-			},
-			"otp_failure_cooldown_timeunit": {
-				Description:      fmt.Sprintf("The type of time unit for `otp_failure_cooldown_duration`.  Options are `%s` or `%s`.", string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)),
-				Type:             schema.TypeString,
-				Optional:         true,
-				Default:          string(mfa.ENUMTIMEUNIT_MINUTES),
-				RequiredWith:     []string{fmt.Sprintf("%s.otp_failure_cooldown_duration", resourcePrefix), fmt.Sprintf("%s.otp_failure_cooldown_timeunit", resourcePrefix)},
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(mfa.ENUMTIMEUNIT_MINUTES), string(mfa.ENUMTIMEUNIT_SECONDS)}, false)),
+
+				Validators: []validator.String{
+					verify.P1ResourceIDValidator(),
+				},
 			},
 		},
 	}
 }
 
-func fidoDeviceResourceSchema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"enabled": {
-				Description: "Enabled or disabled in the policy.",
-				Type:        schema.TypeBool,
-				Required:    true,
-			},
-			"fido_policy_id": {
-				Description:      "Specifies the FIDO policy ID. This property can be null. When null, the environment's default FIDO Policy is used.",
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
-			},
-		},
+func (r *MFAPolicyResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
 	}
+
+	resourceConfig, ok := req.ProviderData.(framework.ResourceType)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected the provider client, got: %T. Please report this issue to the provider maintainers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	preparedClient, err := prepareClient(ctx, resourceConfig)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			err.Error(),
+		)
+
+		return
+	}
+
+	r.client = preparedClient
+	r.region = resourceConfig.Client.API.Region
+
+	preparedMgmtClient, err := prepareMgmtClient(ctx, resourceConfig)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			err.Error(),
+		)
+
+		return
+	}
+
+	r.mgmtClient = preparedMgmtClient
 }
 
-func resourceMFAPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
+func (r *MFAPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan, state mfaPolicyResourceModel
+
+	if r.client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
+
 	ctx = context.WithValue(ctx, mfa.ContextServerVariables, map[string]string{
-		"suffix": p1Client.API.Region.URLSuffix,
+		"suffix": r.region.URLSuffix,
 	})
 
-	managementApiClient := p1Client.API.ManagementAPIClient
-	ctxManagement := context.WithValue(ctx, management.ContextServerVariables, map[string]string{
-		"suffix": p1Client.API.Region.URLSuffix,
-	})
-	var diags diag.Diagnostics
-
-	mfaPolicy, diags := expandMFAPolicy(ctxManagement, managementApiClient, d)
-	if diags.HasError() {
-		return diags
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	resp, diags := sdk.ParseResponse(
+	// Build the model for the API
+	mfaPolicy, d := plan.expand(ctx, r.mgmtClient, plan.EnvironmentId.ValueString())
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	response, d := framework.ParseResponse(
 		ctx,
 
 		func() (interface{}, *http.Response, error) {
-			return apiClient.DeviceAuthenticationPolicyApi.CreateDeviceAuthenticationPolicies(ctx, d.Get("environment_id").(string)).DeviceAuthenticationPolicy(*mfaPolicy).Execute()
+			return r.client.DeviceAuthenticationPolicyApi.CreateDeviceAuthenticationPolicies(ctx, plan.EnvironmentId.ValueString()).DeviceAuthenticationPolicy(*mfaPolicy).Execute()
 		},
 		"CreateDeviceAuthenticationPolicies",
-		sdk.DefaultCustomError,
+		framework.DefaultCustomError,
 		sdk.DefaultCreateReadRetryable,
 	)
-	if diags.HasError() {
-		return diags
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	respObject := resp.(*mfa.DeviceAuthenticationPolicy)
+	// Create the state to save
+	state = plan
 
-	d.SetId(respObject.GetId())
-
-	return resourceMFAPolicyRead(ctx, d, meta)
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(state.toState(response.(*mfa.DeviceAuthenticationPolicy))...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func resourceMFAPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
-	ctx = context.WithValue(ctx, mfa.ContextServerVariables, map[string]string{
-		"suffix": p1Client.API.Region.URLSuffix,
-	})
-	var diags diag.Diagnostics
+func (r *MFAPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *mfaPolicyResourceModel
 
-	resp, diags := sdk.ParseResponse(
+	if r.client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
+
+	ctx = context.WithValue(ctx, mfa.ContextServerVariables, map[string]string{
+		"suffix": r.region.URLSuffix,
+	})
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	response, diags := framework.ParseResponse(
 		ctx,
 
 		func() (interface{}, *http.Response, error) {
-			return apiClient.DeviceAuthenticationPolicyApi.ReadOneDeviceAuthenticationPolicy(ctx, d.Get("environment_id").(string), d.Id()).Execute()
+			return r.client.DeviceAuthenticationPolicyApi.ReadOneDeviceAuthenticationPolicy(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString()).Execute()
 		},
 		"ReadOneDeviceAuthenticationPolicy",
-		sdk.DefaultCustomError,
+		framework.CustomErrorResourceNotFoundWarning,
 		sdk.DefaultCreateReadRetryable,
 	)
-	if diags.HasError() {
-		return diags
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if resp == nil {
-		d.SetId("")
-		return nil
+	// Remove from state if resource is not found
+	if response == nil {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
-	respObject := resp.(*mfa.DeviceAuthenticationPolicy)
-
-	d.Set("name", respObject.GetName())
-
-	if v, ok := respObject.GetAuthenticationOk(); ok {
-		d.Set("device_selection", v.GetDeviceSelection())
-	} else {
-		d.Set("device_selection", nil)
-	}
-
-	if v, ok := respObject.GetSmsOk(); ok {
-		d.Set("sms", flattenMFAPolicyOfflineDevice(v))
-	} else {
-		d.Set("sms", nil)
-	}
-
-	if v, ok := respObject.GetVoiceOk(); ok {
-		d.Set("voice", flattenMFAPolicyOfflineDevice(v))
-	} else {
-		d.Set("voice", nil)
-	}
-
-	if v, ok := respObject.GetEmailOk(); ok {
-		d.Set("email", flattenMFAPolicyOfflineDevice(v))
-	} else {
-		d.Set("email", nil)
-	}
-
-	if v, ok := respObject.GetMobileOk(); ok {
-		d.Set("mobile", flattenMFAPolicyMobile(v))
-	} else {
-		d.Set("mobile", nil)
-	}
-
-	if v, ok := respObject.GetTotpOk(); ok {
-		d.Set("totp", flattenMFAPolicyTotp(v))
-	} else {
-		d.Set("totp", nil)
-	}
-
-	if v, ok := respObject.GetSecurityKeyOk(); ok {
-		d.Set("security_key", flattenMFAPolicyFIDODevice(v))
-	} else {
-		d.Set("security_key", nil)
-	}
-
-	if v, ok := respObject.GetPlatformOk(); ok {
-		d.Set("platform", flattenMFAPolicyFIDODevice(v))
-	} else {
-		d.Set("platform", nil)
-	}
-
-	return diags
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(data.toState(response.(*mfa.DeviceAuthenticationPolicy))...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func resourceMFAPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
-	ctx = context.WithValue(ctx, mfa.ContextServerVariables, map[string]string{
-		"suffix": p1Client.API.Region.URLSuffix,
-	})
+func (r *MFAPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state mfaPolicyResourceModel
 
-	managementApiClient := p1Client.API.ManagementAPIClient
-	ctxManagement := context.WithValue(ctx, management.ContextServerVariables, map[string]string{
-		"suffix": p1Client.API.Region.URLSuffix,
-	})
-	var diags diag.Diagnostics
-
-	mfaPolicy, diags := expandMFAPolicy(ctxManagement, managementApiClient, d)
-	if diags.HasError() {
-		return diags
+	if r.client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
 	}
 
-	_, diags = sdk.ParseResponse(
+	ctx = context.WithValue(ctx, mfa.ContextServerVariables, map[string]string{
+		"suffix": r.region.URLSuffix,
+	})
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Build the model for the API
+	mfaPolicy, d := plan.expand(ctx, r.mgmtClient, plan.EnvironmentId.ValueString())
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	response, d := framework.ParseResponse(
 		ctx,
 
 		func() (interface{}, *http.Response, error) {
-			return apiClient.DeviceAuthenticationPolicyApi.UpdateDeviceAuthenticationPolicy(ctx, d.Get("environment_id").(string), d.Id()).DeviceAuthenticationPolicy(*mfaPolicy).Execute()
+			return r.client.DeviceAuthenticationPolicyApi.UpdateDeviceAuthenticationPolicy(ctx, plan.EnvironmentId.ValueString(), plan.Id.ValueString()).DeviceAuthenticationPolicy(*mfaPolicy).Execute()
 		},
-		"UpdateMFAPolicy",
-		sdk.DefaultCustomError,
-		nil,
+		"UpdateDeviceAuthenticationPolicy",
+		framework.DefaultCustomError,
+		sdk.DefaultCreateReadRetryable,
 	)
-	if diags.HasError() {
-		return diags
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return resourceMFAPolicyRead(ctx, d, meta)
+	// Create the state to save
+	state = plan
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(state.toState(response.(*mfa.DeviceAuthenticationPolicy))...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func resourceMFAPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
-	ctx = context.WithValue(ctx, mfa.ContextServerVariables, map[string]string{
-		"suffix": p1Client.API.Region.URLSuffix,
-	})
-	var diags diag.Diagnostics
+func (r *MFAPolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *mfaPolicyResourceModel
 
-	_, diags = sdk.ParseResponse(
+	if r.client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
+
+	ctx = context.WithValue(ctx, mfa.ContextServerVariables, map[string]string{
+		"suffix": r.region.URLSuffix,
+	})
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	_, d := framework.ParseResponse(
 		ctx,
 
 		func() (interface{}, *http.Response, error) {
-			r, err := apiClient.DeviceAuthenticationPolicyApi.DeleteDeviceAuthenticationPolicy(ctx, d.Get("environment_id").(string), d.Id()).Execute()
+			r, err := r.client.DeviceAuthenticationPolicyApi.DeleteDeviceAuthenticationPolicy(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString()).Execute()
 			return nil, r, err
 		},
 		"DeleteDeviceAuthenticationPolicy",
-		sdk.DefaultCustomError,
-		nil,
+		framework.CustomErrorResourceNotFoundWarning,
+		sdk.DefaultCreateReadRetryable,
 	)
-	if diags.HasError() {
-		return diags
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-
-	return diags
 }
 
-func resourceMFAPolicyImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func (r *MFAPolicyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	splitLength := 2
-	attributes := strings.SplitN(d.Id(), "/", splitLength)
+	attributes := strings.SplitN(req.ID, "/", splitLength)
 
 	if len(attributes) != splitLength {
-		return nil, fmt.Errorf("invalid id (\"%s\") specified, should be in format \"environmentID/mfaPolicyID\"", d.Id())
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("invalid id (\"%s\") specified, should be in format \"environment_id/mfa_device_policy_id\"", req.ID),
+		)
+		return
 	}
 
-	environmentID, mfaPolicyID := attributes[0], attributes[1]
-
-	d.Set("environment_id", environmentID)
-	d.SetId(mfaPolicyID)
-
-	resourceMFAPolicyRead(ctx, d, meta)
-
-	return []*schema.ResourceData{d}, nil
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment_id"), attributes[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), attributes[1])...)
 }
 
-func expandMFAPolicy(ctx context.Context, apiClient *management.APIClient, d *schema.ResourceData) (*mfa.DeviceAuthenticationPolicy, diag.Diagnostics) {
+func (p *mfaPolicyResourceModel) expand(ctx context.Context, apiClient *management.APIClient, environmentID string) (*mfa.DeviceAuthenticationPolicy, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	mobile, diags := expandMFAPolicyMobileDevice(d.Get("mobile").([]interface{})[0], ctx, apiClient, d.Get("environment_id").(string))
+	// SMS
+	var smsPlan []mfaPolicyResourceOfflineDeviceModel
+	diags.Append(p.SMS.ElementsAs(ctx, &smsPlan, false)...)
 	if diags.HasError() {
 		return nil, diags
 	}
 
-	item := mfa.NewDeviceAuthenticationPolicy(
-		d.Get("name").(string),
-		*expandMFAPolicyOfflineDevice(d.Get("sms").([]interface{})[0]),
-		*expandMFAPolicyOfflineDevice(d.Get("voice").([]interface{})[0]),
-		*expandMFAPolicyOfflineDevice(d.Get("email").([]interface{})[0]),
-		*mobile,
-		*expandMFAPolicyTOTPDevice(d.Get("totp").([]interface{})[0]),
-		*expandMFAPolicyFIDODevice(d.Get("security_key").([]interface{})[0]),
-		*expandMFAPolicyFIDODevice(d.Get("platform").([]interface{})[0]),
+	dataSms, d := smsPlan[0].expand(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Voice
+	var voicePlan []mfaPolicyResourceOfflineDeviceModel
+	diags.Append(p.Voice.ElementsAs(ctx, &voicePlan, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	dataVoice, d := voicePlan[0].expand(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Email
+	var emailPlan []mfaPolicyResourceOfflineDeviceModel
+	diags.Append(p.Email.ElementsAs(ctx, &emailPlan, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	dataEmail, d := emailPlan[0].expand(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Mobile
+	var mobilePlan []mfaPolicyResourceMobileModel
+	diags.Append(p.Mobile.ElementsAs(ctx, &mobilePlan, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	dataMobile, d := mobilePlan[0].expand(ctx, apiClient, environmentID)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// TOTP
+	var totpPlan []mfaPolicyResourceTotpModel
+	diags.Append(p.Totp.ElementsAs(ctx, &totpPlan, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	dataTotp, d := totpPlan[0].expand(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Security Key
+	var securityKeyPlan []mfaPolicyResourceFidoDeviceModel
+	diags.Append(p.SecurityKey.ElementsAs(ctx, &securityKeyPlan, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	dataSecurityKey, d := securityKeyPlan[0].expand(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// Platform
+	var platformPlan []mfaPolicyResourceFidoDeviceModel
+	diags.Append(p.Platform.ElementsAs(ctx, &platformPlan, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	dataPlatform, d := platformPlan[0].expand(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	data := mfa.NewDeviceAuthenticationPolicy(
+		p.Name.ValueString(),
+		*dataSms,
+		*dataVoice,
+		*dataEmail,
+		*dataMobile,
+		*dataTotp,
+		*dataSecurityKey,
+		*dataPlatform,
 		false,
 		false,
 	)
 
-	if v, ok := d.GetOk("device_selection"); ok {
-		item.SetAuthentication(*mfa.NewDeviceAuthenticationPolicyAuthentication(mfa.EnumMFADevicePolicySelection(v.(string))))
+	if !p.DeviceSelection.IsNull() && !p.DeviceSelection.IsUnknown() {
+		data.SetAuthentication(
+			*mfa.NewDeviceAuthenticationPolicyAuthentication(
+				mfa.EnumMFADevicePolicySelection(p.DeviceSelection.ValueString()),
+			),
+		)
 	}
 
-	return item, diags
+	return data, diags
 }
 
-func expandMFAPolicyOfflineDevice(v interface{}) *mfa.DeviceAuthenticationPolicyOfflineDevice {
+func (p *mfaPolicyResourceOfflineDeviceModel) expand(ctx context.Context) (*mfa.DeviceAuthenticationPolicyOfflineDevice, diag.Diagnostics) {
+	var diags diag.Diagnostics
 
-	obj := v.(map[string]interface{})
-
-	otp := *mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtp(
-		*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpLifeTime(int32(obj["otp_lifetime_duration"].(int)), mfa.EnumTimeUnit(obj["otp_lifetime_timeunit"].(string))),
-		*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(
-			int32(obj["otp_failure_count"].(int)),
-			*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(int32(obj["otp_failure_cooldown_duration"].(int)), mfa.EnumTimeUnit(obj["otp_failure_cooldown_timeunit"].(string))),
+	data := mfa.NewDeviceAuthenticationPolicyOfflineDevice(p.Enabled.ValueBool(),
+		*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtp(
+			*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpLifeTime(
+				int32(p.OTPLifetimeDuration.ValueInt64()),
+				mfa.EnumTimeUnit(p.OTPLifetimeTimeunit.ValueString()),
+			),
+			*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(
+				int32(p.OTPFailureCount.ValueInt64()),
+				*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(
+					int32(p.OTPFailureCooldownDuration.ValueInt64()),
+					mfa.EnumTimeUnit(p.OTPFailureCooldownTimeunit.ValueString()),
+				),
+			),
 		),
 	)
 
-	item := mfa.NewDeviceAuthenticationPolicyOfflineDevice(obj["enabled"].(bool), otp)
-
-	return item
+	return data, diags
 }
 
-func expandMFAPolicyMobileDevice(v interface{}, ctx context.Context, apiClient *management.APIClient, environmentID string) (*mfa.DeviceAuthenticationPolicyMobile, diag.Diagnostics) {
+func (p *mfaPolicyResourceMobileModel) expand(ctx context.Context, apiClient *management.APIClient, environmentID string) (*mfa.DeviceAuthenticationPolicyMobile, diag.Diagnostics) {
 	var diags diag.Diagnostics
-
-	obj := v.(map[string]interface{})
 
 	otpStepSizeDuration := 30
 
-	item := mfa.NewDeviceAuthenticationPolicyMobile(
-		obj["enabled"].(bool),
+	data := mfa.NewDeviceAuthenticationPolicyMobile(p.Enabled.ValueBool(),
 		*mfa.NewDeviceAuthenticationPolicyMobileOtp(
 			*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(
-				int32(obj["otp_failure_count"].(int)),
-				*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(int32(obj["otp_failure_cooldown_duration"].(int)), mfa.EnumTimeUnit(obj["otp_failure_cooldown_timeunit"].(string))),
+				int32(p.OTPFailureCount.ValueInt64()),
+				*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(
+					int32(p.OTPFailureCooldownDuration.ValueInt64()),
+					mfa.EnumTimeUnit(p.OTPFailureCooldownTimeunit.ValueString()),
+				),
 			),
 			*mfa.NewDeviceAuthenticationPolicyMobileOtpWindow(
 				*mfa.NewDeviceAuthenticationPolicyMobileOtpWindowStepSize(
@@ -551,356 +1279,457 @@ func expandMFAPolicyMobileDevice(v interface{}, ctx context.Context, apiClient *
 		),
 	)
 
-	if c, ok := obj["application"].(*schema.Set); ok && c != nil && len(c.List()) > 0 && c.List()[0] != nil {
+	if !p.Application.IsNull() && !p.Application.IsUnknown() {
+		var applicationsPlan []mfaPolicyResourceMobileApplicationModel
+		diags.Append(p.Application.ElementsAs(ctx, &applicationsPlan, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
 
-		items := make([]mfa.DeviceAuthenticationPolicyMobileApplicationsInner, 0)
+		applications := make([]mfa.DeviceAuthenticationPolicyMobileApplicationsInner, 0)
 
-		for _, cn := range c.List() {
+		for _, applicationPlan := range applicationsPlan {
 
-			c2 := cn.(map[string]interface{})
+			item := *mfa.NewDeviceAuthenticationPolicyMobileApplicationsInner(applicationPlan.Id.ValueString())
 
-			item := *mfa.NewDeviceAuthenticationPolicyMobileApplicationsInner(c2["id"].(string))
-
-			application, diags := checkApplicationForMobileApp(ctx, apiClient, environmentID, c2["id"].(string))
+			diags.Append(checkApplicationForMobileApp(ctx, apiClient, environmentID, applicationPlan.Id.ValueString())...)
 			if diags.HasError() {
 				return nil, diags
 			}
 
-			if c3, ok := c2["push_enabled"].(bool); ok {
-				item.SetPush(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPush(c3))
+			if !applicationPlan.PushEnabled.IsNull() && !applicationPlan.PushEnabled.IsUnknown() {
+				item.SetPush(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPush(applicationPlan.PushEnabled.ValueBool()))
 			}
 
-			if c3, ok := c2["push_timeout_duration"].(int); ok {
-				item.SetPushTimeout(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPushTimeout(int32(c3), mfa.ENUMTIMEUNITPUSHTIMEOUT_SECONDS))
+			if !applicationPlan.PushTimeoutDuration.IsNull() && !applicationPlan.PushTimeoutDuration.IsUnknown() {
+				item.SetPushTimeout(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPushTimeout(
+					int32(applicationPlan.PushTimeoutDuration.ValueInt64()),
+					mfa.EnumTimeUnitPushTimeout(applicationPlan.PushTimeoutTimeunit.ValueString())),
+				)
 			}
 
-			if c3, ok := c2["otp_enabled"].(bool); ok {
-				item.SetOtp(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerOtp(c3))
+			if !applicationPlan.OTPEnabled.IsNull() && !applicationPlan.OTPEnabled.IsUnknown() {
+				item.SetOtp(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerOtp(applicationPlan.OTPEnabled.ValueBool()))
 			}
 
-			deviceAuthz := *mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerDeviceAuthorization(c2["device_authorization_enabled"].(bool))
+			deviceAuthz := *mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerDeviceAuthorization(applicationPlan.DeviceAuthorizationEnabled.ValueBool())
 
-			if c3, ok := c2["device_authorization_extra_verification"].(string); ok && c3 != "" {
-				deviceAuthz.SetExtraVerification(mfa.EnumMFADevicePolicyMobileExtraVerification(c3))
+			if !applicationPlan.DeviceAuthorizationExtraVerification.IsNull() && !applicationPlan.DeviceAuthorizationExtraVerification.IsUnknown() {
+				deviceAuthz.SetExtraVerification(mfa.EnumMFADevicePolicyMobileExtraVerification(applicationPlan.DeviceAuthorizationExtraVerification.ValueString()))
 			}
 
 			item.SetDeviceAuthorization(deviceAuthz)
 
-			if c3, ok := c2["auto_enrollment_enabled"].(bool); ok {
-				item.SetAutoEnrollment(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerAutoEnrollment(c3))
+			if !applicationPlan.AutoEnrollmentEnabled.IsNull() && !applicationPlan.AutoEnrollmentEnabled.IsUnknown() {
+				item.SetAutoEnrollment(*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerAutoEnrollment(applicationPlan.AutoEnrollmentEnabled.ValueBool()))
 			}
 
-			c3, ok := c2["integrity_detection"].(string)
-			if application.GetMobile().IntegrityDetection.GetMode() == management.ENUMENABLEDSTATUS_ENABLED {
-
-				if ok && c3 != "" {
-					item.SetIntegrityDetection(mfa.EnumMFADevicePolicyMobileIntegrityDetection(c3))
-				} else {
-					// error - this must be set
-					diags = append(diags, diag.Diagnostic{
-						Severity: diag.Error,
-						Summary:  "Integrity detection (`mobile.application.integrity_detection`) must be set when the Application resource has integrity detection enabled",
-						Detail:   "The referenced mobile application (`mobile.application.id`) has integrity detection enabled. This policy must specify the level of integrity detection in the `mobile.application.integrity_detection` parameter.",
-					})
-					return nil, diags
-				}
-			} else {
-				if ok && c3 != "" {
-					// error - this has no effect
-					diags = append(diags, diag.Diagnostic{
-						Severity: diag.Error,
-						Summary:  "Integrity detection (`mobile.application.integrity_detection`) has no effect when the Application resource has integrity detection disabled",
-						Detail:   "The referenced mobile application (`mobile.application.id`) has integrity detection disabled. Setting the `mobile.application.integrity_detection` parameter has no effect.",
-					})
-					return nil, diags
-				}
+			if !applicationPlan.IntegrityDetection.IsNull() && !applicationPlan.IntegrityDetection.IsUnknown() {
+				item.SetIntegrityDetection(mfa.EnumMFADevicePolicyMobileIntegrityDetection(applicationPlan.IntegrityDetection.ValueString()))
 			}
 
-			items = append(items, item)
+			applications = append(applications, item)
 		}
 
-		item.SetApplications(items)
+		data.SetApplications(applications)
 	}
 
-	return item, diags
+	return data, diags
 }
 
-func checkApplicationForMobileApp(ctx context.Context, apiClient *management.APIClient, environmentID, appID string) (*management.ApplicationOIDC, diag.Diagnostics) {
+func (p *mfaPolicyResourceTotpModel) expand(ctx context.Context) (*mfa.DeviceAuthenticationPolicyTotp, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	resp, diags := sdk.ParseResponse(
+	data := mfa.NewDeviceAuthenticationPolicyTotp(p.Enabled.ValueBool(),
+		*mfa.NewDeviceAuthenticationPolicyTotpOtp(
+			*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(
+				int32(p.OTPFailureCount.ValueInt64()),
+				*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(
+					int32(p.OTPFailureCooldownDuration.ValueInt64()),
+					mfa.EnumTimeUnit(p.OTPFailureCooldownTimeunit.ValueString()),
+				),
+			),
+		),
+	)
+
+	return data, diags
+}
+
+func (p *mfaPolicyResourceFidoDeviceModel) expand(ctx context.Context) (*mfa.DeviceAuthenticationPolicyFIDODevice, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	data := mfa.NewDeviceAuthenticationPolicyFIDODevice(p.Enabled.ValueBool())
+
+	if !p.FIDOPolicyID.IsNull() && !p.FIDOPolicyID.IsUnknown() {
+		data.SetFidoPolicyId(p.FIDOPolicyID.ValueString())
+	}
+
+	return data, diags
+}
+
+func (p *mfaPolicyResourceModel) toState(apiObject *mfa.DeviceAuthenticationPolicy) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if apiObject == nil {
+		diags.AddError(
+			"Data object missing",
+			"Cannot convert the data object to state as the data object is nil.  Please report this to the provider maintainers.",
+		)
+
+		return diags
+	}
+
+	p.Id = framework.StringToTF(apiObject.GetId())
+	p.EnvironmentId = framework.StringToTF(*apiObject.GetEnvironment().Id)
+	p.Name = framework.StringOkToTF(apiObject.GetNameOk())
+
+	if v, ok := apiObject.GetAuthenticationOk(); ok {
+		p.DeviceSelection = framework.EnumOkToTF(v.GetDeviceSelectionOk())
+	} else {
+		p.DeviceSelection = types.StringNull()
+	}
+
+	var d diag.Diagnostics
+	p.SMS, d = offlineDeviceOkToTF(apiObject.GetSmsOk())
+	diags.Append(d...)
+
+	p.Voice, d = offlineDeviceOkToTF(apiObject.GetVoiceOk())
+	diags.Append(d...)
+
+	p.Email, d = offlineDeviceOkToTF(apiObject.GetEmailOk())
+	diags.Append(d...)
+
+	p.Mobile, d = mobileDeviceOkToTF(apiObject.GetMobileOk())
+	diags.Append(d...)
+
+	p.Totp, d = totpDeviceOkToTF(apiObject.GetTotpOk())
+	diags.Append(d...)
+
+	p.SecurityKey, d = fidoDeviceOkToTF(apiObject.GetSecurityKeyOk())
+	diags.Append(d...)
+
+	p.Platform, d = fidoDeviceOkToTF(apiObject.GetPlatformOk())
+	diags.Append(d...)
+
+	return diags
+}
+
+func offlineDeviceOkToTF(apiObject *mfa.DeviceAuthenticationPolicyOfflineDevice, ok bool) (basetypes.ListValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: mfaPolicyOfflineDeviceTFObjectTypes}
+
+	if !ok || apiObject == nil {
+		return types.ListNull(tfObjType), diags
+	}
+
+	objectMap := map[string]attr.Value{
+		"enabled":                       framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"otp_lifetime_duration":         types.Int64Null(),
+		"otp_lifetime_timeunit":         types.StringNull(),
+		"otp_failure_count":             types.Int64Null(),
+		"otp_failure_cooldown_duration": types.Int64Null(),
+		"otp_failure_cooldown_timeunit": types.StringNull(),
+	}
+
+	if v, ok := apiObject.GetOtpOk(); ok {
+		if v1, ok := v.GetLifeTimeOk(); ok {
+			objectMap["otp_lifetime_duration"] = framework.Int32OkToTF(v1.GetDurationOk())
+			objectMap["otp_lifetime_timeunit"] = framework.EnumOkToTF(v1.GetTimeUnitOk())
+		}
+
+		if v1, ok := v.GetFailureOk(); ok {
+			objectMap["otp_failure_count"] = framework.Int32OkToTF(v1.GetCountOk())
+
+			if v2, ok := v1.GetCoolDownOk(); ok {
+				objectMap["otp_failure_cooldown_duration"] = framework.Int32OkToTF(v2.GetDurationOk())
+				objectMap["otp_failure_cooldown_timeunit"] = framework.EnumOkToTF(v2.GetTimeUnitOk())
+			}
+		}
+	}
+
+	flattenedObj, d := types.ObjectValue(mfaPolicyOfflineDeviceTFObjectTypes, objectMap)
+	diags.Append(d...)
+
+	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func mobileDeviceOkToTF(apiObject *mfa.DeviceAuthenticationPolicyMobile, ok bool) (basetypes.ListValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: mfaPolicyMobileTFObjectTypes}
+
+	if !ok || apiObject == nil {
+		return types.ListNull(tfObjType), diags
+	}
+
+	objectMap := map[string]attr.Value{
+		"enabled":                       framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"otp_failure_count":             types.Int64Null(),
+		"otp_failure_cooldown_duration": types.Int64Null(),
+		"otp_failure_cooldown_timeunit": types.StringNull(),
+		"application":                   types.SetNull(types.ObjectType{AttrTypes: mfaPolicyMobileApplicationTFObjectTypes}),
+	}
+
+	if v, ok := apiObject.GetOtpOk(); ok {
+		if v1, ok := v.GetFailureOk(); ok {
+			objectMap["otp_failure_count"] = framework.Int32OkToTF(v1.GetCountOk())
+
+			if v2, ok := v1.GetCoolDownOk(); ok {
+				objectMap["otp_failure_cooldown_duration"] = framework.Int32OkToTF(v2.GetDurationOk())
+				objectMap["otp_failure_cooldown_timeunit"] = framework.EnumOkToTF(v2.GetTimeUnitOk())
+			}
+		}
+	}
+
+	applicationObj, d := mobileApplicationsOkToTF(apiObject.GetApplicationsOk())
+	diags.Append(d...)
+	objectMap["application"] = applicationObj
+
+	flattenedObj, d := types.ObjectValue(mfaPolicyMobileTFObjectTypes, objectMap)
+	diags.Append(d...)
+
+	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func mobileApplicationsOkToTF(apiObject []mfa.DeviceAuthenticationPolicyMobileApplicationsInner, ok bool) (basetypes.SetValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: mfaPolicyMobileApplicationTFObjectTypes}
+
+	if !ok || apiObject == nil {
+		return types.SetNull(tfObjType), diags
+	}
+
+	list := make([]attr.Value, 0)
+	for _, item := range apiObject {
+		objectMap := map[string]attr.Value{
+			"id":                           framework.StringOkToTF(item.GetIdOk()),
+			"push_enabled":                 types.BoolNull(),
+			"push_timeout_duration":        types.Int64Null(),
+			"push_timeout_timeunit":        types.StringNull(),
+			"otp_enabled":                  types.BoolNull(),
+			"device_authorization_enabled": types.BoolNull(),
+			"device_authorization_extra_verification": types.StringNull(),
+			"auto_enrollment_enabled":                 types.BoolNull(),
+			"integrity_detection":                     framework.EnumOkToTF(item.GetIntegrityDetectionOk()),
+			"pairing_key_lifetime_duration":           types.Int64Null(),
+			"pairing_key_lifetime_timeunit":           types.StringNull(),
+			"push_limit":                              types.ListNull(types.ObjectType{AttrTypes: mfaPolicyMobileApplicationPushLimitTFObjectTypes}),
+		}
+
+		if v, ok := item.GetPushOk(); ok {
+			objectMap["push_enabled"] = framework.BoolOkToTF(v.GetEnabledOk())
+		}
+
+		if v, ok := item.GetPushTimeoutOk(); ok {
+			objectMap["push_timeout_duration"] = framework.Int32OkToTF(v.GetDurationOk())
+			objectMap["push_timeout_timeunit"] = framework.EnumOkToTF(v.GetTimeUnitOk())
+		}
+
+		if v, ok := item.GetOtpOk(); ok {
+			objectMap["otp_enabled"] = framework.BoolOkToTF(v.GetEnabledOk())
+		}
+
+		if v, ok := item.GetDeviceAuthorizationOk(); ok {
+			objectMap["device_authorization_enabled"] = framework.BoolOkToTF(v.GetEnabledOk())
+			objectMap["device_authorization_extra_verification"] = framework.EnumOkToTF(v.GetExtraVerificationOk())
+		}
+
+		if v, ok := item.GetAutoEnrollmentOk(); ok {
+			objectMap["auto_enrollment_enabled"] = framework.BoolOkToTF(v.GetEnabledOk())
+		}
+
+		if v, ok := item.GetPairingKeyLifetimeOk(); ok {
+			objectMap["pairing_key_lifetime_duration"] = framework.Int32OkToTF(v.GetDurationOk())
+			objectMap["pairing_key_lifetime_timeunit"] = framework.EnumOkToTF(v.GetTimeUnitOk())
+		}
+
+		pushLimitObj, d := mobileApplicationsPushLimitsOkToTF(item.GetPushLimitOk())
+		diags.Append(d...)
+		objectMap["push_limit"] = pushLimitObj
+
+		flattenedObj, d := types.ObjectValue(mfaPolicyMobileApplicationTFObjectTypes, objectMap)
+		diags.Append(d...)
+
+		list = append(list, flattenedObj)
+	}
+
+	return types.SetValueMust(tfObjType, list), diags
+}
+
+func mobileApplicationsPushLimitsOkToTF(apiObject *mfa.DeviceAuthenticationPolicyMobileApplicationsInnerPushLimit, ok bool) (basetypes.ListValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: mfaPolicyMobileApplicationPushLimitTFObjectTypes}
+
+	if !ok || apiObject == nil {
+		return types.ListNull(tfObjType), diags
+	}
+
+	objectMap := map[string]attr.Value{
+		"count":                  framework.Int32OkToTF(apiObject.GetCountOk()),
+		"lock_duration_duration": types.Int64Null(),
+		"lock_duration_timeunit": types.StringNull(),
+		"time_period_duration":   types.Int64Null(),
+		"time_period_timeunit":   types.StringNull(),
+	}
+
+	if v, ok := apiObject.GetLockDurationOk(); ok {
+		objectMap["lock_duration_duration"] = framework.Int32OkToTF(v.GetDurationOk())
+		objectMap["lock_duration_timeunit"] = framework.EnumOkToTF(v.GetTimeUnitOk())
+	}
+
+	if v, ok := apiObject.GetTimePeriodOk(); ok {
+		objectMap["time_period_duration"] = framework.Int32OkToTF(v.GetDurationOk())
+		objectMap["time_period_timeunit"] = framework.EnumOkToTF(v.GetTimeUnitOk())
+	}
+
+	flattenedObj, d := types.ObjectValue(mfaPolicyMobileApplicationPushLimitTFObjectTypes, objectMap)
+	diags.Append(d...)
+
+	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	diags.Append(d...)
+
+	return returnVar, diags
+
+}
+
+func totpDeviceOkToTF(apiObject *mfa.DeviceAuthenticationPolicyTotp, ok bool) (basetypes.ListValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: mfaPolicyTotpTFObjectTypes}
+
+	if !ok || apiObject == nil {
+		return types.ListNull(tfObjType), diags
+	}
+
+	objectMap := map[string]attr.Value{
+		"enabled":                       framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"otp_failure_count":             types.Int64Null(),
+		"otp_failure_cooldown_duration": types.Int64Null(),
+		"otp_failure_cooldown_timeunit": types.StringNull(),
+	}
+
+	if v, ok := apiObject.GetOtpOk(); ok {
+		if v1, ok := v.GetFailureOk(); ok {
+			objectMap["otp_failure_count"] = framework.Int32OkToTF(v1.GetCountOk())
+
+			if v2, ok := v1.GetCoolDownOk(); ok {
+				objectMap["otp_failure_cooldown_duration"] = framework.Int32OkToTF(v2.GetDurationOk())
+				objectMap["otp_failure_cooldown_timeunit"] = framework.EnumOkToTF(v2.GetTimeUnitOk())
+			}
+		}
+	}
+
+	flattenedObj, d := types.ObjectValue(mfaPolicyTotpTFObjectTypes, objectMap)
+	diags.Append(d...)
+
+	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func fidoDeviceOkToTF(apiObject *mfa.DeviceAuthenticationPolicyFIDODevice, ok bool) (basetypes.ListValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: mfaPolicyFidoDeviceTFObjectTypes}
+
+	if !ok || apiObject == nil {
+		return types.ListNull(tfObjType), diags
+	}
+
+	objectMap := map[string]attr.Value{
+		"enabled":        framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"fido_policy_id": framework.StringOkToTF(apiObject.GetFidoPolicyIdOk()),
+	}
+
+	flattenedObj, d := types.ObjectValue(mfaPolicyFidoDeviceTFObjectTypes, objectMap)
+	diags.Append(d...)
+
+	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func checkApplicationForMobileApp(ctx context.Context, apiClient *management.APIClient, environmentID, appID string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	resp, d := framework.ParseResponse(
 		ctx,
 
 		func() (interface{}, *http.Response, error) {
 			return apiClient.ApplicationsApi.ReadOneApplication(ctx, environmentID, appID).Execute()
 		},
 		"ReadOneApplication",
-		sdk.CustomErrorResourceNotFoundWarning,
+		framework.CustomErrorResourceNotFoundWarning,
 		sdk.DefaultCreateReadRetryable,
 	)
+	diags.Append(d...)
 	if diags.HasError() {
-		return nil, diags
+		return diags
 	}
 
 	if resp == nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Appliation referenced in `mobile.application.id` does not exist",
-		})
-		return nil, diags
+		diags.AddError(
+			"Application referenced in `mobile.application.id` does not exist",
+			"To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with Apple, Google or Huawei app settings configured.",
+		)
+		return diags
 	}
 
 	respObject := resp.(*management.ReadOneApplication200Response)
 
-	var oidcObject *management.ApplicationOIDC
-
 	// check if oidc
 	if respObject.ApplicationOIDC == nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Appliation referenced in `mobile.application.id` is not of type OIDC",
-			Detail:   "To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with a package or bundle set.",
-		})
-		return nil, diags
-	} else {
-		oidcObject = respObject.ApplicationOIDC
+		diags.AddError(
+			"Application referenced in `mobile.application.id` is not of type OIDC",
+			"To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with Apple, Google or Huawei app settings configured.",
+		)
+		return diags
 	}
 
 	// check if native
 	if respObject.ApplicationOIDC.GetType() != management.ENUMAPPLICATIONTYPE_NATIVE_APP && respObject.ApplicationOIDC.GetType() != management.ENUMAPPLICATIONTYPE_CUSTOM_APP {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Appliation referenced in `mobile.application.id` is OIDC, but is not the required `Native` OIDC application type",
-			Detail:   "To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with a package or bundle set.",
-		})
-		return nil, diags
+		diags.AddError(
+			"Application referenced in `mobile.application.id` is OIDC, but is not the required `Native` OIDC application type",
+			"To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with Apple, Google or Huawei app settings configured.",
+		)
+		return diags
 	}
 
 	// check if mobile set and package/bundle set
 	if _, ok := respObject.ApplicationOIDC.GetMobileOk(); !ok {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Appliation referenced in `mobile.application.id` does not contain mobile application configuration",
-			Detail:   "To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with a package or bundle set.",
-		})
-		return nil, diags
+		diags.AddError(
+			"Application referenced in `mobile.application.id` does not contain mobile application configuration",
+			"To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with Apple, Google or Huawei app settings configured.",
+		)
+		return diags
 	}
 
 	if v, ok := respObject.ApplicationOIDC.GetMobileOk(); ok {
 
 		_, bundleIDOk := v.GetBundleIdOk()
 		_, packageNameOk := v.GetPackageNameOk()
+		_, huaweiAppIdOk := v.GetHuaweiAppIdOk()
 
-		if !bundleIDOk && !packageNameOk {
+		if !bundleIDOk && !packageNameOk && !huaweiAppIdOk {
 
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Appliation referenced in `mobile.application.id` does not contain mobile application configuration",
-				Detail:   "To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with a package or bundle set.",
-			})
-			return nil, diags
+			diags.AddError(
+				"Application referenced in `mobile.application.id` does not contain mobile application configuration",
+				"To configure a mobile application in PingOne, the application must be an OIDC application of type `Native`, with Apple, Google or Huawei app settings configured.",
+			)
+			return diags
 		}
 	}
 
-	return oidcObject, diags
-}
-
-func expandMFAPolicyTOTPDevice(v interface{}) *mfa.DeviceAuthenticationPolicyTotp {
-
-	obj := v.(map[string]interface{})
-
-	item := mfa.NewDeviceAuthenticationPolicyTotp(
-		obj["enabled"].(bool),
-		*mfa.NewDeviceAuthenticationPolicyTotpOtp(
-			*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(
-				int32(obj["otp_failure_count"].(int)),
-				*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(int32(obj["otp_failure_cooldown_duration"].(int)), mfa.EnumTimeUnit(obj["otp_failure_cooldown_timeunit"].(string))),
-			),
-		),
-	)
-
-	return item
-}
-
-func expandMFAPolicyFIDODevice(v interface{}) *mfa.DeviceAuthenticationPolicyFIDODevice {
-
-	obj := v.(map[string]interface{})
-
-	item := mfa.NewDeviceAuthenticationPolicyFIDODevice(obj["enabled"].(bool))
-
-	if v, ok := obj["fido_policy_id"].(string); ok {
-		item.SetFidoPolicyId(v)
-	}
-
-	return item
-}
-
-func flattenMFAPolicyOfflineDevice(c *mfa.DeviceAuthenticationPolicyOfflineDevice) []map[string]interface{} {
-	item := map[string]interface{}{
-		"enabled": c.GetEnabled(),
-	}
-
-	if v, ok := c.GetOtpOk(); ok {
-
-		if v1, ok := v.GetLifeTimeOk(); ok {
-
-			if v2, ok := v1.GetDurationOk(); ok {
-				item["otp_lifetime_duration"] = int(*v2)
-			}
-
-			if v2, ok := v1.GetTimeUnitOk(); ok {
-				item["otp_lifetime_timeunit"] = string(*v2)
-			}
-
-		}
-
-		if v1, ok := v.GetFailureOk(); ok {
-
-			if v2, ok := v1.GetCountOk(); ok {
-				item["otp_failure_count"] = int(*v2)
-			}
-
-			if v2, ok := v1.GetCoolDownOk(); ok {
-
-				if v3, ok := v2.GetDurationOk(); ok {
-					item["otp_failure_cooldown_duration"] = int(*v3)
-				}
-
-				if v3, ok := v2.GetTimeUnitOk(); ok {
-					item["otp_failure_cooldown_timeunit"] = string(*v3)
-				}
-			}
-		}
-
-	}
-
-	return append(make([]map[string]interface{}, 0), item)
-}
-
-func flattenMFAPolicyMobile(c *mfa.DeviceAuthenticationPolicyMobile) []map[string]interface{} {
-
-	item := map[string]interface{}{
-		"enabled": c.GetEnabled(),
-	}
-
-	if v, ok := c.GetOtpOk(); ok {
-
-		if v1, ok := v.GetFailureOk(); ok {
-
-			if v2, ok := v1.GetCountOk(); ok {
-				item["otp_failure_count"] = int(*v2)
-			}
-
-			if v2, ok := v1.GetCoolDownOk(); ok {
-
-				if v3, ok := v2.GetDurationOk(); ok {
-					item["otp_failure_cooldown_duration"] = int(*v3)
-				}
-
-				if v3, ok := v2.GetTimeUnitOk(); ok {
-					item["otp_failure_cooldown_timeunit"] = string(*v3)
-				}
-			}
-		}
-	}
-
-	if v, ok := c.GetApplicationsOk(); ok {
-		item["application"] = expandMFAPolicyMobileApplication(v)
-	}
-
-	return append(make([]map[string]interface{}, 0), item)
-}
-
-func expandMFAPolicyMobileApplication(c []mfa.DeviceAuthenticationPolicyMobileApplicationsInner) []map[string]interface{} {
-
-	items := make([]map[string]interface{}, 0)
-
-	for _, v := range c {
-
-		item := map[string]interface{}{
-			"id":           v.GetId(),
-			"push_enabled": v.GetPush().Enabled,
-			"otp_enabled":  v.GetOtp().Enabled,
-		}
-
-		if v1, ok := v.GetDeviceAuthorizationOk(); ok {
-
-			if v2, ok := v1.GetEnabledOk(); ok {
-				item["device_authorization_enabled"] = v2
-			}
-
-			if v2, ok := v1.GetExtraVerificationOk(); ok {
-				item["device_authorization_extra_verification"] = v2
-			}
-		}
-
-		if v1, ok := v.GetPushTimeoutOk(); ok {
-
-			if v2, ok := v1.GetDurationOk(); ok {
-				item["push_timeout_duration"] = v2
-			}
-
-			if v2, ok := v1.GetTimeUnitOk(); ok {
-				item["push_timeout_timeunit"] = v2
-			}
-		}
-
-		if v1, ok := v.GetAutoEnrollmentOk(); ok {
-			item["auto_enrollment_enabled"] = v1.GetEnabled()
-		}
-
-		if v1, ok := v.GetIntegrityDetectionOk(); ok {
-			item["integrity_detection"] = string(*v1)
-		}
-
-		items = append(items, item)
-
-	}
-
-	return items
-
-}
-
-func flattenMFAPolicyTotp(c *mfa.DeviceAuthenticationPolicyTotp) []map[string]interface{} {
-
-	item := map[string]interface{}{
-		"enabled": c.GetEnabled(),
-	}
-
-	if v, ok := c.GetOtpOk(); ok {
-
-		if v1, ok := v.GetFailureOk(); ok {
-
-			if v2, ok := v1.GetCountOk(); ok {
-				item["otp_failure_count"] = int(*v2)
-			}
-
-			if v2, ok := v1.GetCoolDownOk(); ok {
-
-				if v3, ok := v2.GetDurationOk(); ok {
-					item["otp_failure_cooldown_duration"] = int(*v3)
-				}
-
-				if v3, ok := v2.GetTimeUnitOk(); ok {
-					item["otp_failure_cooldown_timeunit"] = string(*v3)
-				}
-			}
-		}
-
-	}
-
-	return append(make([]map[string]interface{}, 0), item)
-}
-
-func flattenMFAPolicyFIDODevice(c *mfa.DeviceAuthenticationPolicyFIDODevice) []map[string]interface{} {
-
-	item := map[string]interface{}{
-		"enabled": c.GetEnabled(),
-	}
-
-	if v, ok := c.GetFidoPolicyIdOk(); ok {
-		item["fido_policy_id"] = v
-	}
-
-	return append(make([]map[string]interface{}, 0), item)
+	return diags
 }

--- a/internal/service/mfa/resource_mfa_policy_test.go
+++ b/internal/service/mfa/resource_mfa_policy_test.go
@@ -630,24 +630,20 @@ func TestAccMFAPolicy_Mobile_BadApplicationErrors(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMFAPolicyConfig_MobileBadApplicationError_1(resourceName, name),
-				// Appliation referenced in `mobile.application.id` does not exist
-				ExpectError: regexp.MustCompile("Appliation referenced in `mobile.application.id` does not exist"),
+				Config:      testAccMFAPolicyConfig_MobileBadApplicationError_1(resourceName, name),
+				ExpectError: regexp.MustCompile("Application referenced in `mobile.application.id` does not exist"),
 			},
 			{
-				Config: testAccMFAPolicyConfig_MobileBadApplicationError_2(resourceName, name),
-				// Appliation referenced in `mobile.application.id` is not of type OIDC
-				ExpectError: regexp.MustCompile("Appliation referenced in `mobile.application.id` is not of type OIDC"),
+				Config:      testAccMFAPolicyConfig_MobileBadApplicationError_2(resourceName, name),
+				ExpectError: regexp.MustCompile("Application referenced in `mobile.application.id` is not of type OIDC"),
 			},
 			{
-				Config: testAccMFAPolicyConfig_MobileBadApplicationError_3(resourceName, name),
-				// Appliation referenced in `mobile.application.id` is OIDC, but is not the required `Native` OIDC application type
-				ExpectError: regexp.MustCompile("Appliation referenced in `mobile.application.id` is OIDC, but is not the required `Native` OIDC application type"),
+				Config:      testAccMFAPolicyConfig_MobileBadApplicationError_3(resourceName, name),
+				ExpectError: regexp.MustCompile("Application referenced in `mobile.application.id` is OIDC, but is not the required `Native` OIDC application type"),
 			},
 			{
-				Config: testAccMFAPolicyConfig_MobileBadApplicationError_4(resourceName, name),
-				// Appliation referenced in `mobile.application.id` does not contain mobile application configuration
-				ExpectError: regexp.MustCompile("Appliation referenced in `mobile.application.id` does not contain mobile application configuration"),
+				Config:      testAccMFAPolicyConfig_MobileBadApplicationError_4(resourceName, name),
+				ExpectError: regexp.MustCompile("Application referenced in `mobile.application.id` does not contain mobile application configuration"),
 			},
 		},
 	})
@@ -996,7 +992,7 @@ func TestAccMFAPolicy_SecurityKey_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "security_key.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "security_key.0.fido_policy_id", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "security_key.0.fido_policy_id"),
 					resource.TestCheckResourceAttr(resourceFullName, "platform.0.enabled", "false"),
 				),
 			},
@@ -1040,7 +1036,7 @@ func TestAccMFAPolicy_SecurityKey_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "security_key.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "security_key.0.fido_policy_id", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "security_key.0.fido_policy_id"),
 					resource.TestCheckResourceAttr(resourceFullName, "platform.0.enabled", "false"),
 				),
 			},
@@ -1116,7 +1112,7 @@ func TestAccMFAPolicy_Platform_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "totp.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "security_key.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "platform.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "platform.0.fido_policy_id", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "platform.0.fido_policy_id"),
 				),
 			},
 		},
@@ -1160,7 +1156,7 @@ func TestAccMFAPolicy_Platform_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "totp.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "security_key.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "platform.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "platform.0.fido_policy_id", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "platform.0.fido_policy_id"),
 				),
 			},
 			{

--- a/internal/service/mfa/resource_mfa_policy_test.go
+++ b/internal/service/mfa/resource_mfa_policy_test.go
@@ -551,34 +551,53 @@ func TestAccMFAPolicy_Mobile_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.0.application.#", "3"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceFullName, "mobile.0.application.*", map[string]*regexp.Regexp{
 						"id":                           verify.P1ResourceIDRegexp,
-						"push_enabled":                 regexp.MustCompile(`^true$`),
-						"push_timeout_duration":        regexp.MustCompile(`^100$`),
-						"push_timeout_timeunit":        regexp.MustCompile(`^SECONDS$`),
-						"otp_enabled":                  regexp.MustCompile(`^true$`),
+						"auto_enrollment_enabled":      regexp.MustCompile(`^true$`),
 						"device_authorization_enabled": regexp.MustCompile(`^true$`),
 						"device_authorization_extra_verification": regexp.MustCompile(`^restrictive$`),
-						"auto_enrollment_enabled":                 regexp.MustCompile(`^true$`),
-						"integrity_detection":                     regexp.MustCompile(`^$`),
+						"otp_enabled":                       regexp.MustCompile(`^true$`),
+						"pairing_key_lifetime_duration":     regexp.MustCompile(`^15$`),
+						"pairing_key_lifetime_timeunit":     regexp.MustCompile(`^HOURS$`),
+						"push_enabled":                      regexp.MustCompile(`^true$`),
+						"push_limit.count":                  regexp.MustCompile(`^7$`),
+						"push_limit.lock_duration_duration": regexp.MustCompile(`^600$`),
+						"push_limit.lock_duration_timeunit": regexp.MustCompile(`^SECONDS$`),
+						"push_limit.time_period_duration":   regexp.MustCompile(`^5$`),
+						"push_limit.time_period_timeunit":   regexp.MustCompile(`^MINUTES$`),
+						"push_timeout_duration":             regexp.MustCompile(`^100$`),
+						"push_timeout_timeunit":             regexp.MustCompile(`^SECONDS$`),
 					}),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceFullName, "mobile.0.application.*", map[string]*regexp.Regexp{
-						"id":                    verify.P1ResourceIDRegexp,
-						"push_enabled":          regexp.MustCompile(`^false$`),
-						"push_timeout_duration": regexp.MustCompile(`^40$`),
-						"push_timeout_timeunit": regexp.MustCompile(`^SECONDS$`),
-						"otp_enabled":           regexp.MustCompile(`^true$`),
-						"device_authorization_extra_verification": regexp.MustCompile(`^$`),
-						"integrity_detection":                     regexp.MustCompile(`^permissive$`),
+						"id":                                verify.P1ResourceIDRegexp,
+						"device_authorization_enabled":      regexp.MustCompile(`^false$`),
+						"integrity_detection":               regexp.MustCompile(`^permissive$`),
+						"otp_enabled":                       regexp.MustCompile(`^true$`),
+						"pairing_key_lifetime_duration":     regexp.MustCompile(`^10$`),
+						"pairing_key_lifetime_timeunit":     regexp.MustCompile(`^MINUTES$`),
+						"push_enabled":                      regexp.MustCompile(`^false$`),
+						"push_limit.count":                  regexp.MustCompile(`^7$`),
+						"push_limit.lock_duration_duration": regexp.MustCompile(`^20$`),
+						"push_limit.lock_duration_timeunit": regexp.MustCompile(`^MINUTES$`),
+						"push_limit.time_period_duration":   regexp.MustCompile(`^10$`),
+						"push_limit.time_period_timeunit":   regexp.MustCompile(`^MINUTES$`),
+						"push_timeout_duration":             regexp.MustCompile(`^40$`),
+						"push_timeout_timeunit":             regexp.MustCompile(`^SECONDS$`),
 					}),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceFullName, "mobile.0.application.*", map[string]*regexp.Regexp{
-						"id":                           verify.P1ResourceIDRegexp,
-						"push_enabled":                 regexp.MustCompile(`^true$`),
-						"push_timeout_duration":        regexp.MustCompile(`^40$`),
-						"push_timeout_timeunit":        regexp.MustCompile(`^SECONDS$`),
-						"otp_enabled":                  regexp.MustCompile(`^true$`),
-						"device_authorization_enabled": regexp.MustCompile(`^false$`),
-						"device_authorization_extra_verification": regexp.MustCompile(`^$`),
-						"auto_enrollment_enabled":                 regexp.MustCompile(`^true$`),
-						"integrity_detection":                     regexp.MustCompile(`^permissive$`),
+						"id":                                verify.P1ResourceIDRegexp,
+						"auto_enrollment_enabled":           regexp.MustCompile(`^true$`),
+						"device_authorization_enabled":      regexp.MustCompile(`^false$`),
+						"integrity_detection":               regexp.MustCompile(`^permissive$`),
+						"otp_enabled":                       regexp.MustCompile(`^true$`),
+						"pairing_key_lifetime_duration":     regexp.MustCompile(`^10$`),
+						"pairing_key_lifetime_timeunit":     regexp.MustCompile(`^MINUTES$`),
+						"push_enabled":                      regexp.MustCompile(`^true$`),
+						"push_limit.count":                  regexp.MustCompile(`^5$`),
+						"push_limit.lock_duration_duration": regexp.MustCompile(`^30$`),
+						"push_limit.lock_duration_timeunit": regexp.MustCompile(`^MINUTES$`),
+						"push_limit.time_period_duration":   regexp.MustCompile(`^10$`),
+						"push_limit.time_period_timeunit":   regexp.MustCompile(`^MINUTES$`),
+						"push_timeout_duration":             regexp.MustCompile(`^40$`),
+						"push_timeout_timeunit":             regexp.MustCompile(`^SECONDS$`),
 					}),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "security_key.0.enabled", "false"),
@@ -1704,6 +1723,19 @@ resource "pingone_mfa_policy" "%[2]s" {
       device_authorization_extra_verification = "restrictive"
 
       auto_enrollment_enabled = true
+
+	  pairing_key_lifetime_duration = 15
+	  pairing_key_lifetime_timeunit = "HOURS"
+
+	  push_limit = {
+		count = 7
+
+		lock_duration_duration = 600
+		lock_duration_timeunit = "SECONDS"
+
+		time_period_duration = 5
+		time_period_timeunit = "MINUTES"
+	  }
     }
 
     application {
@@ -1713,6 +1745,16 @@ resource "pingone_mfa_policy" "%[2]s" {
       otp_enabled  = true
 
       integrity_detection = "permissive"
+
+
+	  pairing_key_lifetime_duration = 10
+
+	  push_limit = {
+		count = 7
+
+		lock_duration_duration = 20
+		time_period_duration = 10
+	  }
     }
 
     application {

--- a/internal/service/mfa/service.go
+++ b/internal/service/mfa/service.go
@@ -1,14 +1,47 @@
 package mfa
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/patrickcping/pingone-go-sdk-v2/management"
+	"github.com/patrickcping/pingone-go-sdk-v2/mfa"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 )
 
 func Resources() []func() resource.Resource {
-	return []func() resource.Resource{}
+	return []func() resource.Resource{
+		NewMFAPolicyResource,
+	}
 }
 
 func DataSources() []func() datasource.DataSource {
 	return []func() datasource.DataSource{}
+}
+
+func prepareClient(ctx context.Context, resourceConfig framework.ResourceType) (*mfa.APIClient, error) {
+
+	if resourceConfig.Client.API == nil || resourceConfig.Client.API.MFAAPIClient == nil {
+		return nil, fmt.Errorf("Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+	}
+
+	tflog.Info(ctx, "PingOne provider client init successful")
+
+	return resourceConfig.Client.API.MFAAPIClient, nil
+
+}
+
+func prepareMgmtClient(ctx context.Context, resourceConfig framework.ResourceType) (*management.APIClient, error) {
+
+	if resourceConfig.Client.API == nil || resourceConfig.Client.API.ManagementAPIClient == nil {
+		return nil, fmt.Errorf("Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+	}
+
+	tflog.Info(ctx, "PingOne provider client init successful")
+
+	return resourceConfig.Client.API.ManagementAPIClient, nil
+
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* `resource/pingone_mfa_policy`: Support the ability to phase out MFA devices using new `pairing_disabled` parameters for each device type in the policy.
* **BREAKING CHANGE** `resource/pingone_mfa_policy`: The `platform` and `security_key` FIDO device types are deprecated and need to be replaced with the `fido2` device type.  `platform` and `security_key` are no longer configurable for newly created environments, or existing environments that have not had their environment upgraded to use the latest FIDO2 policies.  Existing environments that have not been upgraded to use the latest FIDO2 policies can continue to use the factors to facilitate migration.
* `resource/pingone_mfa_policy`: Add support for the new `fido2` MFA device type to enable support for passkeys.  The `fido2` device type is only configurable for newly created environments, or existing environments that have been upgraded to use the latest FIDO2 policies.
* `resource/pingone_mfa_policy`: Supports the ability to define the pairing key lifetime and push limit for mobile applications.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 240s -run ^TestAccMFAPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell

```