### PR TITLE
Schema corrections for Issue 405 and documentation updates

### DIFF
--- a/.changelog/406.txt
+++ b/.changelog/406.txt
@@ -3,8 +3,17 @@
 ```
 
 ```release-note:bug
-`resource/pingone_digital_wallet_application`: Fixed incorrect replacement of resource if `application_id` value was changed.
-`resource/pingone_credential_issuance_rule`: Fixed incorrect replacement of resource if `digital_wallet_id` value was changed.
+`resource/pingone_digital_wallet_application`: Fixed incorrect replacement of resource when the `application_id` value was changed.
+```
+
+```release-note:bug
+`resource/pingone_credential_issuance_rule`: Fixed incorrect replacement of resource when the `digital_wallet_id` value was changed.
+```
+
+```release-note:bug
 `resource/pingone_credential_issuer_profile`: Fixed mismatched `created_at` and `updated_at` mapping.
+```
+
+```release-note:bug
 `data_source/pingone_credential_issuer_profile`: Fixed mismatched `created_at` and `updated_at` mapping.
 ```

--- a/.changelog/406.txt
+++ b/.changelog/406.txt
@@ -1,0 +1,10 @@
+```release-note:note
+`data_source/pingone_credential_type`: Corrected typo in data source description.
+```
+
+```release-note:bug
+`resource/pingone_digital_wallet_application`: Fixed incorrect replacement of resource if `application_id` value was changed.
+`resource/pingone_credential_issuance_rule`: Fixed incorrect replacement of resource if `digital_wallet_id` value was changed.
+`resource/pingone_credential_issuer_profile`: Fixed mismatched `created_at` and `updated_at` mapping.
+`data_source/pingone_credential_issuer_profile`: Fixed mismatched `created_at` and `updated_at` mapping.
+```

--- a/docs/data-sources/credential_type.md
+++ b/docs/data-sources/credential_type.md
@@ -2,12 +2,12 @@
 page_title: "pingone_credential_type Data Source - terraform-provider-pingone"
 subcategory: "Neo (Verifiable Credentials)"
 description: |-
-  Data to retrieve a PingOne Credentials credential type by its Credential Type Id.
+  Datasource to retrieve a PingOne Credentials credential type by its Credential Type Id.
 ---
 
 # pingone_credential_type (Data Source)
 
-Data to retrieve a PingOne Credentials credential type by its Credential Type Id.
+Datasource to retrieve a PingOne Credentials credential type by its Credential Type Id.
 
 ## Example Usage
 

--- a/docs/resources/credential_issuance_rule.md
+++ b/docs/resources/credential_issuance_rule.md
@@ -75,12 +75,12 @@ resource "pingone_credential_issuance_rule" "my_credential_issuance_rule" {
 
 - `automation` (Attributes) Contains a list of actions, as key names, and the update method for each action. (see [below for nested schema](#nestedatt--automation))
 - `credential_type_id` (String) Identifier (UUID) of the credential type with which this credential issuance rule is associated.
+- `digital_wallet_application_id` (String) Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet.
 - `environment_id` (String) PingOne environment identifier (UUID) in which the credential issuance rule exists.
 - `status` (String) Status of the credential issuance rule. Can be `ACTIVE` or `DISABLED`.
 
 ### Optional
 
-- `digital_wallet_application_id` (String) Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet.
 - `filter` (Attributes) Contains one and only one filter (`group_ids`, `population_ids`, or `scim`) that selects the users to which the credential issuance rule applies. A filter must be defined if the issuance rule `status` is `ACTIVE`. (see [below for nested schema](#nestedatt--filter))
 - `notification` (Attributes) Contains notification information. When this property is supplied, the information within is used to create a custom notification. (see [below for nested schema](#nestedatt--notification))
 

--- a/docs/resources/credential_issuance_rule.md
+++ b/docs/resources/credential_issuance_rule.md
@@ -75,12 +75,12 @@ resource "pingone_credential_issuance_rule" "my_credential_issuance_rule" {
 
 - `automation` (Attributes) Contains a list of actions, as key names, and the update method for each action. (see [below for nested schema](#nestedatt--automation))
 - `credential_type_id` (String) Identifier (UUID) of the credential type with which this credential issuance rule is associated.
-- `digital_wallet_application_id` (String) Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet.
 - `environment_id` (String) PingOne environment identifier (UUID) in which the credential issuance rule exists.
 - `status` (String) Status of the credential issuance rule. Can be `ACTIVE` or `DISABLED`.
 
 ### Optional
 
+- `digital_wallet_application_id` (String) Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet.
 - `filter` (Attributes) Contains one and only one filter (`group_ids`, `population_ids`, or `scim`) that selects the users to which the credential issuance rule applies. A filter must be defined if the issuance rule `status` is `ACTIVE`. (see [below for nested schema](#nestedatt--filter))
 - `notification` (Attributes) Contains notification information. When this property is supplied, the information within is used to create a custom notification. (see [below for nested schema](#nestedatt--notification))
 

--- a/docs/resources/digital_wallet_application.md
+++ b/docs/resources/digital_wallet_application.md
@@ -56,9 +56,12 @@ resource "pingone_digital_wallet_application" "my_digital_wallet_app" {
 ### Required
 
 - `app_open_url` (String) The URL enables deep-linking to the digital wallet application, and is sent in notifications to the user to communicate with the service.
-- `application_id` (String) The identifier (UUID) of the PingOne mobile application associated with the digital wallet application.
 - `environment_id` (String) PingOne environment identifier (UUID) in which the credential digital wallet application is created and managed.
 - `name` (String) The name associated with the digital wallet application.
+
+### Optional
+
+- `application_id` (String) The identifier (UUID) of the PingOne application associated with the digital wallet application.
 
 ### Read-Only
 

--- a/docs/resources/digital_wallet_application.md
+++ b/docs/resources/digital_wallet_application.md
@@ -56,12 +56,9 @@ resource "pingone_digital_wallet_application" "my_digital_wallet_app" {
 ### Required
 
 - `app_open_url` (String) The URL enables deep-linking to the digital wallet application, and is sent in notifications to the user to communicate with the service.
+- `application_id` (String) The identifier (UUID) of the PingOne application associated with the digital wallet application.
 - `environment_id` (String) PingOne environment identifier (UUID) in which the credential digital wallet application is created and managed.
 - `name` (String) The name associated with the digital wallet application.
-
-### Optional
-
-- `application_id` (String) The identifier (UUID) of the PingOne application associated with the digital wallet application.
 
 ### Read-Only
 

--- a/internal/service/credentials/data_source_credential_issuer_profile.go
+++ b/internal/service/credentials/data_source_credential_issuer_profile.go
@@ -26,8 +26,8 @@ type CredentialIssuerProfileDataSourceModel struct {
 	Id                    types.String `tfsdk:"id"`
 	EnvironmentId         types.String `tfsdk:"environment_id"`
 	ApplicationInstanceId types.String `tfsdk:"application_instance_id"`
-	CreatedAt             types.String `tfsdk:"updated_at"`
-	UpdatedAt             types.String `tfsdk:"created_at"`
+	CreatedAt             types.String `tfsdk:"created_at"`
+	UpdatedAt             types.String `tfsdk:"updated_at"`
 	Name                  types.String `tfsdk:"name"`
 }
 

--- a/internal/service/credentials/data_source_credential_type.go
+++ b/internal/service/credentials/data_source_credential_type.go
@@ -99,7 +99,7 @@ func (r *CredentialTypeDataSource) Schema(ctx context.Context, req datasource.Sc
 
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		Description: "Data to retrieve a PingOne Credentials credential type by its Credential Type Id.",
+		Description: "Datasource to retrieve a PingOne Credentials credential type by its Credential Type Id.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": framework.Attr_ID(),

--- a/internal/service/credentials/resource_credential_issuance_rule.go
+++ b/internal/service/credentials/resource_credential_issuance_rule.go
@@ -155,9 +155,13 @@ func (r *CredentialIssuanceRuleResource) Schema(ctx context.Context, req resourc
 				framework.SchemaAttributeDescriptionFromMarkdown("Identifier (UUID) of the credential type with which this credential issuance rule is associated."),
 			),
 
-			"digital_wallet_application_id": framework.Attr_LinkID(
-				framework.SchemaAttributeDescriptionFromMarkdown("Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet."),
-			),
+			"digital_wallet_application_id": schema.StringAttribute{
+				Description: "Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet.",
+				Optional:    true,
+				Validators: []validator.String{
+					verify.P1ResourceIDValidator(),
+				},
+			},
 
 			"status": schema.StringAttribute{
 				Description:         statusDescription.Description,

--- a/internal/service/credentials/resource_credential_issuance_rule.go
+++ b/internal/service/credentials/resource_credential_issuance_rule.go
@@ -157,7 +157,7 @@ func (r *CredentialIssuanceRuleResource) Schema(ctx context.Context, req resourc
 
 			"digital_wallet_application_id": schema.StringAttribute{
 				Description: "Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet.",
-				Optional:    true,
+				Required:    true,
 				Validators: []validator.String{
 					verify.P1ResourceIDValidator(),
 				},

--- a/internal/service/credentials/resource_credential_issuance_rule_test.go
+++ b/internal/service/credentials/resource_credential_issuance_rule_test.go
@@ -188,11 +188,6 @@ func TestAccCredentialIssuanceRule_InvalidConfigs(t *testing.T) {
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialIssuanceRule_InvalidDigitalWalletID(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Missing required argument"),
-				Destroy:     true,
-			},
-			{
 				Config:      testAccCredentialIssuanceRule_InvalidGroupIdFilterAttribute(resourceName, name),
 				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
 				Destroy:     true,
@@ -500,53 +495,6 @@ resource "pingone_credential_issuance_rule" "%[2]s" {
   environment_id                = data.pingone_environment.general_test.id
   digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
   status                        = "DISABLED"
-
-  filter = {
-    scim = "address.countryCode eq \"CA\""
-  }
-
-  automation = {
-    issue  = "PERIODIC"
-    revoke = "PERIODIC"
-    update = "PERIODIC"
-  }
-
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidDigitalWalletID(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id     = data.pingone_environment.general_test.id
-  credential_type_id = resource.pingone_credential_type.%[2]s.id
-  status             = "DISABLED"
 
   filter = {
     scim = "address.countryCode eq \"CA\""

--- a/internal/service/credentials/resource_credential_issuance_rule_test.go
+++ b/internal/service/credentials/resource_credential_issuance_rule_test.go
@@ -188,6 +188,11 @@ func TestAccCredentialIssuanceRule_InvalidConfigs(t *testing.T) {
 				Destroy:     true,
 			},
 			{
+				Config:      testAccCredentialIssuanceRule_InvalidDigitalWalletID(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Missing required argument"),
+				Destroy:     true,
+			},
+			{
 				Config:      testAccCredentialIssuanceRule_InvalidGroupIdFilterAttribute(resourceName, name),
 				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
 				Destroy:     true,
@@ -506,6 +511,46 @@ resource "pingone_credential_issuance_rule" "%[2]s" {
     update = "PERIODIC"
   }
 
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidDigitalWalletID(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id     = data.pingone_environment.general_test.id
+  credential_type_id = resource.pingone_credential_type.%[2]s.id
+  status             = "DISABLED"
+  filter = {
+    scim = "address.countryCode eq \"CA\""
+  }
+  automation = {
+    issue  = "PERIODIC"
+    revoke = "PERIODIC"
+    update = "PERIODIC"
+  }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 

--- a/internal/service/credentials/resource_credential_issuer_profile.go
+++ b/internal/service/credentials/resource_credential_issuer_profile.go
@@ -32,8 +32,8 @@ type CredentialIssuerProfileResourceModel struct {
 	Id                    types.String `tfsdk:"id"`
 	EnvironmentId         types.String `tfsdk:"environment_id"`
 	ApplicationInstanceId types.String `tfsdk:"application_instance_id"`
-	CreatedAt             types.String `tfsdk:"updated_at"`
-	UpdatedAt             types.String `tfsdk:"created_at"`
+	CreatedAt             types.String `tfsdk:"created_at"`
+	UpdatedAt             types.String `tfsdk:"updated_at"`
 	Name                  types.String `tfsdk:"name"`
 }
 

--- a/internal/service/credentials/resource_digital_wallet_application.go
+++ b/internal/service/credentials/resource_digital_wallet_application.go
@@ -74,7 +74,7 @@ func (r *DigitalWalletApplicationResource) Schema(ctx context.Context, req resou
 
 			"application_id": schema.StringAttribute{
 				Description: "The identifier (UUID) of the PingOne application associated with the digital wallet application.",
-				Optional:    true,
+				Required:    true,
 				Validators: []validator.String{
 					verify.P1ResourceIDValidator(),
 				},

--- a/internal/service/credentials/resource_digital_wallet_application.go
+++ b/internal/service/credentials/resource_digital_wallet_application.go
@@ -19,6 +19,7 @@ import (
 	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
+	"github.com/pingidentity/terraform-provider-pingone/internal/verify"
 )
 
 // Types
@@ -71,9 +72,13 @@ func (r *DigitalWalletApplicationResource) Schema(ctx context.Context, req resou
 				framework.SchemaAttributeDescriptionFromMarkdown("PingOne environment identifier (UUID) in which the credential digital wallet application is created and managed."),
 			),
 
-			"application_id": framework.Attr_LinkID(
-				framework.SchemaAttributeDescriptionFromMarkdown("The identifier (UUID) of the PingOne mobile application associated with the digital wallet application."),
-			),
+			"application_id": schema.StringAttribute{
+				Description: "The identifier (UUID) of the PingOne application associated with the digital wallet application.",
+				Optional:    true,
+				Validators: []validator.String{
+					verify.P1ResourceIDValidator(),
+				},
+			},
 
 			"app_open_url": schema.StringAttribute{
 				Description: "The URL enables deep-linking to the digital wallet application, and is sent in notifications to the user to communicate with the service.",


### PR DESCRIPTION
### Change Description
```release-note:note
`data_source/pingone_credential_type`: Corrected typo in data source description.
```

```release-note:bug
`resource/pingone_digital_wallet_application`: Fixed incorrect replacement of resource if `application_id` value was changed.
`resource/pingone_credential_issuance_rule`: Fixed incorrect replacement of resource if `digital_wallet_id` value was changed.
`resource/pingone_credential_issuer_profile`: Fixed mismatched `created_at` and `updated_at` mapping.
`data_source/pingone_credential_issuer_profile`: Fixed mismatched `created_at` and `updated_at` mapping.
```

### Testing Results
`credential_issuance_rule` is no longer replaced if the `digital_wallet_application_id` is changed:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # pingone_credential_issuance_rule.credential1_issuance_rule will be updated in-place
  ~ resource "pingone_credential_issuance_rule" "credential1_issuance_rule" {
      ~ digital_wallet_application_id = "5049b26c-1515-4858-a6f1-daf9571e0414" -> "a3e60fa2-8d25-483b-aaa9-ad7c513d8bfb"
        id                            = "bf4e0941-1bed-474d-b296-68cb9bd666ad"
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

`digital_wallet_application` is no longer replaced if the `application_id` is changed:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # pingone_digital_wallet_application.my_digital_wallet_app will be updated in-place
  ~ resource "pingone_digital_wallet_application" "my_digital_wallet_app" {
      ~ application_id = "c6c6fbe9-ac11-4123-a524-772edf3f6e43" -> "b0850d8a-1dcd-4288-9186-77e4139e2b2c"
        id             = "a3e60fa2-8d25-483b-aaa9-ad7c513d8bfb"
        name           = "PingOne Credentials Sample Digital Wallet App"
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
```shell
TF_LOG=INFO TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

