### PR TITLE
Support p1verify and p1credentials notification templates.

### DIFF
--- a/.changelog/428.txt
+++ b/.changelog/428.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_notification_template_content`: Add support for P1Verify and P1Credentials notification templates: `email_phone_verification`, `id_verification`, `credential_issued`, `credential_updated`, `digital_wallet_pairing`, `credential_revoked`.
+```

--- a/docs/resources/notification_template_content.md
+++ b/docs/resources/notification_template_content.md
@@ -77,7 +77,7 @@ resource "pingone_notification_template_content" "voice" {
 
 - `environment_id` (String) The ID of the environment to manage notification template contents in.
 - `locale` (String) An ISO standard language code. For more information about standard language codes, see [ISO Language Code Table](http://www.lingoes.net/en/translator/langcode.htm).
-- `template_name` (String) The ID of the template to manage localised contents for.  Options are `email_verification_admin`, `email_verification_user`, `general`, `transaction`, `verification_code_template`, `recovery_code_template`, `device_pairing`, `strong_authentication`.
+- `template_name` (String) The ID of the template to manage localised contents for.  Options are `email_verification_admin`, `email_verification_user`, `general`, `transaction`, `verification_code_template`, `recovery_code_template`, `device_pairing`, `strong_authentication`, `email_phone_verification`, `id_verification`, `credential_issued`, `credential_updated`, `digital_wallet_pairing`, `credential_revoked`.
 
 ### Optional
 

--- a/internal/service/base/resource_notification_template_content.go
+++ b/internal/service/base/resource_notification_template_content.go
@@ -40,10 +40,10 @@ func ResourceNotificationTemplateContent() *schema.Resource {
 				ForceNew:         true,
 			},
 			"template_name": {
-				Description:      "The ID of the template to manage localised contents for.  Options are `email_verification_admin`, `email_verification_user`, `general`, `transaction`, `verification_code_template`, `recovery_code_template`, `device_pairing`, `strong_authentication`.",
+				Description:      "The ID of the template to manage localised contents for.  Options are `email_verification_admin`, `email_verification_user`, `general`, `transaction`, `verification_code_template`, `recovery_code_template`, `device_pairing`, `strong_authentication`, `email_phone_verification`, `id_verification`, `credential_issued`, `credential_updated`, `digital_wallet_pairing`, `credential_revoked`.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"email_verification_admin", "email_verification_user", "general", "transaction", "verification_code_template", "recovery_code_template", "device_pairing", "strong_authentication"}, false)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"email_verification_admin", "email_verification_user", "general", "transaction", "verification_code_template", "recovery_code_template", "device_pairing", "strong_authentication", "email_phone_verification", "id_verification", "credential_issued", "credential_updated", "digital_wallet_pairing", "credential_revoked"}, false)),
 				ForceNew:         true,
 			},
 			"locale": {

--- a/internal/service/base/resource_notification_template_content_test.go
+++ b/internal/service/base/resource_notification_template_content_test.go
@@ -310,7 +310,7 @@ func TestAccNotificationTemplateContent_InvalidData(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNotificationTemplateContentConfig_DefaultVariant_Push_Minimal(environmentName, licenseID, resourceName, name.Invalid, locale.Valid),
-				ExpectError: regexp.MustCompile(`expected template_name to be one of \[email_verification_admin email_verification_user general transaction verification_code_template recovery_code_template device_pairing strong_authentication\], got strong_authentication_doesnotexist`),
+				ExpectError: regexp.MustCompile(`expected template_name to be one of \[email_verification_admin email_verification_user general transaction verification_code_template recovery_code_template device_pairing strong_authentication email_phone_verification id_verification credential_issued credential_updated digital_wallet_pairing credential_revoked\], got strong_authentication_doesnotexist`),
 			},
 			{
 				Config:      testAccNotificationTemplateContentConfig_DefaultVariant_Push_Minimal(environmentName, licenseID, resourceName, name.Valid, locale.Invalid),


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
Support P1Verify and P1Credentials notification templates: `email_phone_verification`, `id_verification`, `credential_issued`, `credential_updated`, `digital_wallet_pairing`, `credential_revoked`.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->
For consistency, I stayed with the existing testing structure and did not introduce new tests specific to the P1Verify and P1Credentials notification templates, which are similar to other P1 notification templates.

However performed one-off tests to ensure templates were functional.  However, executed regression tests to ensure the general notification template testing remained successful.

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
for i in `cat internal/service/base/resource_notification_template_content_test.go | grep TestAccNotificationTemplateContent_ | cut -d'(' -f1 | cut -d' ' -f2`
do
  echo "Running test: $i"
  TF_LOG=INFO TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^"$i"$ github.com/pingidentity/terraform-provider-pingone/internal/service/base
done
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
% for i in `cat internal/service/base/resource_notification_template_content_test.go | grep TestAccNotificationTemplateContent_ | cut -d'(' -f1 | cut -d' ' -f2`
do
  echo "Running test: $i"
  TF_LOG=INFO TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^"$i"$ github.com/pingidentity/terraform-provider-pingone/internal/service/base
done
Running test: TestAccNotificationTemplateContent_OverrideDefaultLocale
=== RUN   TestAccNotificationTemplateContent_OverrideDefaultLocale
=== PAUSE TestAccNotificationTemplateContent_OverrideDefaultLocale
=== CONT  TestAccNotificationTemplateContent_OverrideDefaultLocale
--- PASS: TestAccNotificationTemplateContent_OverrideDefaultLocale (25.84s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        26.134s
Running test: TestAccNotificationTemplateContent_NewLocale
=== RUN   TestAccNotificationTemplateContent_NewLocale
=== PAUSE TestAccNotificationTemplateContent_NewLocale
=== CONT  TestAccNotificationTemplateContent_NewLocale
--- PASS: TestAccNotificationTemplateContent_NewLocale (36.94s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        37.246s
Running test: TestAccNotificationTemplateContent_NewVariant
=== RUN   TestAccNotificationTemplateContent_NewVariant
=== PAUSE TestAccNotificationTemplateContent_NewVariant
=== CONT  TestAccNotificationTemplateContent_NewVariant
--- PASS: TestAccNotificationTemplateContent_NewVariant (25.00s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        25.321s
Running test: TestAccNotificationTemplateContent_ChangeVariant
=== RUN   TestAccNotificationTemplateContent_ChangeVariant
=== PAUSE TestAccNotificationTemplateContent_ChangeVariant
=== CONT  TestAccNotificationTemplateContent_ChangeVariant
--- PASS: TestAccNotificationTemplateContent_ChangeVariant (44.74s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        45.069s
Running test: TestAccNotificationTemplateContent_InvalidData
=== RUN   TestAccNotificationTemplateContent_InvalidData
=== PAUSE TestAccNotificationTemplateContent_InvalidData
=== CONT  TestAccNotificationTemplateContent_InvalidData
--- PASS: TestAccNotificationTemplateContent_InvalidData (8.39s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        8.713s
Running test: TestAccNotificationTemplateContent_Email
=== RUN   TestAccNotificationTemplateContent_Email
=== PAUSE TestAccNotificationTemplateContent_Email
=== CONT  TestAccNotificationTemplateContent_Email
--- PASS: TestAccNotificationTemplateContent_Email (54.57s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        54.896s
Running test: TestAccNotificationTemplateContent_Push
=== RUN   TestAccNotificationTemplateContent_Push
=== PAUSE TestAccNotificationTemplateContent_Push
=== CONT  TestAccNotificationTemplateContent_Push
--- PASS: TestAccNotificationTemplateContent_Push (63.19s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        63.517s
Running test: TestAccNotificationTemplateContent_SMS
=== RUN   TestAccNotificationTemplateContent_SMS
=== PAUSE TestAccNotificationTemplateContent_SMS
=== CONT  TestAccNotificationTemplateContent_SMS
--- PASS: TestAccNotificationTemplateContent_SMS (61.03s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        61.343s
Running test: TestAccNotificationTemplateContent_Voice
=== RUN   TestAccNotificationTemplateContent_Voice
=== PAUSE TestAccNotificationTemplateContent_Voice
=== CONT  TestAccNotificationTemplateContent_Voice
--- PASS: TestAccNotificationTemplateContent_Voice (65.36s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        65.633s
```