### PR TITLE
Optimise code for conversion of ENUM to TF state

### DIFF
--- a/.changelog/417.txt
+++ b/.changelog/417.txt
@@ -1,0 +1,27 @@
+```release-note:note
+`data-source/pingone_environment`: Code optimisation of ENUM values to TF state.
+```
+
+```release-note:note
+`resource/pingone_agreement_localization_revision`: Code optimisation of ENUM values to TF state.
+```
+
+```release-note:note
+`resource/pingone_environment`: Code optimisation of ENUM values to TF state.
+```
+
+```release-note:note
+`data-source/pingone_credential_issuance_rule`: Code optimisation of ENUM values to TF state.
+```
+
+```release-note:note
+`data-source/pingone_credential_type`: Code optimisation of ENUM values to TF state.
+```
+
+```release-note:note
+`resource/pingone_credential_issuance_rule`: Code optimisation of ENUM values to TF state.
+```
+
+```release-note:note
+`resource/pingone_credential_type`: Code optimisation of ENUM values to TF state.
+```

--- a/internal/service/base/data_source_environment.go
+++ b/internal/service/base/data_source_environment.go
@@ -341,8 +341,8 @@ func (p *EnvironmentDataSourceModel) toState(environmentApiObject *management.En
 	p.EnvironmentId = framework.StringOkToTF(environmentApiObject.GetIdOk())
 	p.Name = framework.StringOkToTF(environmentApiObject.GetNameOk())
 	p.Description = framework.StringOkToTF(environmentApiObject.GetDescriptionOk())
-	p.Type = enumEnvironmentTypeOkToTF(environmentApiObject.GetTypeOk())
-	p.Region = enumRegionCodeOkToTF(environmentApiObject.GetRegionOk())
+	p.Type = framework.EnumOkToTF(environmentApiObject.GetTypeOk())
+	p.Region = framework.EnumOkToTF(environmentApiObject.GetRegionOk())
 
 	if v, ok := environmentApiObject.GetLicenseOk(); ok {
 		p.LicenseId = framework.StringOkToTF(v.GetIdOk())
@@ -354,7 +354,7 @@ func (p *EnvironmentDataSourceModel) toState(environmentApiObject *management.En
 		p.OrganizationId = types.StringNull()
 	}
 
-	p.Solution = enumSolutionTypeOkToTF(servicesApiObject.GetSolutionTypeOk())
+	p.Solution = framework.EnumOkToTF(servicesApiObject.GetSolutionTypeOk())
 
 	services, d := toStateEnvironmentServices(servicesApiObject.GetProducts())
 	diags.Append(d...)

--- a/internal/service/base/resource_agreement_localization_revision.go
+++ b/internal/service/base/resource_agreement_localization_revision.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
@@ -412,21 +411,13 @@ func (p *AgreementLocalizationRevisionResourceModel) toState(apiObject *manageme
 	p.Id = framework.StringToTF(apiObject.GetId())
 	p.AgreementId = framework.StringToTF(*apiObject.GetAgreement().Id)
 	p.AgreementLocalizationId = framework.StringToTF(*apiObject.GetLanguage().Id)
-	p.ContentType = enumAgreementRevisionContentTypeOkToTF(apiObject.GetContentTypeOk())
+	p.ContentType = framework.EnumOkToTF(apiObject.GetContentTypeOk())
 	p.EffectiveAt = framework.TimeOkToTF(apiObject.GetEffectiveAtOk())
 	p.NotValidAfter = framework.TimeOkToTF(apiObject.GetNotValidAfterOk())
 	p.RequireReconsent = framework.BoolOkToTF(apiObject.GetRequireReconsentOk())
 	p.Text = framework.StringToTF(revisionText)
 
 	return diags
-}
-
-func enumAgreementRevisionContentTypeOkToTF(v *management.EnumAgreementRevisionContentType, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
-	}
 }
 
 func agreementLocalizationRevisionDeleteErrorHandler(error model.P1Error) diag.Diagnostics {

--- a/internal/service/base/resource_environment.go
+++ b/internal/service/base/resource_environment.go
@@ -1099,7 +1099,7 @@ func (p *environmentResourceModel) toState(environmentApiObject *management.Envi
 	p.Id = framework.StringOkToTF(environmentApiObject.GetIdOk())
 	p.Name = framework.StringOkToTF(environmentApiObject.GetNameOk())
 	p.Description = framework.StringOkToTF(environmentApiObject.GetDescriptionOk())
-	p.Type = enumEnvironmentTypeOkToTF(environmentApiObject.GetTypeOk())
+	p.Type = framework.EnumOkToTF(environmentApiObject.GetTypeOk())
 	p.Region = enumRegionCodeOkToTF(environmentApiObject.GetRegionOk())
 
 	if v, ok := environmentApiObject.GetLicenseOk(); ok {
@@ -1112,7 +1112,7 @@ func (p *environmentResourceModel) toState(environmentApiObject *management.Envi
 		p.OrganizationId = types.StringNull()
 	}
 
-	p.Solution = enumSolutionTypeOkToTF(servicesApiObject.GetSolutionTypeOk())
+	p.Solution = framework.EnumOkToTF(servicesApiObject.GetSolutionTypeOk())
 
 	services, d := toStateEnvironmentServices(servicesApiObject.GetProducts())
 	diags.Append(d...)
@@ -1243,27 +1243,11 @@ func toStateEnvironmentServicesBookmark(bookmarks []management.BillOfMaterialsPr
 
 }
 
-func enumEnvironmentTypeOkToTF(v *management.EnumEnvironmentType, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
-	}
-}
-
 func enumRegionCodeOkToTF(v *management.EnumRegionCode, ok bool) basetypes.StringValue {
 	if !ok || v == nil {
 		return types.StringNull()
 	} else {
 		return types.StringValue(model.FindRegionByAPICode(*v).Region)
-	}
-}
-
-func enumSolutionTypeOkToTF(v *management.EnumSolutionType, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
 	}
 }
 

--- a/internal/service/credentials/data_source_credential_issuance_rule.go
+++ b/internal/service/credentials/data_source_credential_issuance_rule.go
@@ -284,7 +284,7 @@ func (p *CredentialIssuanceRuleDataSourceModel) toState(apiObject *credentials.C
 	p.DigitalWalletApplicationId = framework.StringToTF(apiObject.GetDigitalWalletApplication().Id)
 	p.CredentialTypeId = framework.StringToTF(apiObject.CredentialType.GetId())
 	p.CredentialIssuanceRuleId = framework.StringToTF(apiObject.GetId())
-	p.Status = enumCredentialIssuanceStatusDataSourceOkToTF(apiObject.GetStatusOk())
+	p.Status = framework.EnumOkToTF(apiObject.GetStatusOk())
 
 	// automation object
 	automation, d := toStateAutomationDataSource(apiObject.GetAutomationOk())
@@ -308,9 +308,9 @@ func toStateAutomationDataSource(automation *credentials.CredentialIssuanceRuleA
 	var diags diag.Diagnostics
 
 	automationMap := map[string]attr.Value{
-		"issue":  enumCredentialIssuanceRuleAutomationDataSourceOkToTF(automation.GetIssueOk()),
-		"revoke": enumCredentialIssuanceRuleAutomationDataSourceOkToTF(automation.GetRevokeOk()),
-		"update": enumCredentialIssuanceRuleAutomationDataSourceOkToTF(automation.GetUpdateOk()),
+		"issue":  framework.EnumOkToTF(automation.GetIssueOk()),
+		"revoke": framework.EnumOkToTF(automation.GetRevokeOk()),
+		"update": framework.EnumOkToTF(automation.GetUpdateOk()),
 	}
 	flattenedObj, d := types.ObjectValue(automationDataSourceServiceTFObjectTypes, automationMap)
 	diags.Append(d...)
@@ -380,21 +380,5 @@ func enumCredentialIssuanceRuleNotificationMethodDataSourceOkToTF(v []credential
 		}
 
 		return types.SetValueMust(types.StringType, list)
-	}
-}
-
-func enumCredentialIssuanceRuleAutomationDataSourceOkToTF(v *credentials.EnumCredentialIssuanceRuleAutomationMethod, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
-	}
-}
-
-func enumCredentialIssuanceStatusDataSourceOkToTF(v *credentials.EnumCredentialIssuanceRuleStatus, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
 	}
 }

