### PR TITLE
Support `ip_address_exposed` and `useragent_exposed` in `filter_options` in `pingone_webhook.`

### DIFF
--- a/.changelog/470.txt
+++ b/.changelog/470.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_webhook`: Now supports ip address exposed and useragent exposed in filter option configuration.
+```

--- a/.changelog/470.txt
+++ b/.changelog/470.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-`resource/pingone_webhook`: Now supports ip address exposed and useragent exposed in filter option configuration.
+`resource/pingone_webhook`: Now supports `ip_address_exposed` and `useragent_exposed` in filter options configuration.
 ```

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -70,6 +70,8 @@ Optional:
 - `included_application_ids` (Set of String) An array that specifies the list of applications (by ID) whose events are monitored by the webhook (maximum of 10 IDs in the array). If a list of applications is not provided, events are monitored for all applications in the environment.
 - `included_population_ids` (Set of String) An array that specifies the list of populations (by ID) whose events are monitored by the webhook (maximum of 10 IDs in the array). This property matches events for users in the specified populations, as opposed to events generated in which the user in one of the populations is the actor.
 - `included_tags` (Set of String) An array of tags that events must have to be monitored by the webhook. If tags are not specified, all events are monitored. Currently, the available tags are `adminIdentityEvent`. Identifies the event as the action of an administrator on other administrators.
+- `ip_address_exposed` (Boolean) A boolean that specifies whether the IP address of an actor should be present in the source section of the event. Defaults to `false`.
+- `useragent_exposed` (Boolean) A boolean that specifies whether the User-Agent HTTP header of an event should be present in the source section of the event. Defaults to `false`.
 
 ## Import
 

--- a/internal/service/base/resource_webhook.go
+++ b/internal/service/base/resource_webhook.go
@@ -119,6 +119,18 @@ func ResourceWebhook() *schema.Resource {
 								ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(management.ENUMSUBSCRIPTIONFILTERINCLUDEDTAGS_ADMIN_IDENTITY_EVENT)}, false)),
 							},
 						},
+						"ip_address_exposed": {
+							Description: "A boolean that specifies whether the IP address of an actor should be present in the source section of the event.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
+						"useragent_exposed": {
+							Description: "A boolean that specifies whether the User-Agent HTTP header of an event should be present in the source section of the event.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+						},
 					},
 				},
 			},
@@ -348,6 +360,14 @@ func expandWebhookFilterOptions(c []interface{}) (*management.SubscriptionFilter
 		returnVar.SetIncludedTags(objList)
 	}
 
+	if v, ok := obj["ip_address_exposed"]; ok && v != nil {
+		returnVar.SetIpAddressExposed(v.(bool))
+	}
+
+	if v, ok := obj["useragent_exposed"]; ok && v != nil {
+		returnVar.SetUserAgentExposed(v.(bool))
+	}
+
 	return returnVar, diags
 }
 
@@ -388,6 +408,18 @@ func flattenWebhookFilterOptions(subscriptionFilterOptions management.Subscripti
 		}
 
 		item["included_tags"] = list
+	}
+
+	if v, ok := subscriptionFilterOptions.GetIpAddressExposedOk(); ok {
+		item["ip_address_exposed"] = v
+	} else {
+		item["ip_address_exposed"] = nil
+	}
+
+	if v, ok := subscriptionFilterOptions.GetUserAgentExposedOk(); ok {
+		item["useragent_exposed"] = v
+	} else {
+		item["useragent_exposed"] = nil
 	}
 
 	return append(make([]interface{}, 0), item)

--- a/internal/service/base/resource_webhook_test.go
+++ b/internal/service/base/resource_webhook_test.go
@@ -136,6 +136,8 @@ func TestAccWebhook_Full(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.2", verify.P1ResourceIDRegexp),
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_tags.*", "adminIdentityEvent"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "true"),
 				),
 			},
 		},
@@ -174,6 +176,8 @@ func TestAccWebhook_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "false"),
 				),
 			},
 		},
@@ -221,6 +225,8 @@ func TestAccWebhook_Change(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.2", verify.P1ResourceIDRegexp),
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_tags.*", "adminIdentityEvent"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "true"),
 				),
 			},
 			{
@@ -241,6 +247,8 @@ func TestAccWebhook_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "false"),
 				),
 			},
 			{
@@ -270,6 +278,8 @@ func TestAccWebhook_Change(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.2", verify.P1ResourceIDRegexp),
 					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_tags.*", "adminIdentityEvent"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "true"),
 				),
 			},
 		},
@@ -453,6 +463,8 @@ resource "pingone_webhook" "%[2]s" {
     included_application_ids = [pingone_application.%[3]s-2.id, pingone_application.%[3]s-3.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-2.id, pingone_population.%[3]s-3.id, pingone_population.%[3]s-1.id]
     included_tags            = ["adminIdentityEvent"]
+	ip_address_exposed       = true
+	useragent_exposed        = true	
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
@@ -555,6 +567,8 @@ resource "pingone_webhook" "%[2]s" {
     included_action_types    = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
     included_application_ids = [pingone_application.%[3]s-2.id, pingone_application.%[3]s-3.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-2.id, pingone_population.%[3]s-3.id, pingone_population.%[3]s-1.id]
+	ip_address_exposed       = true
+	useragent_exposed        = false	
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
@@ -618,6 +632,8 @@ resource "pingone_webhook" "%[2]s" {
     included_action_types    = ["ACCOUNT.LINKED"]
     included_application_ids = [pingone_application.%[3]s-new.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-new.id, pingone_population.%[3]s-1.id]
+	ip_address_exposed       = false
+	useragent_exposed        = true	
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }

--- a/internal/service/base/resource_webhook_test.go
+++ b/internal/service/base/resource_webhook_test.go
@@ -463,8 +463,8 @@ resource "pingone_webhook" "%[2]s" {
     included_application_ids = [pingone_application.%[3]s-2.id, pingone_application.%[3]s-3.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-2.id, pingone_population.%[3]s-3.id, pingone_population.%[3]s-1.id]
     included_tags            = ["adminIdentityEvent"]
-	ip_address_exposed       = true
-	useragent_exposed        = true	
+    ip_address_exposed       = true
+    useragent_exposed        = true
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
@@ -567,8 +567,8 @@ resource "pingone_webhook" "%[2]s" {
     included_action_types    = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
     included_application_ids = [pingone_application.%[3]s-2.id, pingone_application.%[3]s-3.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-2.id, pingone_population.%[3]s-3.id, pingone_population.%[3]s-1.id]
-	ip_address_exposed       = true
-	useragent_exposed        = false	
+    ip_address_exposed       = true
+    useragent_exposed        = false
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
@@ -632,8 +632,8 @@ resource "pingone_webhook" "%[2]s" {
     included_action_types    = ["ACCOUNT.LINKED"]
     included_application_ids = [pingone_application.%[3]s-new.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-new.id, pingone_population.%[3]s-1.id]
-	ip_address_exposed       = false
-	useragent_exposed        = true	
+    ip_address_exposed       = false
+    useragent_exposed        = true
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
`resource/pingone_webhook`: Now supports ip address exposed and useragent exposed in filter option configuration.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 360s -run ^TestAccWebhook_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccWebhook_NewEnv
=== PAUSE TestAccWebhook_NewEnv
=== RUN   TestAccWebhook_Full
=== PAUSE TestAccWebhook_Full
=== RUN   TestAccWebhook_Minimal
=== PAUSE TestAccWebhook_Minimal
=== RUN   TestAccWebhook_Change
=== PAUSE TestAccWebhook_Change
=== RUN   TestAccWebhook_Applications
=== PAUSE TestAccWebhook_Applications
=== RUN   TestAccWebhook_Populations
=== PAUSE TestAccWebhook_Populations
=== CONT  TestAccWebhook_NewEnv
=== CONT  TestAccWebhook_Applications
=== CONT  TestAccWebhook_Populations
=== CONT  TestAccWebhook_Minimal
=== CONT  TestAccWebhook_Change
=== CONT  TestAccWebhook_Full
--- PASS: TestAccWebhook_Full (9.80s)
--- PASS: TestAccWebhook_Minimal (10.67s)
--- PASS: TestAccWebhook_Populations (15.71s)
--- PASS: TestAccWebhook_Applications (16.71s)
--- PASS: TestAccWebhook_Change (22.16s)
--- PASS: TestAccWebhook_NewEnv (23.10s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        23.562s
```
