### PR TITLE
`pingone_application_resource_grant`: Add validation to disallow assignment of the `openid` scope from the `openid` resource to avoid error.

### DIFF
--- a/.changelog/457.txt
+++ b/.changelog/457.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_application_resource_grant`: Add validation to disallow assignment of the `openid` scope from the `openid` resource to avoid error.
+```

--- a/docs/resources/application_resource_grant.md
+++ b/docs/resources/application_resource_grant.md
@@ -55,7 +55,7 @@ resource "pingone_application_resource_grant" "foo" {
 - `application_id` (String) The ID of the application to create the resource grant for.  The value for `application_id` may come from the `id` attribute of the `pingone_application` or `pingone_system_application` resources or data sources.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `environment_id` (String) The ID of the environment to create the application resource grant in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `resource_id` (String) The ID of the protected resource associated with this grant.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
-- `scopes` (Set of String) A list of IDs of the scopes associated with this grant.
+- `scopes` (Set of String) A list of IDs of the scopes associated with this grant.  When using the "openid" resource, the "openid" scope should not be included.
 
 ### Read-Only
 

--- a/internal/service/sso/resource_application_resource_grant_test.go
+++ b/internal/service/sso/resource_application_resource_grant_test.go
@@ -282,11 +282,11 @@ data "pingone_resource_scope" "%[2]s-2" {
 }
 
 data "pingone_resource_scope" "%[2]s-3" {
-	environment_id = data.pingone_environment.general_test.id
-	resource_id    = data.pingone_resource.%[2]s.id
-  
-	name = "openid"
-  }
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = data.pingone_resource.%[2]s.id
+
+  name = "openid"
+}
 
 resource "pingone_application_resource_grant" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id

--- a/internal/service/sso/resource_application_resource_grant_test.go
+++ b/internal/service/sso/resource_application_resource_grant_test.go
@@ -3,6 +3,7 @@ package sso_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -89,6 +90,20 @@ func TestAccApplicationResourceGrant_OpenIDResource(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "scopes.0", verify.P1ResourceIDRegexp),
 					resource.TestMatchResourceAttr(resourceFullName, "scopes.1", verify.P1ResourceIDRegexp),
 				),
+			},
+			// Test error catch on update
+			{
+				Config:      testAccApplicationResourceGrantConfig_OpenIDResource_InvalidOpenIDScope(resourceName, name),
+				ExpectError: regexp.MustCompile(`Invalid scope`),
+			},
+			{
+				Config:  testAccApplicationResourceGrantConfig_OpenIDResource(resourceName, name),
+				Destroy: true,
+			},
+			// Test error catch on from new
+			{
+				Config:      testAccApplicationResourceGrantConfig_OpenIDResource_InvalidOpenIDScope(resourceName, name),
+				ExpectError: regexp.MustCompile(`Invalid scope`),
 			},
 		},
 	})
@@ -223,6 +238,65 @@ resource "pingone_application_resource_grant" "%[2]s" {
   scopes = [
     data.pingone_resource_scope.%[2]s-1.id,
     data.pingone_resource_scope.%[2]s-2.id,
+  ]
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccApplicationResourceGrantConfig_OpenIDResource_InvalidOpenIDScope(resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "SINGLE_PAGE_APP"
+    grant_types                 = ["AUTHORIZATION_CODE"]
+    response_types              = ["CODE"]
+    pkce_enforcement            = "S256_REQUIRED"
+    token_endpoint_authn_method = "NONE"
+    redirect_uris               = ["https://www.pingidentity.com"]
+  }
+}
+
+data "pingone_resource" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "openid"
+}
+
+data "pingone_resource_scope" "%[2]s-1" {
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = data.pingone_resource.%[2]s.id
+
+  name = "email"
+}
+
+data "pingone_resource_scope" "%[2]s-2" {
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = data.pingone_resource.%[2]s.id
+
+  name = "profile"
+}
+
+data "pingone_resource_scope" "%[2]s-3" {
+	environment_id = data.pingone_environment.general_test.id
+	resource_id    = data.pingone_resource.%[2]s.id
+  
+	name = "openid"
+  }
+
+resource "pingone_application_resource_grant" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = pingone_application.%[2]s.id
+
+  resource_id = data.pingone_resource.%[2]s.id
+  scopes = [
+    data.pingone_resource_scope.%[2]s-1.id,
+    data.pingone_resource_scope.%[2]s-2.id,
+    data.pingone_resource_scope.%[2]s-3.id,
   ]
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* `pingone_application_resource_grant`: Add validation to disallow assignment of the `openid` scope from the `openid` resource to avoid error.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 240s -run ^TestAccApplicationResourceGrant_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccApplicationResourceGrant_OpenIDResource
=== PAUSE TestAccApplicationResourceGrant_OpenIDResource
=== RUN   TestAccApplicationResourceGrant_CustomResource
=== PAUSE TestAccApplicationResourceGrant_CustomResource
=== RUN   TestAccApplicationResourceGrant_Change
=== PAUSE TestAccApplicationResourceGrant_Change
=== CONT  TestAccApplicationResourceGrant_OpenIDResource
=== CONT  TestAccApplicationResourceGrant_Change
=== CONT  TestAccApplicationResourceGrant_CustomResource
--- PASS: TestAccApplicationResourceGrant_CustomResource (8.13s)
--- PASS: TestAccApplicationResourceGrant_OpenIDResource (17.03s)
--- PASS: TestAccApplicationResourceGrant_Change (19.18s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 19.625s
```