### PR TITLE
Support user provisioning gateway configuration on the "Login" sign-on policy action

### DIFF
--- a/docs/resources/sign_on_policy_action.md
+++ b/docs/resources/sign_on_policy_action.md
@@ -289,7 +289,29 @@ Optional:
 
 Optional:
 
+- `new_user_provisioning` (Block List, Max: 1) Enables user entries existing outside of PingOne to be provisioned during login, using an external integration solution (such as a Gateway). (see [below for nested schema](#nestedblock--login--new_user_provisioning))
 - `recovery_enabled` (Boolean) A boolean that specifies whether account recovery features are active on the policy action. Defaults to `true`.
+
+<a id="nestedblock--login--new_user_provisioning"></a>
+### Nested Schema for `login.new_user_provisioning`
+
+Required:
+
+- `gateway` (Block Set, Min: 1) One or more blocks that describe a preconfigured gateway and user type that are specified in the Gateway Management schema to determine how to find and migrate user entries existing in an external directory. (see [below for nested schema](#nestedblock--login--new_user_provisioning--gateway))
+
+<a id="nestedblock--login--new_user_provisioning--gateway"></a>
+### Nested Schema for `login.new_user_provisioning.gateway`
+
+Required:
+
+- `id` (String) A string that specifies the UUID ID of the gateway instance.  The ID may come from the `id` parameter of the `pingone_gateway` resource.  Must be a valid PingOne resource ID.
+- `user_type_id` (String) A string that specifies the UUID ID of the user type within the gateway instance.  The ID may come from the `user_type[*].id` parameter of the `pingone_gateway` resource.  Must be a valid PingOne resource ID.
+
+Optional:
+
+- `type` (String) A string that specifies the type of the gateway. Currently, only `LDAP` is supported. Defaults to `LDAP`.
+
+
 
 
 <a id="nestedblock--mfa"></a>

--- a/internal/service/sso/resource_sign_on_policy_action_test.go
+++ b/internal/service/sso/resource_sign_on_policy_action_test.go
@@ -153,6 +153,56 @@ func TestAccSignOnPolicyAction_LoginAction(t *testing.T) {
 	})
 }
 
+func TestAccSignOnPolicyAction_LoginAction_Gateway(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_sign_on_policy_action.%s", resourceName)
+
+	name := resourceName
+
+	withGateway := resource.TestStep{
+		Config: testAccSignOnPolicyActionConfig_LoginFullWithNewUserProvisioning(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "new_user_provisioning.#", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.#", "3"),
+			resource.TestMatchResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.0.id", verify.P1ResourceIDRegexp),
+			resource.TestCheckResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.0.type", "LDAP"),
+			resource.TestMatchResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.0.user_type_id", verify.P1ResourceIDRegexp),
+			resource.TestMatchResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.1.id", verify.P1ResourceIDRegexp),
+			resource.TestCheckResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.1.type", "LDAP"),
+			resource.TestMatchResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.1.user_type_id", verify.P1ResourceIDRegexp),
+			resource.TestMatchResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.2.id", verify.P1ResourceIDRegexp),
+			resource.TestCheckResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.2.type", "LDAP"),
+			resource.TestMatchResourceAttr(resourceFullName, "new_user_provisioning.0.gateway.2.user_type_id", verify.P1ResourceIDRegexp),
+		),
+	}
+
+	withoutGateway := resource.TestStep{
+		Config: testAccSignOnPolicyActionConfig_LoginMinimal(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "new_user_provisioning.#", "0"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSignOnPolicyActionDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			withGateway,
+			withoutGateway,
+			withGateway,
+			//Errors
+			{
+				Config:      testAccSignOnPolicyActionConfig_LoginFullWithNewUserProvisioningWrongGateway(resourceName, name),
+				ExpectError: regexp.MustCompile(`gateway.0.type must be one of \[LDAP\]`),
+			},
+		},
+	})
+}
+
 func TestAccSignOnPolicyAction_IDFirstAction(t *testing.T) {
 	t.Parallel()
 
@@ -1302,6 +1352,227 @@ resource "pingone_sign_on_policy_action" "%[2]s" {
 
   login {
     recovery_enabled = false // we set this to false because the calculated default from the api is true
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccSignOnPolicyActionConfig_LoginFullWithNewUserProvisioning(resourceName, name string) string {
+
+	return fmt.Sprintf(`
+		%[1]s
+
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_gateway" "%[2]s-1" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s-1"
+  enabled        = true
+
+  type = "LDAP"
+
+  bind_dn       = "ou=test,dc=example,dc=com"
+  bind_password = "dummyPasswordValue"
+
+  vendor = "PingDirectory"
+
+  servers = [
+    "ds1.dummyldapservice.com:636",
+    "ds3.dummyldapservice.com:636",
+    "ds2.dummyldapservice.com:636",
+  ]
+
+  user_type {
+    name               = "User Set 1"
+    password_authority = "LDAP"
+    search_base_dn     = "ou=users1,dc=example,dc=com"
+
+    user_link_attributes = ["objectGUID", "objectSid"]
+
+    user_migration {
+      lookup_filter_pattern = "(|(uid=$${identifier})(mail=$${identifier}))"
+
+      population_id = pingone_population.%[2]s.id
+
+      attribute_mapping {
+        name  = "username"
+        value = "$${ldapAttributes.uid}"
+      }
+
+      attribute_mapping {
+        name  = "email"
+        value = "$${ldapAttributes.mail}"
+      }
+    }
+
+    push_password_changes_to_ldap = true
+  }
+
+  user_type {
+    name               = "User Set 2"
+    password_authority = "PING_ONE"
+    search_base_dn     = "ou=users,dc=example,dc=com"
+
+    user_link_attributes = ["objectGUID", "dn", "objectSid"]
+
+    user_migration {
+      lookup_filter_pattern = "(|(uid=$${identifier})(mail=$${identifier}))"
+
+      population_id = pingone_population.%[2]s.id
+
+      attribute_mapping {
+        name  = "username"
+        value = "$${ldapAttributes.uid}"
+      }
+
+      attribute_mapping {
+        name  = "email"
+        value = "$${ldapAttributes.mail}"
+      }
+
+      attribute_mapping {
+        name  = "name.family"
+        value = "$${ldapAttributes.sn}"
+      }
+    }
+
+    push_password_changes_to_ldap = true
+  }
+
+}
+
+resource "pingone_gateway_credential" "%[2]s-1" {
+  environment_id = data.pingone_environment.general_test.id
+  gateway_id     = pingone_gateway.%[2]s-1.id
+}
+
+resource "pingone_gateway" "%[2]s-2" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s-2"
+  enabled        = true
+
+  type = "LDAP"
+
+  bind_dn       = "ou=test,dc=example,dc=com"
+  bind_password = "dummyPasswordValue"
+
+  vendor = "PingDirectory"
+
+  servers = [
+    "ds1.dummyldapservice.com:636",
+    "ds3.dummyldapservice.com:636",
+    "ds2.dummyldapservice.com:636",
+  ]
+
+  user_type {
+    name               = "User Set 1"
+    password_authority = "LDAP"
+    search_base_dn     = "ou=users1,dc=example,dc=com"
+
+    user_link_attributes = ["objectGUID", "objectSid"]
+
+    user_migration {
+      lookup_filter_pattern = "(|(uid=$${identifier})(mail=$${identifier}))"
+
+      population_id = pingone_population.%[2]s.id
+
+      attribute_mapping {
+        name  = "username"
+        value = "$${ldapAttributes.uid}"
+      }
+
+      attribute_mapping {
+        name  = "email"
+        value = "$${ldapAttributes.mail}"
+      }
+    }
+
+    push_password_changes_to_ldap = true
+  }
+}
+
+resource "pingone_gateway_credential" "%[2]s-2" {
+  environment_id = data.pingone_environment.general_test.id
+  gateway_id     = pingone_gateway.%[2]s-2.id
+}
+
+resource "pingone_sign_on_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+}
+
+resource "pingone_sign_on_policy_action" "%[2]s" {
+  environment_id    = data.pingone_environment.general_test.id
+  sign_on_policy_id = pingone_sign_on_policy.%[2]s.id
+
+  priority = 1
+
+  login {
+    recovery_enabled = false
+
+    new_user_provisioning {
+      gateway {
+        id           = pingone_gateway.%[2]s-1.id
+		user_type_id = pingone_gateway.%[2]s-1.user_type.*[index(pingone_gateway.%[2]s-1.user_type[*].name, "User Set 2")].id
+      }
+
+      gateway {
+        id           = pingone_gateway.%[2]s-2.id
+		user_type_id = pingone_gateway.%[2]s-2.user_type.*[index(pingone_gateway.%[2]s-2.user_type[*].name, "User Set 1")].id
+      }
+
+      gateway {
+        id           = pingone_gateway.%[2]s-1.id
+		user_type_id = pingone_gateway.%[2]s-1.user_type.*[index(pingone_gateway.%[2]s-1.user_type[*].name, "User Set 1")].id
+      }
+    }
+  }
+
+  depends_on = [
+    pingone_gateway_credential.%[2]s-1,
+    pingone_gateway_credential.%[2]s-2,
+  ]
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccSignOnPolicyActionConfig_LoginFullWithNewUserProvisioningWrongGateway(resourceName, name string) string {
+
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_gateway" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  type = "PING_FEDERATE"
+}
+
+resource "pingone_sign_on_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+}
+
+resource "pingone_sign_on_policy_action" "%[2]s" {
+  environment_id    = data.pingone_environment.general_test.id
+  sign_on_policy_id = pingone_sign_on_policy.%[2]s.id
+
+  priority = 1
+
+  login {
+    recovery_enabled = false
+
+    new_user_provisioning {
+      gateway {
+        id           = pingone_gateway.%[2]s.id
+        user_type_id = pingone_gateway.%[2]s.id
+      }
+    }
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }

--- a/internal/service/sso/schema_sign_on_policy_action.go
+++ b/internal/service/sso/schema_sign_on_policy_action.go
@@ -1,6 +1,8 @@
 package sso
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
@@ -281,6 +283,45 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"recovery_enabled": recoveryEnabledSchema(),
+					"new_user_provisioning": {
+						Description: "Enables user entries existing outside of PingOne to be provisioned during login, using an external integration solution (such as a Gateway).",
+						Type:        schema.TypeList,
+						MaxItems:    1,
+						Optional:    true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"gateway": {
+									Description: "One or more blocks that describe a preconfigured gateway and user type that are specified in the Gateway Management schema to determine how to find and migrate user entries existing in an external directory.",
+									Type:        schema.TypeSet,
+									MinItems:    1,
+									Required:    true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"id": {
+												Description:      "A string that specifies the UUID ID of the gateway instance.  The ID may come from the `id` parameter of the `pingone_gateway` resource.  Must be a valid PingOne resource ID.",
+												Type:             schema.TypeString,
+												Required:         true,
+												ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
+											},
+											"type": {
+												Description:      fmt.Sprintf("A string that specifies the type of the gateway. Currently, only `%s` is supported.", string(management.ENUMGATEWAYTYPE_LDAP)),
+												Type:             schema.TypeString,
+												Optional:         true,
+												Default:          string(management.ENUMGATEWAYTYPE_LDAP),
+												ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(management.ENUMGATEWAYTYPE_LDAP)}, false)),
+											},
+											"user_type_id": {
+												Description:      "A string that specifies the UUID ID of the user type within the gateway instance.  The ID may come from the `user_type[*].id` parameter of the `pingone_gateway` resource.  Must be a valid PingOne resource ID.",
+												Type:             schema.TypeString,
+												Required:         true,
+												ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* Support user provisioning gateway configuration on the "Login" sign-on policy action

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell

```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell

```