--- a/internal/service/credentials/data_source_credential_type.go
+++ b/internal/service/credentials/data_source_credential_type.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/patrickcping/pingone-go-sdk-v2/credentials"
 	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
@@ -358,7 +357,7 @@ func toStateFieldsDataSource(innerFields []credentials.CredentialTypeMetaDataFie
 			"attribute":  framework.StringOkToTF(v.GetAttributeOk()),
 			"value":      framework.StringOkToTF(v.GetValueOk()),
 			"is_visible": framework.BoolOkToTF(v.GetIsVisibleOk()),
-			"type":       enumCredentialTypeMetaDataFieldsDataSourceOkToTF(v.GetTypeOk()),
+			"type":       framework.EnumOkToTF(v.GetTypeOk()),
 		}
 		innerflattenedObj, d := types.ObjectValue(innerFieldsDataSourceServiceTFObjectTypes, fieldsMap)
 		diags.Append(d...)
@@ -369,12 +368,4 @@ func toStateFieldsDataSource(innerFields []credentials.CredentialTypeMetaDataFie
 	diags.Append(d...)
 
 	return fields, diags
-}
-
-func enumCredentialTypeMetaDataFieldsDataSourceOkToTF(v *credentials.EnumCredentialTypeMetaDataFieldsType, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
-	}
 }

