### PR TITLE
`resource/pingone_sign_on_policy_action`: Fix plugin panic crash when defining `conditions.user_attribute_equals` in a priority 1 `mfa` sign-on policy

### DIFF
--- a/.changelog/412.txt
+++ b/.changelog/412.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/pingone_sign_on_policy_action: Fix plugin panic crash when defining conditions.user_attribute_equals in a priority 1 MFA sign-on policy.
+```
+
+```release-note:note
+resource/pingone_sign_on_policy_action: Adjust documentation to clarify the use of the conditions.user_attribute_equals condition in MFA policy actions.
+```

--- a/.changelog/412.txt
+++ b/.changelog/412.txt
@@ -1,7 +1,7 @@
 ```release-note:bug
-resource/pingone_sign_on_policy_action: Fix plugin panic crash when defining conditions.user_attribute_equals in a priority 1 MFA sign-on policy.
+`resource/pingone_sign_on_policy_action`: Fix panic crash when defining `conditions.user_attribute_equals` and/or `conditions.user_is_member_of_any_population_id` in a sign-on policy action that is priority 1.
 ```
 
 ```release-note:note
-resource/pingone_sign_on_policy_action: Adjust documentation to clarify the use of the conditions.user_attribute_equals condition in MFA policy actions.
+`resource/pingone_sign_on_policy_action`: Adjust documentation to clarify the where conditions can and cannot be used in a policy action.
 ```

--- a/docs/resources/sign_on_policy_action.md
+++ b/docs/resources/sign_on_policy_action.md
@@ -11,6 +11,8 @@ Resource to create and manage PingOne sign on policy actions.
 
 ~> A warning will be issued following `terraform apply` when attempting to remove the final sign-on policy action from an associated sign-on policy.  When removing the final sign-on policy action from a sign-on policy, it's recommended to also remove the associated sign-on policy at the same time.  Further information can be found [here](https://github.com/pingidentity/terraform-provider-pingone/issues/68).
 
+~> Some policy action conditions, such as `conditions.user_attribute_equals` and `conditions.user_is_member_of_any_population_id` conditions, are not available where the `priority` of a policy action is `1`.  Please refer to the schema documentation for more information.
+
 ## Example Usage - First Factor (Username/Password)
 
 ```terraform
