### PR TITLE
Optimise environment data source filtering by name

### DIFF
--- a/.changelog/469.txt
+++ b/.changelog/469.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`data-source/pingone_environment`: Optimised environment filtering by name.
+```

--- a/internal/service/base/data_source_environment.go
+++ b/internal/service/base/data_source_environment.go
@@ -233,13 +233,15 @@ func (r *EnvironmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	if !data.Name.IsNull() {
 
+		scimFilter := fmt.Sprintf("name sw \"%s\"", data.Name.ValueString())
+
 		// Run the API call
 		var entityArray *management.EntityArray
 		resp.Diagnostics.Append(framework.ParseResponse(
 			ctx,
 
 			func() (any, *http.Response, error) {
-				return r.client.EnvironmentsApi.ReadAllEnvironments(ctx).Execute()
+				return r.client.EnvironmentsApi.ReadAllEnvironments(ctx).Filter(scimFilter).Execute()
 			},
 			"ReadAllEnvironments",
 			framework.DefaultCustomError,


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* `data-source/pingone_environment`: Optimised environment filtering by name.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 360s -run ^TestAccEnvironmentDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccEnvironmentDataSource_ByNameFull
=== PAUSE TestAccEnvironmentDataSource_ByNameFull
=== RUN   TestAccEnvironmentDataSource_ByNameMinimal
=== PAUSE TestAccEnvironmentDataSource_ByNameMinimal
=== RUN   TestAccEnvironmentDataSource_ByIDFull
=== PAUSE TestAccEnvironmentDataSource_ByIDFull
=== RUN   TestAccEnvironmentDataSource_ByIDMinimal
=== PAUSE TestAccEnvironmentDataSource_ByIDMinimal
=== RUN   TestAccEnvironmentDataSource_NotFound
=== PAUSE TestAccEnvironmentDataSource_NotFound
=== CONT  TestAccEnvironmentDataSource_ByNameFull
=== CONT  TestAccEnvironmentDataSource_ByIDMinimal
=== CONT  TestAccEnvironmentDataSource_ByIDFull
=== CONT  TestAccEnvironmentDataSource_ByNameMinimal
=== CONT  TestAccEnvironmentDataSource_NotFound
--- PASS: TestAccEnvironmentDataSource_NotFound (1.70s)
--- PASS: TestAccEnvironmentDataSource_ByNameMinimal (9.09s)
--- PASS: TestAccEnvironmentDataSource_ByIDMinimal (9.11s)
--- PASS: TestAccEnvironmentDataSource_ByNameFull (9.21s)
--- PASS: TestAccEnvironmentDataSource_ByIDFull (9.79s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        10.181s
```