### PR TITLE
Support country limit on `pingone_notification_policy` resource

### DIFF
--- a/.changelog/458.txt
+++ b/.changelog/458.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_notification_policy`: Now supports country limit configuration.
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -71,7 +71,7 @@ resource "pingone_notification_policy" "user" {
 
 ### Optional
 
-- `country_limit` (Attributes) A single block object to limit the countries where you can send SMS and voice notifications. (see [below for nested schema](#nestedatt--country_limit))
+- `country_limit` (Attributes) A single object to limit the countries where you can send SMS and voice notifications. (see [below for nested schema](#nestedatt--country_limit))
 - `quota` (Block List) A single object block that define the SMS/Voice limits. (see [below for nested schema](#nestedblock--quota))
 
 ### Read-Only

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -71,6 +71,7 @@ resource "pingone_notification_policy" "user" {
 
 ### Optional
 
+- `country_limit` (Attributes) A single block object to limit the countries where you can send SMS and voice notifications. (see [below for nested schema](#nestedatt--country_limit))
 - `quota` (Block List) A single object block that define the SMS/Voice limits. (see [below for nested schema](#nestedblock--quota))
 
 ### Read-Only
@@ -78,12 +79,25 @@ resource "pingone_notification_policy" "user" {
 - `default` (Boolean) A boolean to provide an indication of whether this policy is the default notification policy for the environment. If the parameter is not provided, the value used is `false`.
 - `id` (String) The ID of this resource.
 
+<a id="nestedatt--country_limit"></a>
+### Nested Schema for `country_limit`
+
+Required:
+
+- `type` (String) A string that specifies the kind of limitation being defined.  Options are `ALLOWED` (allows notifications only for the countries specified in the `countries` parameter), `DENIED` (denies notifications only for the countries specified in the `countries` parameter), `NONE` (no limitation is defined).
+
+Optional:
+
+- `countries` (Set of String) The countries where the specified methods should be allowed or denied. Use two-letter country codes from ISO 3166-1.  Required when `type` is not `NONE`.
+- `delivery_methods` (Set of String) The delivery methods that the defined limitation should be applied to. Content of the array can be `SMS`, `Voice`, or both. If the parameter is not provided, the default is `SMS` and `Voice`.
+
+
 <a id="nestedblock--quota"></a>
 ### Nested Schema for `quota`
 
 Required:
 
-- `type` (String) A string to specify whether the limit defined is per-user or per environment. Allowed values: `USER`, `ENVIRONMENT`.
+- `type` (String) A string to specify whether the limit defined is per-user or per environment.  Options are `ENVIRONMENT`, `USER`.
 
 Optional:
 

--- a/internal/service/base/resource_notification_policy.go
+++ b/internal/service/base/resource_notification_policy.go
@@ -109,7 +109,7 @@ func (r *NotificationPolicyResource) Schema(ctx context.Context, req resource.Sc
 	)
 
 	countryLimitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"A single block object to limit the countries where you can send SMS and voice notifications.",
+		"A single object to limit the countries where you can send SMS and voice notifications.",
 	)
 
 	countryLimitTypeDescription := framework.SchemaAttributeDescriptionFromMarkdown(


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* `resource/pingone_notification_policy`: Now supports country limit configuration.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 240s -run ^TestAccNotificationPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccNotificationPolicy_NewEnv
=== PAUSE TestAccNotificationPolicy_NewEnv
=== RUN   TestAccNotificationPolicy_Full
=== PAUSE TestAccNotificationPolicy_Full
=== RUN   TestAccNotificationPolicy_Quotas
=== PAUSE TestAccNotificationPolicy_Quotas
=== RUN   TestAccNotificationPolicy_CountryLimit
=== PAUSE TestAccNotificationPolicy_CountryLimit
=== CONT  TestAccNotificationPolicy_NewEnv
=== CONT  TestAccNotificationPolicy_Quotas
=== CONT  TestAccNotificationPolicy_Full
=== CONT  TestAccNotificationPolicy_CountryLimit
--- PASS: TestAccNotificationPolicy_NewEnv (8.35s)
--- PASS: TestAccNotificationPolicy_Full (42.08s)
--- PASS: TestAccNotificationPolicy_Quotas (47.79s)
--- PASS: TestAccNotificationPolicy_CountryLimit (53.43s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        53.770s
```