--- a/internal/service/credentials/resource_credential_issuance_rule.go
+++ b/internal/service/credentials/resource_credential_issuance_rule.go
@@ -740,7 +740,7 @@ func (p *CredentialIssuanceRuleResourceModel) toState(apiObject *credentials.Cre
 	p.EnvironmentId = framework.StringToTF(*apiObject.GetEnvironment().Id)
 	p.DigitalWalletApplicationId = framework.StringToTF(apiObject.GetDigitalWalletApplication().Id)
 	p.CredentialTypeId = framework.StringToTF(apiObject.CredentialType.GetId())
-	p.Status = enumCredentialIssuanceStatusOkToTF(apiObject.GetStatusOk())
+	p.Status = framework.EnumOkToTF(apiObject.GetStatusOk())
 
 	// automation object
 	if v, ok := apiObject.GetAutomationOk(); ok {
@@ -774,9 +774,9 @@ func toStateAutomation(automation *credentials.CredentialIssuanceRuleAutomation)
 	var diags diag.Diagnostics
 
 	automationMap := map[string]attr.Value{
-		"issue":  enumCredentialIssuanceRuleAutomationOkToTF(automation.GetIssueOk()),
-		"revoke": enumCredentialIssuanceRuleAutomationOkToTF(automation.GetRevokeOk()),
-		"update": enumCredentialIssuanceRuleAutomationOkToTF(automation.GetUpdateOk()),
+		"issue":  framework.EnumOkToTF(automation.GetIssueOk()),
+		"revoke": framework.EnumOkToTF(automation.GetRevokeOk()),
+		"update": framework.EnumOkToTF(automation.GetUpdateOk()),
 	}
 	flattenedObj, d := types.ObjectValue(automationServiceTFObjectTypes, automationMap)
 	diags.Append(d...)
@@ -864,21 +864,5 @@ func enumCredentialIssuanceRuleNotificationMethodOkToTF(v []credentials.EnumCred
 		}
 
 		return types.SetValueMust(types.StringType, list)
-	}
-}
-
-func enumCredentialIssuanceRuleAutomationOkToTF(v *credentials.EnumCredentialIssuanceRuleAutomationMethod, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
-	}
-}
-
-func enumCredentialIssuanceStatusOkToTF(v *credentials.EnumCredentialIssuanceRuleStatus, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
 	}
 }

--- a/internal/service/credentials/resource_credential_type.go
+++ b/internal/service/credentials/resource_credential_type.go
@@ -842,7 +842,7 @@ func toStateFields(innerFields []credentials.CredentialTypeMetaDataFieldsInner, 
 			"attribute":  framework.StringOkToTF(v.GetAttributeOk()),
 			"value":      framework.StringOkToTF(v.GetValueOk()),
 			"is_visible": framework.BoolOkToTF(v.GetIsVisibleOk()),
-			"type":       enumCredentialTypeMetaDataFieldsOkToTF(v.GetTypeOk()),
+			"type":       framework.EnumOkToTF(v.GetTypeOk()),
 		}
 		innerflattenedObj, d := types.ObjectValue(innerFieldsServiceTFObjectTypes, fieldsMap)
 		diags.Append(d...)
