### PR TITLE
Changed "Risk" documentation subcategory to "Protect", for the release of PingOne Protect

### DIFF
--- a/.changelog/452.txt
+++ b/.changelog/452.txt
@@ -1,0 +1,3 @@
+```release-note:note
+Changed "Risk" documentation subcategory to "Protect", for the release of PingOne Protect.
+```

--- a/docs/resources/risk_policy.md
+++ b/docs/resources/risk_policy.md
@@ -1,6 +1,6 @@
 ---
 page_title: "pingone_risk_policy Resource - terraform-provider-pingone"
-subcategory: "Risk"
+subcategory: "Protect"
 description: |-
   Resource to manage Risk policies in a PingOne environment.
 ---

--- a/docs/resources/risk_predictor.md
+++ b/docs/resources/risk_predictor.md
@@ -1,6 +1,6 @@
 ---
 page_title: "pingone_risk_predictor Resource - terraform-provider-pingone"
-subcategory: "Risk"
+subcategory: "Protect"
 description: |-
   Resource to manage Risk predictors in a PingOne environment.
 ---

--- a/templates/resources/risk_policy.md.tmpl
+++ b/templates/resources/risk_policy.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.RenderedProviderName}}"
-subcategory: "Risk"
+subcategory: "Protect"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---

--- a/templates/resources/risk_predictor.md.tmpl
+++ b/templates/resources/risk_predictor.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.RenderedProviderName}}"
-subcategory: "Risk"
+subcategory: "Protect"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Changed "Risk" documentation subcategory to "Protect", for the release of PingOne Protect.
