### PR TITLE
Correct `digital_wallet_application_id` validation from `REQUIRED` to `OPTIONAL`.

### DIFF
--- a/.changelog/490.txt
+++ b/.changelog/490.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/pingone_credential_issuance_rule`: Corrected `digital_wallet_application_id from `REQUIRED` to `OPTIONAL` per API specification.
+`resource/pingone_credential_issuance_rule`: Corrected `digital_wallet_application_id` from `REQUIRED` to `OPTIONAL` per API specification.
 ```

--- a/.changelog/490.txt
+++ b/.changelog/490.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_credential_issuance_rule`: Corrected `digital_wallet_application_id from `REQUIRED` to `OPTIONAL` per API specification.
+```

--- a/docs/resources/credential_issuance_rule.md
+++ b/docs/resources/credential_issuance_rule.md
@@ -75,12 +75,12 @@ resource "pingone_credential_issuance_rule" "my_credential_issuance_rule" {
 
 - `automation` (Attributes) Contains a list of actions, as key names, and the update method for each action. (see [below for nested schema](#nestedatt--automation))
 - `credential_type_id` (String) Identifier (UUID) of the credential type with which this credential issuance rule is associated.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
-- `digital_wallet_application_id` (String) Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet.
 - `environment_id` (String) PingOne environment identifier (UUID) in which the credential issuance rule exists.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `status` (String) Status of the credential issuance rule. Can be `ACTIVE` or `DISABLED`.
 
 ### Optional
 
+- `digital_wallet_application_id` (String) Identifier (UUID) of the customer's Digital Wallet App that will interact with the user's Digital Wallet. If present, digital wallet pairing automatically starts when a user matches the credential issuance rule.
 - `filter` (Attributes) Contains one and only one filter (`group_ids`, `population_ids`, or `scim`) that selects the users to which the credential issuance rule applies. A filter must be defined if the issuance rule `status` is `ACTIVE`. (see [below for nested schema](#nestedatt--filter))
 - `notification` (Attributes) Contains notification information. When this property is supplied, the information within is used to create a custom notification. (see [below for nested schema](#nestedatt--notification))
 

--- a/internal/service/credentials/resource_credential_issuance_rule_test.go
+++ b/internal/service/credentials/resource_credential_issuance_rule_test.go
@@ -335,9 +335,9 @@ resource "pingone_credential_type" "%[2]s" {
 }
 
 resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  status                        = "ACTIVE"
+  environment_id     = data.pingone_environment.general_test.id
+  credential_type_id = resource.pingone_credential_type.%[2]s.id
+  status             = "ACTIVE"
 
   filter = {
     scim = "address.countryCode eq \"NG\""
@@ -382,9 +382,9 @@ resource "pingone_credential_type" "%[2]s" {
 }
 
 resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  status                        = "DISABLED"
+  environment_id     = data.pingone_environment.general_test.id
+  credential_type_id = resource.pingone_credential_type.%[2]s.id
+  status             = "DISABLED"
 
   automation = {
     issue  = "PERIODIC"

--- a/internal/service/credentials/resource_credential_issuance_rule_test.go
+++ b/internal/service/credentials/resource_credential_issuance_rule_test.go
@@ -3,6 +3,7 @@ package credentials_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -75,74 +76,6 @@ func TestAccCredentialIssuanceRule_Full(t *testing.T) {
 
 	name := acctest.ResourceNameGen()
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
-		ErrorCheck:               acctest.ErrorCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCredentialIssuanceRule_Full(resourceName, name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
-					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
-					resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
-					resource.TestMatchResourceAttr(resourceFullName, "digital_wallet_application_id", verify.P1ResourceIDRegexp),
-					resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "ON_DEMAND"),
-					resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "automation.update", "ON_DEMAND"),
-					resource.TestCheckResourceAttrSet(resourceFullName, "filter.population_ids.#"),
-					resource.TestCheckResourceAttr(resourceFullName, "notification.methods.#", "2"),
-					resource.TestCheckResourceAttr(resourceFullName, "notification.methods.0", "EMAIL"),
-					resource.TestCheckResourceAttr(resourceFullName, "notification.methods.1", "SMS"),
-					resource.TestCheckResourceAttr(resourceFullName, "notification.template.locale", "en"),
-					resource.TestCheckResourceAttr(resourceFullName, "notification.template.variant", "template_B"),
-					resource.TestCheckResourceAttr(resourceFullName, "status", "ACTIVE"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCredentialIssuanceRule_Minimal(t *testing.T) {
-	t.Parallel()
-
-	resourceName := acctest.ResourceNameGen()
-	resourceFullName := fmt.Sprintf("pingone_credential_issuance_rule.%s", resourceName)
-
-	name := acctest.ResourceNameGen()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
-		ErrorCheck:               acctest.ErrorCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCredentialIssuanceRule_Minimal(resourceName, name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
-					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
-					resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
-					resource.TestCheckResourceAttr(resourceFullName, "filter.scim", "address.countryCode eq \"NG\""),
-					resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "PERIODIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "automation.update", "PERIODIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "status", "ACTIVE"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCredentialIssuanceRule_Change(t *testing.T) {
-	t.Parallel()
-
-	resourceName := acctest.ResourceNameGen()
-	resourceFullName := fmt.Sprintf("pingone_credential_issuance_rule.%s", resourceName)
-
-	name := acctest.ResourceNameGen()
-
 	fullStep := resource.TestStep{
 		Config: testAccCredentialIssuanceRule_Full(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
@@ -169,6 +102,7 @@ func TestAccCredentialIssuanceRule_Change(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
+			resource.TestCheckNoResourceAttr(resourceFullName, "digital_wallet_application_id"),
 			resource.TestCheckResourceAttr(resourceFullName, "filter.scim", "address.countryCode eq \"NG\""),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "PERIODIC"),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
@@ -183,6 +117,7 @@ func TestAccCredentialIssuanceRule_Change(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
+			resource.TestCheckNoResourceAttr(resourceFullName, "digital_wallet_application_id"),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.%", "3"),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "PERIODIC"),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
@@ -201,11 +136,84 @@ func TestAccCredentialIssuanceRule_Change(t *testing.T) {
 		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
+			// full
+			fullStep,
+			{
+				Config:  testAccCredentialIssuanceRule_Full(resourceName, name),
+				Destroy: true,
+			},
+			//minimalStep,
+			{
+				Config:  testAccCredentialIssuanceRule_Minimal(resourceName, name),
+				Destroy: true,
+			},
+			disabledStep,
+			{
+				Config:  testAccCredentialIssuanceRule_Disabled(resourceName, name),
+				Destroy: true,
+			},
 			fullStep,
 			minimalStep,
 			fullStep,
 			disabledStep,
 			fullStep,
+		},
+	})
+}
+
+func TestAccCredentialIssuanceRule_InvalidConfigs(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+
+	name := acctest.ResourceNameGen()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidCredentialTypeID(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Missing required argument"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidGroupIdFilterAttribute(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidPopulationIdFilterAttribute(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidFilterAttribute(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Invalid Attribute Combination"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidAutomationAttribute(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Incorrect attribute value type"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidNotificationAttribute(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Incorrect attribute value type"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidNotificationMethodsAttribute(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialIssuanceRule_InvalidNotificationTemplateAttribute(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Incorrect attribute value type"),
+				Destroy:     true,
+			},
 		},
 	})
 }
@@ -327,9 +335,9 @@ resource "pingone_credential_type" "%[2]s" {
 }
 
 resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id     = data.pingone_environment.general_test.id
-  credential_type_id = resource.pingone_credential_type.%[2]s.id
-  status             = "ACTIVE"
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  status                        = "ACTIVE"
 
   filter = {
     scim = "address.countryCode eq \"NG\""
@@ -374,9 +382,9 @@ resource "pingone_credential_type" "%[2]s" {
 }
 
 resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id     = data.pingone_environment.general_test.id
-  credential_type_id = resource.pingone_credential_type.%[2]s.id
-  status             = "DISABLED"
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  status                        = "DISABLED"
 
   automation = {
     issue  = "PERIODIC"
@@ -384,5 +392,649 @@ resource "pingone_credential_issuance_rule" "%[2]s" {
     update = "PERIODIC"
   }
 
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidCredentialTypeID(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "DISABLED"
+
+  filter = {
+    scim = "address.countryCode eq \"CA\""
+  }
+
+  automation = {
+    issue  = "PERIODIC"
+    revoke = "PERIODIC"
+    update = "PERIODIC"
+  }
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidGroupIdFilterAttribute(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "ACTIVE"
+
+  filter = {
+    group_ids = []
+  }
+
+  automation = {
+    issue  = "ON_DEMAND"
+    revoke = "PERIODIC"
+    update = "ON_DEMAND"
+  }
+
+  notification = {
+    methods = ["EMAIL", "SMS"]
+    template = {
+      locale  = "en"
+      variant = "template_B"
+    }
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidPopulationIdFilterAttribute(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "ACTIVE"
+
+  filter = {
+    population_ids = []
+  }
+
+  automation = {
+    issue  = "ON_DEMAND"
+    revoke = "PERIODIC"
+    update = "ON_DEMAND"
+  }
+
+  notification = {
+    methods = ["EMAIL", "SMS"]
+    template = {
+      locale  = "en"
+      variant = "template_B"
+    }
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidFilterAttribute(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "ACTIVE"
+
+  filter = {}
+
+  automation = {
+    issue  = "ON_DEMAND"
+    revoke = "PERIODIC"
+    update = "ON_DEMAND"
+  }
+
+  notification = {
+    methods = ["EMAIL", "SMS"]
+    template = {
+      locale  = "en"
+      variant = "template_B"
+    }
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidAutomationAttribute(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "ACTIVE"
+
+  filter = {
+    scim = "address.countryCode eq \"NG\""
+  }
+
+  automation = {}
+
+  notification = {
+    methods = ["EMAIL", "SMS"]
+    template = {
+      locale  = "en"
+      variant = "template_B"
+    }
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidNotificationAttribute(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "ACTIVE"
+
+  filter = {
+    scim = "address.countryCode eq \"NG\""
+  }
+
+  automation = {
+    issue  = "ON_DEMAND"
+    revoke = "PERIODIC"
+    update = "ON_DEMAND"
+  }
+
+  notification = {}
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidNotificationMethodsAttribute(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "ACTIVE"
+
+  filter = {
+    scim = "address.countryCode eq \"NG\""
+  }
+
+  automation = {
+    issue  = "ON_DEMAND"
+    revoke = "PERIODIC"
+    update = "ON_DEMAND"
+  }
+
+  notification = {
+    methods = []
+    template = {
+      locale  = "en"
+      variant = "template_B"
+    }
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccCredentialIssuanceRule_InvalidNotificationTemplateAttribute(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+}
+
+resource "pingone_credential_type" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  title                = "%[3]s"
+  description          = "%[3]s Example Description"
+  card_type            = "%[3]s"
+  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
+
+  metadata = {
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
+    bg_opacity_percent = 100
+    card_color         = "#000000"
+    text_color         = "#eff0f1"
+
+    fields = [
+      {
+        type       = "Alphanumeric Text"
+        title      = "Example Field"
+        value      = "Demo"
+        is_visible = false
+      },
+    ]
+  }
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options {
+    type                        = "NATIVE_APP"
+    grant_types                 = ["CLIENT_CREDENTIALS"]
+    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
+
+    mobile_app {
+      bundle_id                = "com.pingidentity.ios_%[3]s"
+      package_name             = "com.pingidentity.android_%[3]s"
+      passcode_refresh_seconds = 30
+    }
+  }
+}
+
+resource "pingone_digital_wallet_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = resource.pingone_application.%[2]s.id
+  name           = "%[3]s"
+  app_open_url   = "https://www.example.com"
+
+  depends_on = [resource.pingone_application.%[2]s]
+}
+
+resource "pingone_credential_issuance_rule" "%[2]s" {
+  environment_id                = data.pingone_environment.general_test.id
+  credential_type_id            = resource.pingone_credential_type.%[2]s.id
+  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
+  status                        = "ACTIVE"
+
+  filter = {
+    scim = "address.countryCode eq \"NG\""
+  }
+
+  automation = {
+    issue  = "ON_DEMAND"
+    revoke = "PERIODIC"
+    update = "ON_DEMAND"
+  }
+
+  notification = {
+    methods  = ["EMAIL", "SMS"]
+    template = {}
+  }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }

--- a/internal/service/credentials/resource_credential_issuance_rule_test.go
+++ b/internal/service/credentials/resource_credential_issuance_rule_test.go
@@ -3,7 +3,6 @@ package credentials_test
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -76,6 +75,74 @@ func TestAccCredentialIssuanceRule_Full(t *testing.T) {
 
 	name := acctest.ResourceNameGen()
 
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCredentialIssuanceRule_Full(resourceName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
+					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
+					resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
+					resource.TestMatchResourceAttr(resourceFullName, "digital_wallet_application_id", verify.P1ResourceIDRegexp),
+					resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "ON_DEMAND"),
+					resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "automation.update", "ON_DEMAND"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "filter.population_ids.#"),
+					resource.TestCheckResourceAttr(resourceFullName, "notification.methods.#", "2"),
+					resource.TestCheckResourceAttr(resourceFullName, "notification.methods.0", "EMAIL"),
+					resource.TestCheckResourceAttr(resourceFullName, "notification.methods.1", "SMS"),
+					resource.TestCheckResourceAttr(resourceFullName, "notification.template.locale", "en"),
+					resource.TestCheckResourceAttr(resourceFullName, "notification.template.variant", "template_B"),
+					resource.TestCheckResourceAttr(resourceFullName, "status", "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCredentialIssuanceRule_Minimal(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_credential_issuance_rule.%s", resourceName)
+
+	name := acctest.ResourceNameGen()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCredentialIssuanceRule_Minimal(resourceName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
+					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
+					resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
+					resource.TestCheckResourceAttr(resourceFullName, "filter.scim", "address.countryCode eq \"NG\""),
+					resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "PERIODIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "automation.update", "PERIODIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "status", "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCredentialIssuanceRule_Change(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_credential_issuance_rule.%s", resourceName)
+
+	name := acctest.ResourceNameGen()
+
 	fullStep := resource.TestStep{
 		Config: testAccCredentialIssuanceRule_Full(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
@@ -102,7 +169,6 @@ func TestAccCredentialIssuanceRule_Full(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
-			resource.TestMatchResourceAttr(resourceFullName, "digital_wallet_application_id", verify.P1ResourceIDRegexp),
 			resource.TestCheckResourceAttr(resourceFullName, "filter.scim", "address.countryCode eq \"NG\""),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "PERIODIC"),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
@@ -117,7 +183,6 @@ func TestAccCredentialIssuanceRule_Full(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexp),
 			resource.TestMatchResourceAttr(resourceFullName, "credential_type_id", verify.P1ResourceIDRegexp),
-			resource.TestMatchResourceAttr(resourceFullName, "digital_wallet_application_id", verify.P1ResourceIDRegexp),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.%", "3"),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.issue", "PERIODIC"),
 			resource.TestCheckResourceAttr(resourceFullName, "automation.revoke", "PERIODIC"),
@@ -136,89 +201,11 @@ func TestAccCredentialIssuanceRule_Full(t *testing.T) {
 		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
-			// full
-			fullStep,
-			{
-				Config:  testAccCredentialIssuanceRule_Full(resourceName, name),
-				Destroy: true,
-			},
-			//minimalStep,
-			{
-				Config:  testAccCredentialIssuanceRule_Minimal(resourceName, name),
-				Destroy: true,
-			},
-			disabledStep,
-			{
-				Config:  testAccCredentialIssuanceRule_Disabled(resourceName, name),
-				Destroy: true,
-			},
 			fullStep,
 			minimalStep,
 			fullStep,
 			disabledStep,
 			fullStep,
-		},
-	})
-}
-
-func TestAccCredentialIssuanceRule_InvalidConfigs(t *testing.T) {
-	t.Parallel()
-
-	resourceName := acctest.ResourceNameGen()
-
-	name := acctest.ResourceNameGen()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy:             testAccCheckCredentiaIssuanceRuleDestroy,
-		ErrorCheck:               acctest.ErrorCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidCredentialTypeID(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Missing required argument"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidDigitalWalletID(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Missing required argument"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidGroupIdFilterAttribute(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidPopulationIdFilterAttribute(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidFilterAttribute(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Invalid Attribute Combination"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidAutomationAttribute(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Incorrect attribute value type"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidNotificationAttribute(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Incorrect attribute value type"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidNotificationMethodsAttribute(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value"),
-				Destroy:     true,
-			},
-			{
-				Config:      testAccCredentialIssuanceRule_InvalidNotificationTemplateAttribute(resourceName, name),
-				ExpectError: regexp.MustCompile("Error: Incorrect attribute value type"),
-				Destroy:     true,
-			},
 		},
 	})
 }
@@ -339,37 +326,9 @@ resource "pingone_credential_type" "%[2]s" {
   }
 }
 
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
 resource "pingone_credential_issuance_rule" "%[2]s" {
   environment_id                = data.pingone_environment.general_test.id
   credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
   status                        = "ACTIVE"
 
   filter = {
@@ -414,37 +373,9 @@ resource "pingone_credential_type" "%[2]s" {
   }
 }
 
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
 resource "pingone_credential_issuance_rule" "%[2]s" {
   environment_id                = data.pingone_environment.general_test.id
   credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
   status                        = "DISABLED"
 
   automation = {
@@ -453,689 +384,5 @@ resource "pingone_credential_issuance_rule" "%[2]s" {
     update = "PERIODIC"
   }
 
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidCredentialTypeID(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "DISABLED"
-
-  filter = {
-    scim = "address.countryCode eq \"CA\""
-  }
-
-  automation = {
-    issue  = "PERIODIC"
-    revoke = "PERIODIC"
-    update = "PERIODIC"
-  }
-
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidDigitalWalletID(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id     = data.pingone_environment.general_test.id
-  credential_type_id = resource.pingone_credential_type.%[2]s.id
-  status             = "DISABLED"
-  filter = {
-    scim = "address.countryCode eq \"CA\""
-  }
-  automation = {
-    issue  = "PERIODIC"
-    revoke = "PERIODIC"
-    update = "PERIODIC"
-  }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidGroupIdFilterAttribute(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-}
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "ACTIVE"
-
-  filter = {
-    group_ids = []
-  }
-
-  automation = {
-    issue  = "ON_DEMAND"
-    revoke = "PERIODIC"
-    update = "ON_DEMAND"
-  }
-
-  notification = {
-    methods = ["EMAIL", "SMS"]
-    template = {
-      locale  = "en"
-      variant = "template_B"
-    }
-  }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidPopulationIdFilterAttribute(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-}
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "ACTIVE"
-
-  filter = {
-    population_ids = []
-  }
-
-  automation = {
-    issue  = "ON_DEMAND"
-    revoke = "PERIODIC"
-    update = "ON_DEMAND"
-  }
-
-  notification = {
-    methods = ["EMAIL", "SMS"]
-    template = {
-      locale  = "en"
-      variant = "template_B"
-    }
-  }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidFilterAttribute(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-}
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "ACTIVE"
-
-  filter = {}
-
-  automation = {
-    issue  = "ON_DEMAND"
-    revoke = "PERIODIC"
-    update = "ON_DEMAND"
-  }
-
-  notification = {
-    methods = ["EMAIL", "SMS"]
-    template = {
-      locale  = "en"
-      variant = "template_B"
-    }
-  }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidAutomationAttribute(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-}
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "ACTIVE"
-
-  filter = {
-    scim = "address.countryCode eq \"NG\""
-  }
-
-  automation = {}
-
-  notification = {
-    methods = ["EMAIL", "SMS"]
-    template = {
-      locale  = "en"
-      variant = "template_B"
-    }
-  }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidNotificationAttribute(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-}
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "ACTIVE"
-
-  filter = {
-    scim = "address.countryCode eq \"NG\""
-  }
-
-  automation = {
-    issue  = "ON_DEMAND"
-    revoke = "PERIODIC"
-    update = "ON_DEMAND"
-  }
-
-  notification = {}
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidNotificationMethodsAttribute(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-}
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "ACTIVE"
-
-  filter = {
-    scim = "address.countryCode eq \"NG\""
-  }
-
-  automation = {
-    issue  = "ON_DEMAND"
-    revoke = "PERIODIC"
-    update = "ON_DEMAND"
-  }
-
-  notification = {
-    methods = []
-    template = {
-      locale  = "en"
-      variant = "template_B"
-    }
-  }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccCredentialIssuanceRule_InvalidNotificationTemplateAttribute(resourceName, name string) string {
-	return fmt.Sprintf(`
-	%[1]s
-
-resource "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-}
-
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
-  card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
-
-  metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
-    bg_opacity_percent = 100
-    card_color         = "#000000"
-    text_color         = "#eff0f1"
-
-    fields = [
-      {
-        type       = "Alphanumeric Text"
-        title      = "Example Field"
-        value      = "Demo"
-        is_visible = false
-      },
-    ]
-  }
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      bundle_id                = "com.pingidentity.ios_%[3]s"
-      package_name             = "com.pingidentity.android_%[3]s"
-      passcode_refresh_seconds = 30
-    }
-  }
-}
-
-resource "pingone_digital_wallet_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = resource.pingone_application.%[2]s.id
-  name           = "%[3]s"
-  app_open_url   = "https://www.example.com"
-
-  depends_on = [resource.pingone_application.%[2]s]
-}
-
-resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  digital_wallet_application_id = resource.pingone_digital_wallet_application.%[2]s.id
-  status                        = "ACTIVE"
-
-  filter = {
-    scim = "address.countryCode eq \"NG\""
-  }
-
-  automation = {
-    issue  = "ON_DEMAND"
-    revoke = "PERIODIC"
-    update = "ON_DEMAND"
-  }
-
-  notification = {
-    methods  = ["EMAIL", "SMS"]
-    template = {}
-  }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }

--- a/internal/service/credentials/resource_credential_issuance_rule_test.go
+++ b/internal/service/credentials/resource_credential_issuance_rule_test.go
@@ -327,9 +327,9 @@ resource "pingone_credential_type" "%[2]s" {
 }
 
 resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  status                        = "ACTIVE"
+  environment_id     = data.pingone_environment.general_test.id
+  credential_type_id = resource.pingone_credential_type.%[2]s.id
+  status             = "ACTIVE"
 
   filter = {
     scim = "address.countryCode eq \"NG\""
@@ -374,9 +374,9 @@ resource "pingone_credential_type" "%[2]s" {
 }
 
 resource "pingone_credential_issuance_rule" "%[2]s" {
-  environment_id                = data.pingone_environment.general_test.id
-  credential_type_id            = resource.pingone_credential_type.%[2]s.id
-  status                        = "DISABLED"
+  environment_id     = data.pingone_environment.general_test.id
+  credential_type_id = resource.pingone_credential_type.%[2]s.id
+  status             = "DISABLED"
 
   automation = {
     issue  = "PERIODIC"


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
`resource/pingone_credential_issuance_rule`: Corrected `digital_wallet_application_id` from `REQUIRED` to `OPTIONAL` per API specification.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccCredentialIssuanceRule_ github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccCredentialIssuanceRule_Full
=== PAUSE TestAccCredentialIssuanceRule_Full
=== RUN   TestAccCredentialIssuanceRule_InvalidConfigs
=== PAUSE TestAccCredentialIssuanceRule_InvalidConfigs
=== CONT  TestAccCredentialIssuanceRule_Full
=== CONT  TestAccCredentialIssuanceRule_InvalidConfigs
--- PASS: TestAccCredentialIssuanceRule_InvalidConfigs (1.00s)
--- PASS: TestAccCredentialIssuanceRule_Full (60.64s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 61.089s
```