### PR TITLE
Fixed unable to update PKCE enforcement on OIDC worker app

### DIFF
--- a/.changelog/475.txt
+++ b/.changelog/475.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_application`: Fixed bug where the `pkce_enforcement` parameter wasn't being configured correctly on OIDC worker apps.
+```

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -1139,9 +1139,7 @@ func expandApplicationOIDC(d *schema.ResourceData) (*management.ApplicationOIDC,
 		}
 
 		if v1, ok := oidcOptions["pkce_enforcement"].(string); ok && v1 != "" {
-			if application.GetType() == management.ENUMAPPLICATIONTYPE_WEB_APP || application.GetType() == management.ENUMAPPLICATIONTYPE_NATIVE_APP || application.GetType() == management.ENUMAPPLICATIONTYPE_SINGLE_PAGE_APP || application.GetType() == management.ENUMAPPLICATIONTYPE_CUSTOM_APP || application.GetType() == management.ENUMAPPLICATIONTYPE_SERVICE {
-				application.SetPkceEnforcement(management.EnumApplicationOIDCPKCEOption(v1))
-			}
+			application.SetPkceEnforcement(management.EnumApplicationOIDCPKCEOption(v1))
 		}
 
 		if v1, ok := oidcOptions["redirect_uris"].(*schema.Set); ok && v1 != nil && len(v1.List()) > 0 && v1.List()[0] != nil {


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* Fixed unable to update PKCE enforcement on OIDC worker app

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 360s -run ^TestAccApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccApplication_NewEnv
=== PAUSE TestAccApplication_NewEnv
=== RUN   TestAccApplication_OIDCFullWeb
=== PAUSE TestAccApplication_OIDCFullWeb
=== RUN   TestAccApplication_OIDCMinimalWeb
=== PAUSE TestAccApplication_OIDCMinimalWeb
=== RUN   TestAccApplication_OIDCWebUpdate
=== PAUSE TestAccApplication_OIDCWebUpdate
=== RUN   TestAccApplication_OIDCFullNative
=== PAUSE TestAccApplication_OIDCFullNative
=== RUN   TestAccApplication_OIDCMinimalNative
=== PAUSE TestAccApplication_OIDCMinimalNative
=== RUN   TestAccApplication_OIDCNativeUpdate
=== PAUSE TestAccApplication_OIDCNativeUpdate
=== RUN   TestAccApplication_NativeKerberos
=== PAUSE TestAccApplication_NativeKerberos
=== RUN   TestAccApplication_NativeMobile
=== PAUSE TestAccApplication_NativeMobile
=== RUN   TestAccApplication_NativeMobile_IntegrityDetection
=== PAUSE TestAccApplication_NativeMobile_IntegrityDetection
=== RUN   TestAccApplication_OIDCFullCustom
=== PAUSE TestAccApplication_OIDCFullCustom
=== RUN   TestAccApplication_OIDCMinimalCustom
=== PAUSE TestAccApplication_OIDCMinimalCustom
=== RUN   TestAccApplication_OIDCCustomUpdate
=== PAUSE TestAccApplication_OIDCCustomUpdate
=== RUN   TestAccApplication_OIDCFullService
=== PAUSE TestAccApplication_OIDCFullService
=== RUN   TestAccApplication_OIDCMinimalService
=== PAUSE TestAccApplication_OIDCMinimalService
=== RUN   TestAccApplication_OIDCServiceUpdate
=== PAUSE TestAccApplication_OIDCServiceUpdate
=== RUN   TestAccApplication_OIDCFullSPA
=== PAUSE TestAccApplication_OIDCFullSPA
=== RUN   TestAccApplication_OIDCMinimalSPA
=== PAUSE TestAccApplication_OIDCMinimalSPA
=== RUN   TestAccApplication_OIDCSPAUpdate
=== PAUSE TestAccApplication_OIDCSPAUpdate
=== RUN   TestAccApplication_OIDCFullWorker
=== PAUSE TestAccApplication_OIDCFullWorker
=== RUN   TestAccApplication_OIDCMinimalWorker
=== PAUSE TestAccApplication_OIDCMinimalWorker
=== RUN   TestAccApplication_OIDCWorkerUpdate
=== PAUSE TestAccApplication_OIDCWorkerUpdate
=== RUN   TestAccApplication_OIDC_WildcardInRedirectURI
=== PAUSE TestAccApplication_OIDC_WildcardInRedirectURI
=== RUN   TestAccApplication_OIDC_LocalhostAddresses
=== PAUSE TestAccApplication_OIDC_LocalhostAddresses
=== RUN   TestAccApplication_OIDC_NativeAppAddresses
=== PAUSE TestAccApplication_OIDC_NativeAppAddresses
=== RUN   TestAccApplication_SAMLFull
=== PAUSE TestAccApplication_SAMLFull
=== RUN   TestAccApplication_SAMLMinimal
=== PAUSE TestAccApplication_SAMLMinimal
=== RUN   TestAccApplication_SAMLSigningKey
=== PAUSE TestAccApplication_SAMLSigningKey
=== RUN   TestAccApplication_ExternalLinkFull
=== PAUSE TestAccApplication_ExternalLinkFull
=== RUN   TestAccApplication_ExternalLinkMinimal
=== PAUSE TestAccApplication_ExternalLinkMinimal
=== RUN   TestAccApplication_Enabled
=== PAUSE TestAccApplication_Enabled
=== CONT  TestAccApplication_NewEnv
=== CONT  TestAccApplication_OIDCFullSPA
=== CONT  TestAccApplication_NativeMobile
=== CONT  TestAccApplication_OIDCCustomUpdate
=== CONT  TestAccApplication_OIDCFullCustom
=== CONT  TestAccApplication_OIDCFullNative
=== CONT  TestAccApplication_OIDCMinimalService
=== CONT  TestAccApplication_OIDCFullService
=== CONT  TestAccApplication_Enabled
=== CONT  TestAccApplication_ExternalLinkMinimal
=== CONT  TestAccApplication_ExternalLinkFull
=== CONT  TestAccApplication_SAMLSigningKey
=== CONT  TestAccApplication_SAMLMinimal
=== CONT  TestAccApplication_SAMLFull
=== CONT  TestAccApplication_OIDCMinimalWeb
=== CONT  TestAccApplication_OIDC_NativeAppAddresses
--- PASS: TestAccApplication_ExternalLinkMinimal (7.28s)
=== CONT  TestAccApplication_OIDCWebUpdate
--- PASS: TestAccApplication_OIDC_NativeAppAddresses (8.40s)
=== CONT  TestAccApplication_NativeKerberos
--- PASS: TestAccApplication_SAMLMinimal (8.56s)
=== CONT  TestAccApplication_OIDCFullWeb
--- PASS: TestAccApplication_OIDCMinimalWeb (8.62s)
=== CONT  TestAccApplication_OIDCMinimalWorker
=== CONT  TestAccApplication_OIDC_LocalhostAddresses
--- PASS: TestAccApplication_OIDCMinimalService (8.72s)
--- PASS: TestAccApplication_ExternalLinkFull (9.44s)
=== CONT  TestAccApplication_OIDC_WildcardInRedirectURI
=== CONT  TestAccApplication_OIDCWorkerUpdate
--- PASS: TestAccApplication_SAMLFull (9.67s)
--- PASS: TestAccApplication_OIDCFullService (9.96s)
=== CONT  TestAccApplication_OIDCMinimalNative
--- PASS: TestAccApplication_OIDCFullSPA (9.97s)
=== CONT  TestAccApplication_NativeMobile_IntegrityDetection
--- PASS: TestAccApplication_OIDCFullNative (10.04s)
=== CONT  TestAccApplication_OIDCMinimalCustom
--- PASS: TestAccApplication_OIDCFullCustom (10.22s)
=== CONT  TestAccApplication_OIDCSPAUpdate
--- PASS: TestAccApplication_NewEnv (10.34s)
=== CONT  TestAccApplication_OIDCFullWorker
--- PASS: TestAccApplication_OIDCMinimalWorker (8.59s)
=== CONT  TestAccApplication_OIDCMinimalSPA
--- PASS: TestAccApplication_OIDCMinimalNative (8.09s)
=== CONT  TestAccApplication_OIDCServiceUpdate
--- PASS: TestAccApplication_OIDCFullWeb (10.31s)
=== CONT  TestAccApplication_OIDCNativeUpdate
--- PASS: TestAccApplication_OIDCMinimalCustom (8.83s)
--- PASS: TestAccApplication_OIDCFullWorker (9.59s)
--- PASS: TestAccApplication_OIDC_WildcardInRedirectURI (11.54s)
--- PASS: TestAccApplication_Enabled (21.11s)
--- PASS: TestAccApplication_OIDCCustomUpdate (24.68s)
--- PASS: TestAccApplication_OIDCMinimalSPA (7.69s)
--- PASS: TestAccApplication_OIDCWebUpdate (21.42s)
--- PASS: TestAccApplication_OIDC_LocalhostAddresses (21.65s)
--- PASS: TestAccApplication_OIDCWorkerUpdate (21.19s)
--- PASS: TestAccApplication_OIDCSPAUpdate (21.92s)
--- PASS: TestAccApplication_OIDCServiceUpdate (19.48s)
--- PASS: TestAccApplication_OIDCNativeUpdate (20.06s)
--- PASS: TestAccApplication_SAMLSigningKey (48.00s)
--- PASS: TestAccApplication_NativeMobile (56.02s)
--- PASS: TestAccApplication_NativeKerberos (48.10s)
--- PASS: TestAccApplication_NativeMobile_IntegrityDetection (79.45s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 89.888s
```