### PR TITLE
Add validators to list blocks to prevent multiple single-object configurations

### DIFF
--- a/.changelog/440.txt
+++ b/.changelog/440.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/pingone_branding_theme`: Added missing schema validators to prevent misconfiguration of the single-object `background_image` and `logo` blocks.
+```
+
+```release-note:bug
+`resource/pingone_branding_settings`: Added missing schema validators to prevent misconfiguration of the single-object `logo_image` block.
+```

--- a/docs/resources/branding_settings.md
+++ b/docs/resources/branding_settings.md
@@ -44,7 +44,7 @@ resource "pingone_branding_settings" "branding" {
 ### Optional
 
 - `company_name` (String) The company name associated with the specified environment.
-- `logo_image` (Block List) The HREF and the ID for the company logo. (see [below for nested schema](#nestedblock--logo_image))
+- `logo_image` (Block List) A single block that specifies the HREF and ID for the company logo. (see [below for nested schema](#nestedblock--logo_image))
 
 ### Read-Only
 

--- a/docs/resources/branding_theme.md
+++ b/docs/resources/branding_theme.md
@@ -71,9 +71,9 @@ resource "pingone_branding_theme" "my_awesome_theme" {
 ### Optional
 
 - `background_color` (String) The background color for the theme. It must be a valid hexadecimal color code.  At least one of the following must be defined: `background_image`, `background_color`, `use_default_background`.
-- `background_image` (Block List) The HREF and the ID for the background image.  At least one of the following must be defined: `background_image`, `background_color`, `use_default_background`. (see [below for nested schema](#nestedblock--background_image))
+- `background_image` (Block List) A single block that specifies the HREF and ID for the background image.  At least one of the following must be defined: `background_image`, `background_color`, `use_default_background`. (see [below for nested schema](#nestedblock--background_image))
 - `footer_text` (String) The text to be displayed in the footer of the branding theme.
-- `logo` (Block List) The HREF and the ID for the company logo, for this branding template.  If not set, the environment's default logo (set with the `pingone_branding_settings` resource) will be applied. (see [below for nested schema](#nestedblock--logo))
+- `logo` (Block List) A single block that specifies the HREF and ID for the company logo, for this branding template.  If not set, the environment's default logo (set with the `pingone_branding_settings` resource) will be applied. (see [below for nested schema](#nestedblock--logo))
 - `use_default_background` (Boolean) A boolean to specify that the background should be set to the theme template's default.  At least one of the following must be defined: `background_image`, `background_color`, `use_default_background`.
 
 ### Read-Only

--- a/internal/service/base/resource_branding_settings.go
+++ b/internal/service/base/resource_branding_settings.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -101,7 +102,7 @@ func (r *BrandingSettingsResource) Schema(ctx context.Context, req resource.Sche
 		Blocks: map[string]schema.Block{
 
 			"logo_image": schema.ListNestedBlock{
-				Description: framework.SchemaAttributeDescriptionFromMarkdown("The HREF and the ID for the company logo.").Description,
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies the HREF and ID for the company logo.").Description,
 
 				NestedObject: schema.NestedBlockObject{
 
@@ -125,6 +126,10 @@ func (r *BrandingSettingsResource) Schema(ctx context.Context, req resource.Sche
 							},
 						},
 					},
+				},
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
 				},
 			},
 		},

--- a/internal/service/base/resource_branding_theme.go
+++ b/internal/service/base/resource_branding_theme.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -91,11 +92,11 @@ func (r *BrandingThemeResource) Schema(ctx context.Context, req resource.SchemaR
 	).ExactlyOneOf(backgroundExactlyOneOfRelativePaths)
 
 	backgroundImageDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"The HREF and the ID for the background image.",
+		"A single block that specifies the HREF and ID for the background image.",
 	).ExactlyOneOf(backgroundExactlyOneOfRelativePaths)
 
 	logoDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"The HREF and the ID for the company logo, for this branding template.  If not set, the environment's default logo (set with the `pingone_branding_settings` resource) will be applied.",
+		"A single block that specifies the HREF and ID for the company logo, for this branding template.  If not set, the environment's default logo (set with the `pingone_branding_settings` resource) will be applied.",
 	)
 
 	logoIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -264,6 +265,10 @@ func (r *BrandingThemeResource) Schema(ctx context.Context, req resource.SchemaR
 						},
 					},
 				},
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
 			},
 
 			"background_image": schema.ListNestedBlock{
@@ -292,6 +297,10 @@ func (r *BrandingThemeResource) Schema(ctx context.Context, req resource.SchemaR
 							},
 						},
 					},
+				},
+
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
 				},
 			},
 		},


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* `resource/pingone_branding_theme`: Added missing schema validators to prevent misconfiguration of the single-object `background_image` and `logo` blocks.
* `resource/pingone_branding_settings`: Added missing schema validators to prevent misconfiguration of the single-object `logo_image` block.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccBranding github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccBrandingSettings_Full
=== PAUSE TestAccBrandingSettings_Full
=== RUN   TestAccBrandingSettings_Minimal1
=== PAUSE TestAccBrandingSettings_Minimal1
=== RUN   TestAccBrandingSettings_Minimal2
=== PAUSE TestAccBrandingSettings_Minimal2
=== RUN   TestAccBrandingSettings_Minimal3
=== PAUSE TestAccBrandingSettings_Minimal3
=== RUN   TestAccBrandingSettings_Change
=== PAUSE TestAccBrandingSettings_Change
=== RUN   TestAccBrandingThemeDefault_Full
=== PAUSE TestAccBrandingThemeDefault_Full
=== RUN   TestAccBrandingTheme_NewEnv
=== PAUSE TestAccBrandingTheme_NewEnv
=== RUN   TestAccBrandingTheme_Full
=== PAUSE TestAccBrandingTheme_Full
=== RUN   TestAccBrandingTheme_Minimal
=== PAUSE TestAccBrandingTheme_Minimal
=== RUN   TestAccBrandingTheme_Change
=== PAUSE TestAccBrandingTheme_Change
=== CONT  TestAccBrandingSettings_Full
=== CONT  TestAccBrandingThemeDefault_Full
=== CONT  TestAccBrandingTheme_Minimal
=== CONT  TestAccBrandingTheme_Change
=== CONT  TestAccBrandingTheme_Full
=== CONT  TestAccBrandingTheme_NewEnv
=== CONT  TestAccBrandingSettings_Minimal3
=== CONT  TestAccBrandingSettings_Change
=== CONT  TestAccBrandingSettings_Minimal2
=== CONT  TestAccBrandingSettings_Minimal1
--- PASS: TestAccBrandingTheme_Minimal (8.64s)
--- PASS: TestAccBrandingTheme_NewEnv (9.59s)
--- PASS: TestAccBrandingSettings_Minimal1 (10.01s)
--- PASS: TestAccBrandingThemeDefault_Full (10.04s)
--- PASS: TestAccBrandingSettings_Minimal2 (10.16s)
--- PASS: TestAccBrandingTheme_Full (11.75s)
--- PASS: TestAccBrandingSettings_Full (12.04s)
--- PASS: TestAccBrandingSettings_Minimal3 (12.22s)
--- PASS: TestAccBrandingTheme_Change (25.74s)
--- PASS: TestAccBrandingSettings_Change (38.64s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        39.108s
```