@@ -194,7 +196,7 @@ resource "pingone_sign_on_policy_action" "my_policy_pingid" {
 ### Optional
 
 - `agreement` (Block List, Max: 1) Options specific to the **Agreements** policy action. (see [below for nested schema](#nestedblock--agreement))
-- `conditions` (Block List, Max: 1) Conditions to apply to the sign on policy action. (see [below for nested schema](#nestedblock--conditions))
+- `conditions` (Block List, Max: 1) Conditions to apply to the sign on policy action.  Applies to policy actions of type `agreement`, `identifier_first`, `identity_provider`, `login`, `mfa`, `progressive_profiling`. (see [below for nested schema](#nestedblock--conditions))
 - `enforce_lockout_for_identity_providers` (Boolean) A boolean that if set to true and if the user's account is locked (the account.canAuthenticate attribute is set to false), then social sign on with an external identity provider is prevented. Defaults to `false`.
 - `identifier_first` (Block List, Max: 1) Options specific to the **Identifier First** policy action. (see [below for nested schema](#nestedblock--identifier_first))
 - `identity_provider` (Block List, Max: 1) Options specific to the **Identity Provider** policy action. (see [below for nested schema](#nestedblock--identity_provider))
@@ -229,15 +231,15 @@ Optional:
 
 Optional:
 
-- `anonymous_network_detected` (Boolean) A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected anonymous network. Defaults to `false`.
-- `anonymous_network_detected_allowed_cidr` (Set of String) A list of allowed CIDR when an anonymous network is detected.
-- `geovelocity_anomaly_detected` (Boolean) A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected geovelocity anomaly. Defaults to `false`.
-- `ip_out_of_range_cidr` (Set of String) A list of strings that specifies the supported network IP addresses expressed as classless inter-domain routing (CIDR) strings.
-- `ip_reputation_high_risk` (Boolean) A boolean that specifies whether the user's IP risk should be used when evaluating this policy action.  A value of `HIGH` will prompt the user to authenticate with this action. Defaults to `false`.
-- `last_sign_on_older_than_seconds` (Number) Set the number of seconds by which the user will not be prompted for this action following the last successful authentication.
-- `last_sign_on_older_than_seconds_mfa` (Number) Set the number of seconds by which the user will not be prompted for this action following the last successful authentication of an MFA authenticator device.
-- `user_attribute_equals` (Block Set) One or more conditions where an attribute on the user's profile must match the configured value. (see [below for nested schema](#nestedblock--conditions--user_attribute_equals))
-- `user_is_member_of_any_population_id` (Set of String) Activate this action only for users within the specified list of population IDs.
+- `anonymous_network_detected` (Boolean) A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected anonymous network.  Applies to policy actions of type `mfa`. Defaults to `false`.
+- `anonymous_network_detected_allowed_cidr` (Set of String) A list of allowed CIDR when an anonymous network is detected.  Applies to policy actions of type `mfa`.
+- `geovelocity_anomaly_detected` (Boolean) A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected geovelocity anomaly.  Applies to policy actions of type `mfa`. Defaults to `false`.
+- `ip_out_of_range_cidr` (Set of String) A list of strings that specifies the supported network IP addresses expressed as classless inter-domain routing (CIDR) strings.  Applies to policy actions of type `mfa`.
+- `ip_reputation_high_risk` (Boolean) A boolean that specifies whether the user's IP risk should be used when evaluating this policy action.  A value of `HIGH` will prompt the user to authenticate with this action.  Applies to policy actions of type `mfa`. Defaults to `false`.
+- `last_sign_on_older_than_seconds` (Number) Set the number of seconds by which the user will not be prompted for this action following the last successful authentication.  Applies to policy actions of type `identifier_first`, `identity_provider`, `login`, `mfa`.
+- `last_sign_on_older_than_seconds_mfa` (Number) Set the number of seconds by which the user will not be prompted for this action following the last successful authentication of an MFA authenticator device.  Applies to policy actions of type `mfa`.
+- `user_attribute_equals` (Block Set) One or more conditions where an attribute on the user's profile must match the configured value.  Applies to policy actions of type `identifier_first`, `login`, `mfa`, but cannot be set on policy actions where the priority is `1`. (see [below for nested schema](#nestedblock--conditions--user_attribute_equals))
+- `user_is_member_of_any_population_id` (Set of String) Activate this action only for users within the specified list of population IDs.  Applies to policy actions of type `identifier_first`, `login`, `mfa`, but cannot be set on policy actions where the priority is `1`.
 
 <a id="nestedblock--conditions--user_attribute_equals"></a>
 ### Nested Schema for `conditions.user_attribute_equals`

--- a/internal/service/sso/resource_sign_on_policy_action.go
+++ b/internal/service/sso/resource_sign_on_policy_action.go
@@ -986,7 +986,7 @@ func buildAttributeEqualsCondition(v []attributeEquality, tfSchemaAttribute stri
 
 	if sopPriority < 2 {
 		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
+			Severity: diag.Error,
 			Summary:  fmt.Sprintf("Condition `%s` is defined but has no effect where the action priority is 1.", tfSchemaAttribute),
 		})
 	} else {

--- a/internal/service/sso/resource_sign_on_policy_action.go
+++ b/internal/service/sso/resource_sign_on_policy_action.go
@@ -987,7 +987,7 @@ func buildAttributeEqualsCondition(v []attributeEquality, tfSchemaAttribute stri
 	if sopPriority < 2 {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("Condition `%s` is defined but has no effect where the action priority is 1.", tfSchemaAttribute),
+			Summary:  fmt.Sprintf("Condition `%s` is defined cannot be set when the policy action priority is 1.", tfSchemaAttribute),
 		})
 	} else {
 

--- a/internal/service/sso/schema_sign_on_policy_action.go
+++ b/internal/service/sso/schema_sign_on_policy_action.go
@@ -31,7 +31,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
 		},
 		"conditions": {
-			Description:   "Conditions to apply to the sign on policy action.",
+			Description:   "Conditions to apply to the sign on policy action.  Applies to policy actions of type `agreement`, `identifier_first`, `identity_provider`, `login`, `mfa`, `progressive_profiling`.",
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
@@ -39,7 +39,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"last_sign_on_older_than_seconds": {
-						Description:      "Set the number of seconds by which the user will not be prompted for this action following the last successful authentication.",
+						Description:      "Set the number of seconds by which the user will not be prompted for this action following the last successful authentication.  Applies to policy actions of type `identifier_first`, `identity_provider`, `login`, `mfa`.",
 						Type:             schema.TypeInt,
 						Optional:         true,
 						ConflictsWith:    []string{"progressive_profiling", "agreement", "conditions.0.last_sign_on_older_than_seconds_mfa"},
@@ -47,7 +47,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf:     []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"last_sign_on_older_than_seconds_mfa": {
-						Description:      "Set the number of seconds by which the user will not be prompted for this action following the last successful authentication of an MFA authenticator device.",
+						Description:      "Set the number of seconds by which the user will not be prompted for this action following the last successful authentication of an MFA authenticator device.  Applies to policy actions of type `mfa`.",
 						Type:             schema.TypeInt,
 						Optional:         true,
 						ConflictsWith:    []string{"identifier_first", "login", "progressive_profiling", "agreement", "identity_provider", "conditions.0.last_sign_on_older_than_seconds"},
@@ -55,7 +55,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf:     []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"user_is_member_of_any_population_id": {
-						Description:   "Activate this action only for users within the specified list of population IDs.",
+						Description:   "Activate this action only for users within the specified list of population IDs.  Applies to policy actions of type `identifier_first`, `login`, `mfa`, but cannot be set on policy actions where the priority is `1`.",
 						Type:          schema.TypeSet,
 						MaxItems:      100,
 						Optional:      true,
@@ -67,9 +67,10 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf: []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"user_attribute_equals": {
-						Description:   "One or more conditions where an attribute on the user's profile must match the configured value.",
-						Type:          schema.TypeSet,
-						Optional:      true,
+						Description: "One or more conditions where an attribute on the user's profile must match the configured value.  Applies to policy actions of type `identifier_first`, `login`, `mfa`, but cannot be set on policy actions where the priority is `1`.",
+						Type:        schema.TypeSet,
+						Optional:    true,
+						//ValidateFunc:  validation..ValidateStructHasKeysFunc([]string{"attribute_reference", "value", "value_boolean"}, nil),
 						ConflictsWith: []string{"progressive_profiling", "agreement", "identity_provider"},
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
@@ -95,7 +96,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf: []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"ip_out_of_range_cidr": {
-						Description:   "A list of strings that specifies the supported network IP addresses expressed as classless inter-domain routing (CIDR) strings.",
+						Description:   "A list of strings that specifies the supported network IP addresses expressed as classless inter-domain routing (CIDR) strings.  Applies to policy actions of type `mfa`.",
 						Type:          schema.TypeSet,
 						MaxItems:      100,
 						Optional:      true,
@@ -107,7 +108,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf: []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"ip_reputation_high_risk": {
-						Description:   "A boolean that specifies whether the user's IP risk should be used when evaluating this policy action.  A value of `HIGH` will prompt the user to authenticate with this action.",
+						Description:   "A boolean that specifies whether the user's IP risk should be used when evaluating this policy action.  A value of `HIGH` will prompt the user to authenticate with this action.  Applies to policy actions of type `mfa`.",
 						Type:          schema.TypeBool,
 						Optional:      true,
 						Default:       false,
@@ -115,7 +116,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf:  []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"geovelocity_anomaly_detected": {
-						Description:   "A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected geovelocity anomaly.",
+						Description:   "A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected geovelocity anomaly.  Applies to policy actions of type `mfa`.",
 						Type:          schema.TypeBool,
 						Optional:      true,
 						Default:       false,
@@ -123,7 +124,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf:  []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"anonymous_network_detected": {
-						Description:   "A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected anonymous network.",
+						Description:   "A boolean that specifies whether the user should be prompted for re-authentication on this action based on a detected anonymous network.  Applies to policy actions of type `mfa`.",
 						Type:          schema.TypeBool,
 						Optional:      true,
 						Default:       false,
@@ -131,7 +132,7 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf:  []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"anonymous_network_detected_allowed_cidr": {
-						Description:   "A list of allowed CIDR when an anonymous network is detected.",
+						Description:   "A list of allowed CIDR when an anonymous network is detected.  Applies to policy actions of type `mfa`.",
 						Type:          schema.TypeSet,
 						MaxItems:      100,
 						Optional:      true,

--- a/internal/service/sso/schema_sign_on_policy_action.go
+++ b/internal/service/sso/schema_sign_on_policy_action.go
@@ -67,10 +67,9 @@ func resourceSignOnPolicyActionSchema() map[string]*schema.Schema {
 						AtLeastOneOf: []string{"conditions.0.last_sign_on_older_than_seconds", "conditions.0.last_sign_on_older_than_seconds_mfa", "conditions.0.user_is_member_of_any_population_id", "conditions.0.user_attribute_equals", "conditions.0.ip_out_of_range_cidr", "conditions.0.ip_reputation_high_risk", "conditions.0.geovelocity_anomaly_detected", "conditions.0.anonymous_network_detected"},
 					},
 					"user_attribute_equals": {
-						Description: "One or more conditions where an attribute on the user's profile must match the configured value.  Applies to policy actions of type `identifier_first`, `login`, `mfa`, but cannot be set on policy actions where the priority is `1`.",
-						Type:        schema.TypeSet,
-						Optional:    true,
-						//ValidateFunc:  validation..ValidateStructHasKeysFunc([]string{"attribute_reference", "value", "value_boolean"}, nil),
+						Description:   "One or more conditions where an attribute on the user's profile must match the configured value.  Applies to policy actions of type `identifier_first`, `login`, `mfa`, but cannot be set on policy actions where the priority is `1`.",
+						Type:          schema.TypeSet,
+						Optional:      true,
 						ConflictsWith: []string{"progressive_profiling", "agreement", "identity_provider"},
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{

--- a/templates/resources/sign_on_policy_action.md.tmpl
+++ b/templates/resources/sign_on_policy_action.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 
 ~> A warning will be issued following `terraform apply` when attempting to remove the final sign-on policy action from an associated sign-on policy.  When removing the final sign-on policy action from a sign-on policy, it's recommended to also remove the associated sign-on policy at the same time.  Further information can be found [here](https://github.com/pingidentity/terraform-provider-pingone/issues/68).
 
+~> Some policy action conditions, such as `conditions.user_attribute_equals` and `conditions.user_is_member_of_any_population_id` conditions, are not available where the `priority` of a policy action is `1`.  Please refer to the schema documentation for more information.
+
 ## Example Usage - First Factor (Username/Password)
 
 {{ tffile (printf "%s%s%s" "examples/resources/" .Name "/resource-login.tf") }}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* `resource/pingone_sign_on_policy_action`: Fix plugin panic crash when defining `conditions.user_attribute_equals` in a priority 1 MFA sign-on policy.
* `resource/pingone_sign_on_policy_action`: Adjust documentation to clarify the use of the `conditions.user_attribute_equals` condition in MFA policy actions.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccSignOnPolicyAction_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccSignOnPolicyAction_LoginAction
=== PAUSE TestAccSignOnPolicyAction_LoginAction
=== RUN   TestAccSignOnPolicyAction_IDFirstAction
=== PAUSE TestAccSignOnPolicyAction_IDFirstAction
=== RUN   TestAccSignOnPolicyAction_MFAAction
=== PAUSE TestAccSignOnPolicyAction_MFAAction
=== RUN   TestAccSignOnPolicyAction_IDPAction
=== PAUSE TestAccSignOnPolicyAction_IDPAction
=== RUN   TestAccSignOnPolicyAction_AgreementAction
=== PAUSE TestAccSignOnPolicyAction_AgreementAction
=== RUN   TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== PAUSE TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== RUN   TestAccSignOnPolicyAction_PingIDAction
=== PAUSE TestAccSignOnPolicyAction_PingIDAction
=== RUN   TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
=== PAUSE TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
=== RUN   TestAccSignOnPolicyAction_MultipleActionChange
=== PAUSE TestAccSignOnPolicyAction_MultipleActionChange
=== RUN   TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== PAUSE TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== RUN   TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== PAUSE TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== RUN   TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== PAUSE TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== RUN   TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== PAUSE TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== RUN   TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== RUN   TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== RUN   TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== RUN   TestAccSignOnPolicyAction_ConditionsGeovelocity
=== PAUSE TestAccSignOnPolicyAction_ConditionsGeovelocity
=== RUN   TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== PAUSE TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== RUN   TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== PAUSE TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== RUN   TestAccSignOnPolicyAction_ConditionsCompound
=== PAUSE TestAccSignOnPolicyAction_ConditionsCompound
=== CONT  TestAccSignOnPolicyAction_LoginAction
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== CONT  TestAccSignOnPolicyAction_PingIDAction
=== CONT  TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== CONT  TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== CONT  TestAccSignOnPolicyAction_MultipleActionChange
=== CONT  TestAccSignOnPolicyAction_IDPAction
=== CONT  TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== CONT  TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== CONT  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== CONT  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== CONT  TestAccSignOnPolicyAction_IDFirstAction
=== CONT  TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== CONT  TestAccSignOnPolicyAction_ConditionsCompound
=== CONT  TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== CONT  TestAccSignOnPolicyAction_MFAAction
=== NAME  TestAccSignOnPolicyAction_ConditionsIPHighRisk
    resource_sign_on_policy_action_test.go:1011: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPHighRisk (0.00s)
=== CONT  TestAccSignOnPolicyAction_AgreementAction
=== NAME  TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
    resource_sign_on_policy_action_test.go:1095: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsAnonymousNetwork (0.01s)
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== NAME  TestAccSignOnPolicyAction_MFAAction
    resource_sign_on_policy_action_test.go:252: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_MFAAction (0.01s)
=== CONT  TestAccSignOnPolicyAction_ConditionsGeovelocity
=== NAME  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
    resource_sign_on_policy_action_test.go:921: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle (0.03s)
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== NAME  TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
    resource_sign_on_policy_action_test.go:1139: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed (0.04s)
=== CONT  TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== NAME  TestAccSignOnPolicyAction_ConditionsGeovelocity
    resource_sign_on_policy_action_test.go:1053: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsGeovelocity (0.03s)
=== CONT  TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== NAME  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
    resource_sign_on_policy_action_test.go:965: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple (0.05s)
=== CONT  TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
--- PASS: TestAccSignOnPolicyAction_ConditionsInvalidPriority1 (8.64s)
--- PASS: TestAccSignOnPolicyAction_PingIDAction (9.48s)
--- PASS: TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction (10.96s)
--- PASS: TestAccSignOnPolicyAction_ConditionsCompound (11.01s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple (22.00s)
--- PASS: TestAccSignOnPolicyAction_ProgressiveProfilingAction (22.30s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString (22.43s)
--- PASS: TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle (22.80s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool (22.80s)
--- PASS: TestAccSignOnPolicyAction_ConditionsMemberOfPopulations (23.52s)
--- PASS: TestAccSignOnPolicyAction_IDPAction (23.59s)
--- PASS: TestAccSignOnPolicyAction_MultipleActionChange (24.63s)
--- PASS: TestAccSignOnPolicyAction_ConditionsMemberOfPopulation (25.14s)
--- PASS: TestAccSignOnPolicyAction_LoginAction (27.50s)
--- PASS: TestAccSignOnPolicyAction_IDFirstAction (27.60s)
--- PASS: TestAccSignOnPolicyAction_AgreementAction (54.59s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 54.951s
```