#### Testing Results
```shell
=== RUN   TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== PAUSE TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== RUN   TestAccCredentialIssuanceRuleDataSource_NotFound
=== PAUSE TestAccCredentialIssuanceRuleDataSource_NotFound
=== RUN   TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== PAUSE TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== RUN   TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
=== PAUSE TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
=== RUN   TestAccCredentialIssuerProfileDataSource_NotFound
=== PAUSE TestAccCredentialIssuerProfileDataSource_NotFound
=== RUN   TestAccCredentialTypeDataSource_ByIDFull
=== PAUSE TestAccCredentialTypeDataSource_ByIDFull
=== RUN   TestAccCredentialTypeDataSource_NotFound
=== PAUSE TestAccCredentialTypeDataSource_NotFound
=== RUN   TestAccCredentialTypeDataSource_InvalidConfig
=== PAUSE TestAccCredentialTypeDataSource_InvalidConfig
=== RUN   TestAccCredentialTypesDataSource_NoFilter
=== PAUSE TestAccCredentialTypesDataSource_NoFilter
=== RUN   TestAccCredentialTypesDataSource_NotFound
=== PAUSE TestAccCredentialTypesDataSource_NotFound
=== RUN   TestAccDigitalWalletApplicationDataSource_ByIDFull
=== PAUSE TestAccDigitalWalletApplicationDataSource_ByIDFull
=== RUN   TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull
=== PAUSE TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull
=== RUN   TestAccDigitalWalletApplicationDataSource_ByNameFull
=== PAUSE TestAccDigitalWalletApplicationDataSource_ByNameFull
=== RUN   TestAccDigitalWalletApplicationDataSource_NotFound
=== PAUSE TestAccDigitalWalletApplicationDataSource_NotFound
=== RUN   TestAccDigitalWalletApplicationsDataSource_NoFilter
=== PAUSE TestAccDigitalWalletApplicationsDataSource_NoFilter
=== RUN   TestAccDigitalWalletApplicationsDataSource_NotFound
=== PAUSE TestAccDigitalWalletApplicationsDataSource_NotFound
=== RUN   TestAccCredentialIssuanceRule_Full
=== PAUSE TestAccCredentialIssuanceRule_Full
=== RUN   TestAccCredentialIssuanceRule_InvalidConfigs
=== PAUSE TestAccCredentialIssuanceRule_InvalidConfigs
=== RUN   TestAccCredentialIssuerProfile_Full
=== PAUSE TestAccCredentialIssuerProfile_Full
=== RUN   TestAccCredentialIssuerProfile_InvalidConfig
=== PAUSE TestAccCredentialIssuerProfile_InvalidConfig
=== RUN   TestAccCredentialType_NewEnv
=== PAUSE TestAccCredentialType_NewEnv
=== RUN   TestAccCredentialType_Full
=== PAUSE TestAccCredentialType_Full
=== RUN   TestAccCredentialType_MetaData
=== PAUSE TestAccCredentialType_MetaData
=== RUN   TestAccCredentialType_CardDesignTemplate
=== PAUSE TestAccCredentialType_CardDesignTemplate
=== RUN   TestAccDigitalWalletApplication_NewEnv
=== PAUSE TestAccDigitalWalletApplication_NewEnv
=== RUN   TestAccDigitalWalletApplication_Full
=== PAUSE TestAccDigitalWalletApplication_Full
=== RUN   TestAccDigitalWalletApplication_InvalidNativeApplication
=== PAUSE TestAccDigitalWalletApplication_InvalidNativeApplication
=== RUN   TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== PAUSE TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== CONT  TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== CONT  TestAccDigitalWalletApplicationsDataSource_NoFilter
=== CONT  TestAccCredentialType_Full
=== CONT  TestAccCredentialIssuerProfile_Full
=== CONT  TestAccCredentialIssuanceRule_Full
=== CONT  TestAccCredentialTypeDataSource_InvalidConfig
=== CONT  TestAccDigitalWalletApplicationDataSource_NotFound
=== CONT  TestAccDigitalWalletApplicationDataSource_ByNameFull
=== CONT  TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull
=== CONT  TestAccDigitalWalletApplicationDataSource_ByIDFull
--- PASS: TestAccCredentialTypeDataSource_InvalidConfig (0.37s)
=== CONT  TestAccCredentialTypesDataSource_NotFound
--- PASS: TestAccDigitalWalletApplicationDataSource_NotFound (2.95s)
=== CONT  TestAccCredentialTypesDataSource_NoFilter
--- PASS: TestAccCredentialTypesDataSource_NotFound (6.78s)
=== CONT  TestAccCredentialType_NewEnv
--- PASS: TestAccDigitalWalletApplicationDataSource_ByNameFull (7.19s)
=== CONT  TestAccCredentialIssuanceRule_InvalidConfigs
--- PASS: TestAccDigitalWalletApplicationDataSource_ByApplicationIDFull (7.25s)
=== CONT  TestAccCredentialIssuerProfile_InvalidConfig
--- PASS: TestAccCredentialIssuerProfile_InvalidConfig (0.23s)
=== CONT  TestAccCredentialIssuerProfileDataSource_NotFound
--- PASS: TestAccCredentialIssuanceRule_InvalidConfigs (0.88s)
=== CONT  TestAccCredentialTypeDataSource_NotFound
--- PASS: TestAccCredentialIssuanceRuleDataSource_ByIDFull (8.16s)
=== CONT  TestAccCredentialTypeDataSource_ByIDFull
--- PASS: TestAccDigitalWalletApplicationDataSource_ByIDFull (8.27s)
=== CONT  TestAccDigitalWalletApplication_Full
--- PASS: TestAccCredentialTypeDataSource_NotFound (0.95s)
=== CONT  TestAccDigitalWalletApplication_InvalidAppOpenUrl
--- PASS: TestAccDigitalWalletApplication_InvalidAppOpenUrl (3.05s)
=== CONT  TestAccDigitalWalletApplication_InvalidNativeApplication
--- PASS: TestAccCredentialIssuerProfileDataSource_NotFound (4.94s)
=== CONT  TestAccCredentialIssuanceRuleDataSource_InvalidConfig
--- PASS: TestAccCredentialIssuanceRuleDataSource_InvalidConfig (0.29s)
=== CONT  TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
--- PASS: TestAccCredentialTypesDataSource_NoFilter (10.37s)
=== CONT  TestAccCredentialType_CardDesignTemplate
--- PASS: TestAccCredentialType_CardDesignTemplate (0.78s)
=== CONT  TestAccDigitalWalletApplication_NewEnv
--- PASS: TestAccCredentialType_NewEnv (7.85s)
=== CONT  TestAccCredentialIssuanceRuleDataSource_NotFound
--- PASS: TestAccCredentialTypeDataSource_ByIDFull (8.14s)
=== CONT  TestAccDigitalWalletApplicationsDataSource_NotFound
--- PASS: TestAccCredentialIssuanceRuleDataSource_NotFound (3.04s)
=== CONT  TestAccCredentialType_MetaData
--- PASS: TestAccCredentialType_MetaData (1.23s)
--- PASS: TestAccDigitalWalletApplication_InvalidNativeApplication (11.05s)
--- PASS: TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull (10.94s)
--- PASS: TestAccDigitalWalletApplicationsDataSource_NotFound (8.76s)
--- PASS: TestAccDigitalWalletApplicationsDataSource_NoFilter (25.81s)
--- PASS: TestAccDigitalWalletApplication_NewEnv (11.96s)
--- PASS: TestAccCredentialType_Full (36.51s)
--- PASS: TestAccCredentialIssuerProfile_Full (38.76s)
--- PASS: TestAccDigitalWalletApplication_Full (32.73s)
--- PASS: TestAccCredentialIssuanceRule_Full (51.74s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 52.060s
```