@@ -853,14 +853,6 @@ func toStateFields(innerFields []credentials.CredentialTypeMetaDataFieldsInner, 
 	diags.Append(d...)
 
 	return fields, diags
-}
-
-func enumCredentialTypeMetaDataFieldsOkToTF(v *credentials.EnumCredentialTypeMetaDataFieldsType, ok bool) basetypes.StringValue {
-	if !ok || v == nil {
-		return types.StringNull()
-	} else {
-		return types.StringValue(string(*v))
-	}
 }
 
 func credentialTypeRetryConditions(ctx context.Context, r *http.Response, p1error *model.P1Error) bool {


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->


* `data-source/pingone_environment`: Code optimisation of ENUM values to TF state.
* `resource/pingone_agreement_localization_revision`: Code optimisation of ENUM values to TF state.
* `resource/pingone_environment`: Code optimisation of ENUM values to TF state.
* `data-source/pingone_credential_issuance_rule`: Code optimisation of ENUM values to TF state.
* `data-source/pingone_credential_type`: Code optimisation of ENUM values to TF state.
* `resource/pingone_credential_issuance_rule`: Code optimisation of ENUM values to TF state.
* `resource/pingone_credential_type`: Code optimisation of ENUM values to TF state.

### Testing Results - `data-source/pingone_environment`
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccEnvironmentDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccEnvironmentDataSource_ByNameFull
=== PAUSE TestAccEnvironmentDataSource_ByNameFull
=== RUN   TestAccEnvironmentDataSource_ByNameMinimal
=== PAUSE TestAccEnvironmentDataSource_ByNameMinimal
=== RUN   TestAccEnvironmentDataSource_ByIDFull
=== PAUSE TestAccEnvironmentDataSource_ByIDFull
=== RUN   TestAccEnvironmentDataSource_ByIDMinimal
=== PAUSE TestAccEnvironmentDataSource_ByIDMinimal
=== RUN   TestAccEnvironmentDataSource_NotFound
=== PAUSE TestAccEnvironmentDataSource_NotFound
=== CONT  TestAccEnvironmentDataSource_ByNameFull
=== CONT  TestAccEnvironmentDataSource_ByIDMinimal
=== CONT  TestAccEnvironmentDataSource_ByIDFull
=== CONT  TestAccEnvironmentDataSource_NotFound
=== CONT  TestAccEnvironmentDataSource_ByNameMinimal
--- PASS: TestAccEnvironmentDataSource_NotFound (1.35s)
--- PASS: TestAccEnvironmentDataSource_ByNameMinimal (7.82s)
--- PASS: TestAccEnvironmentDataSource_ByNameFull (8.10s)
--- PASS: TestAccEnvironmentDataSource_ByIDMinimal (8.27s)
--- PASS: TestAccEnvironmentDataSource_ByIDFull (8.51s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        8.846s
```

### Testing Results - `resource/pingone_agreement_localization_revision`
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccAgreementLocalizationRevision_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccAgreementLocalizationRevision_Full
=== PAUSE TestAccAgreementLocalizationRevision_Full
=== CONT  TestAccAgreementLocalizationRevision_Full
--- PASS: TestAccAgreementLocalizationRevision_Full (41.06s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        41.451s
```

### Testing Results - `resource/pingone_environment`
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccEnvironment_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccEnvironment_Full
=== PAUSE TestAccEnvironment_Full
=== RUN   TestAccEnvironment_Minimal
=== PAUSE TestAccEnvironment_Minimal
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== RUN   TestAccEnvironment_DeleteProductionEnvironmentProtection
=== PAUSE TestAccEnvironment_DeleteProductionEnvironmentProtection
=== RUN   TestAccEnvironment_DeleteProductionEnvironment
=== PAUSE TestAccEnvironment_DeleteProductionEnvironment
=== RUN   TestAccEnvironment_NonPopulationServices
=== PAUSE TestAccEnvironment_NonPopulationServices
=== RUN   TestAccEnvironment_EnvironmentTypeSwitching
=== PAUSE TestAccEnvironment_EnvironmentTypeSwitching
=== RUN   TestAccEnvironment_ServiceAndPopulationSwitching
=== PAUSE TestAccEnvironment_ServiceAndPopulationSwitching
=== RUN   TestAccEnvironment_Services
=== PAUSE TestAccEnvironment_Services
=== CONT  TestAccEnvironment_Full
=== CONT  TestAccEnvironment_NonPopulationServices
=== CONT  TestAccEnvironment_ServiceAndPopulationSwitching
=== CONT  TestAccEnvironment_EnvironmentTypeSwitching
=== CONT  TestAccEnvironment_DeleteProductionEnvironmentProtection
=== CONT  TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_Minimal
=== CONT  TestAccEnvironment_DeleteProductionEnvironment
=== CONT  TestAccEnvironment_Services
=== NAME  TestAccEnvironment_DeleteProductionEnvironment
    resource_environment_test.go:259: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironment (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironmentProtection
    resource_environment_test.go:232: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironmentProtection (0.00s)
--- PASS: TestAccEnvironment_NonCompatibleRegion (2.16s)
--- PASS: TestAccEnvironment_Minimal (7.13s)
--- PASS: TestAccEnvironment_NonPopulationServices (7.23s)
--- PASS: TestAccEnvironment_EnvironmentTypeSwitching (14.86s)
--- PASS: TestAccEnvironment_Services (14.88s)
--- PASS: TestAccEnvironment_Full (14.93s)
--- PASS: TestAccEnvironment_ServiceAndPopulationSwitching (19.39s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        19.741s
```

### Testing Results - `data-source/pingone_credential_issuance_rule`
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccCredentialIssuanceRuleDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/cr
edentials
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== PAUSE TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== RUN   TestAccCredentialIssuanceRuleDataSource_NotFound
=== PAUSE TestAccCredentialIssuanceRuleDataSource_NotFound
=== RUN   TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== PAUSE TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== CONT  TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== CONT  TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== CONT  TestAccCredentialIssuanceRuleDataSource_NotFound
--- PASS: TestAccCredentialIssuanceRuleDataSource_InvalidConfig (0.49s)
--- PASS: TestAccCredentialIssuanceRuleDataSource_NotFound (3.68s)
--- PASS: TestAccCredentialIssuanceRuleDataSource_ByIDFull (8.33s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 8.738s
```

### Testing Results - `data-source/pingone_credential_type`
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccCredentialTypeDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccCredentialTypeDataSource_ByIDFull
=== PAUSE TestAccCredentialTypeDataSource_ByIDFull
=== RUN   TestAccCredentialTypeDataSource_NotFound
=== PAUSE TestAccCredentialTypeDataSource_NotFound
=== RUN   TestAccCredentialTypeDataSource_InvalidConfig
=== PAUSE TestAccCredentialTypeDataSource_InvalidConfig
=== CONT  TestAccCredentialTypeDataSource_ByIDFull
=== CONT  TestAccCredentialTypeDataSource_InvalidConfig
=== CONT  TestAccCredentialTypeDataSource_NotFound
--- PASS: TestAccCredentialTypeDataSource_InvalidConfig (0.51s)
--- PASS: TestAccCredentialTypeDataSource_NotFound (1.14s)
--- PASS: TestAccCredentialTypeDataSource_ByIDFull (9.43s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 9.772s
```

### Testing Results - `resource/pingone_credential_issuance_rule`
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccCredentialIssuanceRule_ github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccCredentialIssuanceRule_Full
=== PAUSE TestAccCredentialIssuanceRule_Full
=== RUN   TestAccCredentialIssuanceRule_InvalidConfigs
=== PAUSE TestAccCredentialIssuanceRule_InvalidConfigs
=== CONT  TestAccCredentialIssuanceRule_Full
=== CONT  TestAccCredentialIssuanceRule_InvalidConfigs
--- PASS: TestAccCredentialIssuanceRule_InvalidConfigs (1.45s)
--- PASS: TestAccCredentialIssuanceRule_Full (51.25s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 51.613s
```

### Testing Results - `resource/pingone_credential_type`
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccCredentialType_ github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccCredentialType_NewEnv
=== PAUSE TestAccCredentialType_NewEnv
=== RUN   TestAccCredentialType_Full
=== PAUSE TestAccCredentialType_Full
=== RUN   TestAccCredentialType_MetaData
=== PAUSE TestAccCredentialType_MetaData
=== RUN   TestAccCredentialType_CardDesignTemplate
=== PAUSE TestAccCredentialType_CardDesignTemplate
=== CONT  TestAccCredentialType_NewEnv
=== CONT  TestAccCredentialType_MetaData
=== CONT  TestAccCredentialType_Full
=== CONT  TestAccCredentialType_CardDesignTemplate
--- PASS: TestAccCredentialType_CardDesignTemplate (1.18s)
--- PASS: TestAccCredentialType_MetaData (1.38s)
--- PASS: TestAccCredentialType_NewEnv (7.70s)
--- PASS: TestAccCredentialType_Full (38.14s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 38.540s
```