### PR TITLE
Fix defect which triggers an error if optional SAML slo_window value is undefined.

### DIFF
--- a/.changelog/472.txt
+++ b/.changelog/472.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/pingone_application`: Resolved error condition if optional `slo_window` value in the `saml_options` block was undefined.
+```
+
+```release-note:bug
+`resource/pingone_identity_provider`: Resolved error condition if optional `slo_window` value in the `saml` block was undefined.
+```

--- a/.changelog/472.txt
+++ b/.changelog/472.txt
@@ -1,7 +1,0 @@
-```release-note:bug
-`resource/pingone_application`: Resolved error condition if optional `slo_window` value in the `saml_options` block was undefined.
-```
-
-```release-note:bug
-`resource/pingone_identity_provider`: Resolved error condition if optional `slo_window` value in the `saml` block was undefined.
-```

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -2008,7 +2008,7 @@ func flattenSAMLOptions(application *management.ApplicationSAML) interface{} {
 		item["slo_response_endpoint"] = nil
 	}
 
-	if v, ok := application.GetSloWindowOk(); ok && *v > 0 {
+	if v, ok := application.GetSloWindowOk(); ok {
 		item["slo_window"] = v
 	} else {
 		item["slo_window"] = nil

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -1527,7 +1527,7 @@ func expandApplicationSAML(d *schema.ResourceData) (*management.ApplicationSAML,
 			application.SetSloResponseEndpoint(v1)
 		}
 
-		if v1, ok := samlOptions["slo_window"].(int); ok {
+		if v1, ok := samlOptions["slo_window"].(int); ok && v1 > 0 {
 			application.SetSloWindow(int32(v1))
 		}
 
@@ -2008,7 +2008,7 @@ func flattenSAMLOptions(application *management.ApplicationSAML) interface{} {
 		item["slo_response_endpoint"] = nil
 	}
 
-	if v, ok := application.GetSloWindowOk(); ok {
+	if v, ok := application.GetSloWindowOk(); ok && *v > 0 {
 		item["slo_window"] = v
 	} else {
 		item["slo_window"] = nil

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -2457,7 +2457,7 @@ func TestAccApplication_SAMLMinimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.slo_binding", "HTTP_POST"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.slo_endpoint", ""),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.slo_response_endpoint", ""),
-					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.slo_window", ""),
+					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.slo_window", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.sp_entity_id", fmt.Sprintf("sp:entity:%s", resourceName)),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.sp_verification_certificate_ids.#", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "hidden_from_app_portal", "false"),

--- a/internal/service/sso/resource_identity_provider.go
+++ b/internal/service/sso/resource_identity_provider.go
@@ -1228,7 +1228,7 @@ func expandIdPSAML(v []interface{}, common management.IdentityProviderCommon) (*
 			idpObj.SetSloResponseEndpoint(v1)
 		}
 
-		if v1, ok := idp["slo_window"].(int); ok {
+		if v1, ok := idp["slo_window"].(int); ok && v1 > 0 {
 			idpObj.SetSloWindow(int32(v1))
 		}
 

--- a/internal/service/sso/resource_identity_provider_test.go
+++ b/internal/service/sso/resource_identity_provider_test.go
@@ -1010,7 +1010,7 @@ func TestAccIdentityProvider_SAML(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_binding", ""),
 					resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_endpoint", ""),
 					resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_response_endpoint", ""),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_window", ""),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_window", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

`resource/pingone_application`: Resolved error condition if optional `slo_window` value in the `saml_options` block was undefined.

`resource/pingone_identity_provider`: Resolved error condition if optional `slo_window` value in the `saml` block was undefined.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->
NOTE: All germane application tests were successful. The failed tests re: google signing-key and missing workforce environment are unrelated to the SAML `slo_window` changes and only relevant to missing, unrelated test environment configurations.

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccIdentityProvider_  github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccApplication_  github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccIdentityProvider_NewEnv
=== PAUSE TestAccIdentityProvider_NewEnv
=== RUN   TestAccIdentityProvider_Full
=== PAUSE TestAccIdentityProvider_Full
=== RUN   TestAccIdentityProvider_Minimal
=== PAUSE TestAccIdentityProvider_Minimal
=== RUN   TestAccIdentityProvider_Change
=== PAUSE TestAccIdentityProvider_Change
=== RUN   TestAccIdentityProvider_Facebook
=== PAUSE TestAccIdentityProvider_Facebook
=== RUN   TestAccIdentityProvider_Google
=== PAUSE TestAccIdentityProvider_Google
=== RUN   TestAccIdentityProvider_LinkedIn
=== PAUSE TestAccIdentityProvider_LinkedIn
=== RUN   TestAccIdentityProvider_Yahoo
=== PAUSE TestAccIdentityProvider_Yahoo
=== RUN   TestAccIdentityProvider_Amazon
=== PAUSE TestAccIdentityProvider_Amazon
=== RUN   TestAccIdentityProvider_Twitter
=== PAUSE TestAccIdentityProvider_Twitter
=== RUN   TestAccIdentityProvider_Apple
=== PAUSE TestAccIdentityProvider_Apple
=== RUN   TestAccIdentityProvider_Paypal
=== PAUSE TestAccIdentityProvider_Paypal
=== RUN   TestAccIdentityProvider_Microsoft
=== PAUSE TestAccIdentityProvider_Microsoft
=== RUN   TestAccIdentityProvider_Github
=== PAUSE TestAccIdentityProvider_Github
=== RUN   TestAccIdentityProvider_OIDC
=== PAUSE TestAccIdentityProvider_OIDC
=== RUN   TestAccIdentityProvider_SAML
=== PAUSE TestAccIdentityProvider_SAML
=== RUN   TestAccIdentityProvider_ChangeProvider
=== PAUSE TestAccIdentityProvider_ChangeProvider
=== CONT  TestAccIdentityProvider_NewEnv
=== CONT  TestAccIdentityProvider_Github
=== CONT  TestAccIdentityProvider_Twitter
=== CONT  TestAccIdentityProvider_SAML
=== CONT  TestAccIdentityProvider_OIDC
=== CONT  TestAccIdentityProvider_Google
=== CONT  TestAccIdentityProvider_Paypal
=== CONT  TestAccIdentityProvider_ChangeProvider
=== CONT  TestAccIdentityProvider_Change
=== CONT  TestAccIdentityProvider_Facebook
=== NAME  TestAccIdentityProvider_SAML
    resource_identity_provider_test.go:955: Test to be re-defined
--- SKIP: TestAccIdentityProvider_SAML (0.00s)
=== CONT  TestAccIdentityProvider_Minimal
--- PASS: TestAccIdentityProvider_Minimal (5.60s)
=== CONT  TestAccIdentityProvider_Full
--- PASS: TestAccIdentityProvider_NewEnv (6.83s)
=== CONT  TestAccIdentityProvider_Microsoft
--- PASS: TestAccIdentityProvider_Facebook (8.34s)
=== CONT  TestAccIdentityProvider_Yahoo
--- PASS: TestAccIdentityProvider_Twitter (8.49s)
=== CONT  TestAccIdentityProvider_Amazon
--- PASS: TestAccIdentityProvider_Github (8.51s)
=== CONT  TestAccIdentityProvider_LinkedIn
--- PASS: TestAccIdentityProvider_Paypal (8.54s)
=== CONT  TestAccIdentityProvider_Apple
--- PASS: TestAccIdentityProvider_Google (8.59s)
--- PASS: TestAccIdentityProvider_ChangeProvider (8.69s)
--- PASS: TestAccIdentityProvider_Full (4.67s)
--- PASS: TestAccIdentityProvider_Microsoft (7.52s)
--- PASS: TestAccIdentityProvider_OIDC (14.48s)
--- PASS: TestAccIdentityProvider_Change (14.65s)
--- PASS: TestAccIdentityProvider_Yahoo (7.58s)
--- PASS: TestAccIdentityProvider_Apple (7.45s)
--- PASS: TestAccIdentityProvider_LinkedIn (7.55s)
--- PASS: TestAccIdentityProvider_Amazon (7.63s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 
```

``` shell
=== RUN   TestAccApplication_NewEnv
=== PAUSE TestAccApplication_NewEnv
=== RUN   TestAccApplication_OIDCFullWeb
=== PAUSE TestAccApplication_OIDCFullWeb
=== RUN   TestAccApplication_OIDCMinimalWeb
=== PAUSE TestAccApplication_OIDCMinimalWeb
=== RUN   TestAccApplication_OIDCWebUpdate
=== PAUSE TestAccApplication_OIDCWebUpdate
=== RUN   TestAccApplication_OIDCFullNative
=== PAUSE TestAccApplication_OIDCFullNative
=== RUN   TestAccApplication_OIDCMinimalNative
=== PAUSE TestAccApplication_OIDCMinimalNative
=== RUN   TestAccApplication_OIDCNativeUpdate
=== PAUSE TestAccApplication_OIDCNativeUpdate
=== RUN   TestAccApplication_NativeKerberos
=== PAUSE TestAccApplication_NativeKerberos
=== RUN   TestAccApplication_NativeMobile
=== PAUSE TestAccApplication_NativeMobile
=== RUN   TestAccApplication_NativeMobile_IntegrityDetection
=== PAUSE TestAccApplication_NativeMobile_IntegrityDetection
=== RUN   TestAccApplication_OIDCFullCustom
=== PAUSE TestAccApplication_OIDCFullCustom
=== RUN   TestAccApplication_OIDCMinimalCustom
=== PAUSE TestAccApplication_OIDCMinimalCustom
=== RUN   TestAccApplication_OIDCCustomUpdate
=== PAUSE TestAccApplication_OIDCCustomUpdate
=== RUN   TestAccApplication_OIDCFullService
=== PAUSE TestAccApplication_OIDCFullService
=== RUN   TestAccApplication_OIDCMinimalService
=== PAUSE TestAccApplication_OIDCMinimalService
=== RUN   TestAccApplication_OIDCServiceUpdate
=== PAUSE TestAccApplication_OIDCServiceUpdate
=== RUN   TestAccApplication_OIDCFullSPA
=== PAUSE TestAccApplication_OIDCFullSPA
=== RUN   TestAccApplication_OIDCMinimalSPA
=== PAUSE TestAccApplication_OIDCMinimalSPA
=== RUN   TestAccApplication_OIDCSPAUpdate
=== PAUSE TestAccApplication_OIDCSPAUpdate
=== RUN   TestAccApplication_OIDCFullWorker
=== PAUSE TestAccApplication_OIDCFullWorker
=== RUN   TestAccApplication_OIDCMinimalWorker
=== PAUSE TestAccApplication_OIDCMinimalWorker
=== RUN   TestAccApplication_OIDCWorkerUpdate
=== PAUSE TestAccApplication_OIDCWorkerUpdate
=== RUN   TestAccApplication_OIDC_WildcardInRedirectURI
=== PAUSE TestAccApplication_OIDC_WildcardInRedirectURI
=== RUN   TestAccApplication_OIDC_LocalhostAddresses
=== PAUSE TestAccApplication_OIDC_LocalhostAddresses
=== RUN   TestAccApplication_OIDC_NativeAppAddresses
=== PAUSE TestAccApplication_OIDC_NativeAppAddresses
=== RUN   TestAccApplication_SAMLFull
=== PAUSE TestAccApplication_SAMLFull
=== RUN   TestAccApplication_SAMLMinimal
=== PAUSE TestAccApplication_SAMLMinimal
=== RUN   TestAccApplication_SAMLSigningKey
=== PAUSE TestAccApplication_SAMLSigningKey
=== RUN   TestAccApplication_ExternalLinkFull
=== PAUSE TestAccApplication_ExternalLinkFull
=== RUN   TestAccApplication_ExternalLinkMinimal
=== PAUSE TestAccApplication_ExternalLinkMinimal
=== RUN   TestAccApplication_Enabled
=== PAUSE TestAccApplication_Enabled
=== CONT  TestAccApplication_NewEnv
=== CONT  TestAccApplication_OIDCFullSPA
=== CONT  TestAccApplication_OIDC_NativeAppAddresses
=== CONT  TestAccApplication_OIDCMinimalWorker
=== CONT  TestAccApplication_OIDC_WildcardInRedirectURI
=== CONT  TestAccApplication_OIDCWorkerUpdate
=== CONT  TestAccApplication_ExternalLinkFull
=== CONT  TestAccApplication_NativeMobile
=== CONT  TestAccApplication_OIDCCustomUpdate
=== CONT  TestAccApplication_OIDCServiceUpdate
--- PASS: TestAccApplication_OIDCMinimalWorker (5.30s)
=== CONT  TestAccApplication_OIDCMinimalService
--- PASS: TestAccApplication_OIDC_NativeAppAddresses (5.48s)
=== CONT  TestAccApplication_OIDCFullService
--- PASS: TestAccApplication_OIDCFullSPA (5.96s)
=== CONT  TestAccApplication_OIDCFullCustom
--- PASS: TestAccApplication_ExternalLinkFull (6.52s)
=== CONT  TestAccApplication_OIDCMinimalCustom
--- PASS: TestAccApplication_OIDC_WildcardInRedirectURI (6.70s)
=== CONT  TestAccApplication_Enabled
--- PASS: TestAccApplication_NewEnv (7.22s)
=== CONT  TestAccApplication_OIDC_LocalhostAddresses
--- PASS: TestAccApplication_OIDCMinimalService (5.24s)
=== CONT  TestAccApplication_NativeMobile_IntegrityDetection
    acctest.go:214: PINGONE_GOOGLE_JSON_KEY is missing and must be set
--- FAIL: TestAccApplication_NativeMobile_IntegrityDetection (0.00s)
=== CONT  TestAccApplication_ExternalLinkMinimal
--- PASS: TestAccApplication_OIDCMinimalCustom (4.48s)
=== CONT  TestAccApplication_OIDCSPAUpdate
--- PASS: TestAccApplication_OIDCFullCustom (5.28s)
=== CONT  TestAccApplication_SAMLMinimal
--- PASS: TestAccApplication_OIDCFullService (5.96s)
=== CONT  TestAccApplication_OIDCFullWorker
--- PASS: TestAccApplication_OIDCServiceUpdate (14.03s)
=== CONT  TestAccApplication_SAMLSigningKey
--- PASS: TestAccApplication_OIDCCustomUpdate (14.31s)
=== CONT  TestAccApplication_SAMLFull
--- PASS: TestAccApplication_OIDCWorkerUpdate (14.55s)
=== CONT  TestAccApplication_OIDCMinimalSPA
--- PASS: TestAccApplication_ExternalLinkMinimal (5.14s)
=== CONT  TestAccApplication_OIDCFullNative
--- PASS: TestAccApplication_SAMLMinimal (5.29s)
=== CONT  TestAccApplication_OIDCMinimalWeb
--- PASS: TestAccApplication_OIDCFullWorker (5.33s)
=== CONT  TestAccApplication_NativeKerberos
    resource_application_test.go:768: Step 1/10 error: Error running pre-apply refresh: exit status 1
        
        Error: Cannot find environment from name
        
          with data.pingone_environment.workforce_test,
          on terraform_plugin_test.tf line 3, in data "pingone_environment" "workforce_test":
           3:           data "pingone_environment" "workforce_test" {
        
        The environment "tf-testacc-static-workforce-test" cannot be found
--- FAIL: TestAccApplication_NativeKerberos (0.50s)
=== CONT  TestAccApplication_OIDCWebUpdate
--- PASS: TestAccApplication_Enabled (11.82s)
=== CONT  TestAccApplication_OIDCNativeUpdate
=== CONT  TestAccApplication_OIDCMinimalNative
--- PASS: TestAccApplication_OIDCMinimalSPA (4.57s)
--- PASS: TestAccApplication_SAMLFull (5.08s)
=== CONT  TestAccApplication_OIDCFullWeb
--- PASS: TestAccApplication_OIDC_LocalhostAddresses (12.39s)
--- PASS: TestAccApplication_OIDCFullNative (4.92s)
--- PASS: TestAccApplication_OIDCMinimalWeb (4.39s)
--- PASS: TestAccApplication_OIDCSPAUpdate (12.27s)
--- PASS: TestAccApplication_OIDCMinimalNative (4.33s)
--- PASS: TestAccApplication_OIDCFullWeb (5.16s)
--- PASS: TestAccApplication_OIDCWebUpdate (12.39s)
--- PASS: TestAccApplication_OIDCNativeUpdate (13.35s)
--- PASS: TestAccApplication_NativeMobile (36.48s)
--- PASS: TestAccApplication_SAMLSigningKey (30.18s)
FAIL
FAIL    github.com/pingidentity/terraform-provider-pingone/internal/service/sso 44.524s
```