### PR TITLE
Fixed blocking error on plan when MFA device policy is removed outside of Terraform

### DIFF
--- a/internal/service/mfa/resource_mfa_policy.go
+++ b/internal/service/mfa/resource_mfa_policy.go
@@ -451,7 +451,7 @@ func resourceMFAPolicyRead(ctx context.Context, d *schema.ResourceData, meta int
 			return apiClient.DeviceAuthenticationPolicyApi.ReadOneDeviceAuthenticationPolicy(ctx, d.Get("environment_id").(string), d.Id()).Execute()
 		},
 		"ReadOneDeviceAuthenticationPolicy",
-		sdk.DefaultCustomError,
+		sdk.CustomErrorResourceNotFoundWarning,
 		sdk.DefaultCreateReadRetryable,
 	)
 	if diags.HasError() {

--- a/internal/service/mfa/resource_mfa_policy_test.go
+++ b/internal/service/mfa/resource_mfa_policy_test.go
@@ -69,6 +69,70 @@ func testAccCheckMFAPolicyDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccGetMFAPolicyIDs(resourceName string, environmentID, resourceID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource Not found: %s", resourceName)
+		}
+
+		*resourceID = rs.Primary.ID
+		*environmentID = rs.Primary.Attributes["environment_id"]
+
+		return nil
+	}
+}
+
+func TestAccMFAPolicy_RemovalDrift(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_mfa_policy.%s", resourceName)
+
+	name := resourceName
+
+	var resourceID, environmentID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMFAPolicyDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			// Configure
+			{
+				Config: testAccMFAPolicyConfig_FullSMS(resourceName, name),
+				Check:  testAccGetMFAPolicyIDs(resourceFullName, &environmentID, &resourceID),
+			},
+			// Replan after removal preconfig
+			{
+				PreConfig: func() {
+					var ctx = context.Background()
+					p1Client, err := acctest.TestClient(ctx)
+
+					if err != nil {
+						t.Fatalf("Failed to get API client: %v", err)
+					}
+
+					apiClient := p1Client.API.MFAAPIClient
+
+					if environmentID == "" || resourceID == "" {
+						t.Fatalf("One of environment ID or resource ID cannot be determined. Environment ID: %s, Resource ID: %s", environmentID, resourceID)
+					}
+
+					_, err = apiClient.DeviceAuthenticationPolicyApi.DeleteDeviceAuthenticationPolicy(ctx, environmentID, resourceID).Execute()
+					if err != nil {
+						t.Fatalf("Failed to delete MFA Policy: %v", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccMFAPolicy_NewEnv(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* Bug fix: Fixed blocking error on plan when MFA device policy is removed outside of Terraform

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG=TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run ^TestAccMFAPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccMFAPolicy_RemovalDrift
=== PAUSE TestAccMFAPolicy_RemovalDrift
=== RUN   TestAccMFAPolicy_NewEnv
=== PAUSE TestAccMFAPolicy_NewEnv
=== RUN   TestAccMFAPolicy_SMS_Full
=== PAUSE TestAccMFAPolicy_SMS_Full
=== RUN   TestAccMFAPolicy_SMS_Minimal
=== PAUSE TestAccMFAPolicy_SMS_Minimal
=== RUN   TestAccMFAPolicy_SMS_Change
=== PAUSE TestAccMFAPolicy_SMS_Change
=== RUN   TestAccMFAPolicy_Voice_Full
=== PAUSE TestAccMFAPolicy_Voice_Full
=== RUN   TestAccMFAPolicy_Voice_Minimal
=== PAUSE TestAccMFAPolicy_Voice_Minimal
=== RUN   TestAccMFAPolicy_Voice_Change
=== PAUSE TestAccMFAPolicy_Voice_Change
=== RUN   TestAccMFAPolicy_Email_Full
=== PAUSE TestAccMFAPolicy_Email_Full
=== RUN   TestAccMFAPolicy_Email_Minimal
=== PAUSE TestAccMFAPolicy_Email_Minimal
=== RUN   TestAccMFAPolicy_Email_Change
=== PAUSE TestAccMFAPolicy_Email_Change
=== RUN   TestAccMFAPolicy_Mobile_Full
=== PAUSE TestAccMFAPolicy_Mobile_Full
=== RUN   TestAccMFAPolicy_Mobile_IntegrityDetectionErrors
=== PAUSE TestAccMFAPolicy_Mobile_IntegrityDetectionErrors
=== RUN   TestAccMFAPolicy_Mobile_BadApplicationErrors
=== PAUSE TestAccMFAPolicy_Mobile_BadApplicationErrors
=== RUN   TestAccMFAPolicy_Mobile_Minimal
=== PAUSE TestAccMFAPolicy_Mobile_Minimal
=== RUN   TestAccMFAPolicy_Mobile_Change
=== PAUSE TestAccMFAPolicy_Mobile_Change
=== RUN   TestAccMFAPolicy_Totp_Full
=== PAUSE TestAccMFAPolicy_Totp_Full
=== RUN   TestAccMFAPolicy_Totp_Minimal
=== PAUSE TestAccMFAPolicy_Totp_Minimal
=== RUN   TestAccMFAPolicy_Totp_Change
=== PAUSE TestAccMFAPolicy_Totp_Change
=== RUN   TestAccMFAPolicy_FIDO2_Full
=== PAUSE TestAccMFAPolicy_FIDO2_Full
=== RUN   TestAccMFAPolicy_FIDO2_Minimal
=== PAUSE TestAccMFAPolicy_FIDO2_Minimal
=== RUN   TestAccMFAPolicy_FIDO2_Change
=== PAUSE TestAccMFAPolicy_FIDO2_Change
=== RUN   TestAccMFAPolicy_SecurityKey_Full
=== PAUSE TestAccMFAPolicy_SecurityKey_Full
=== RUN   TestAccMFAPolicy_SecurityKey_Minimal
=== PAUSE TestAccMFAPolicy_SecurityKey_Minimal
=== RUN   TestAccMFAPolicy_SecurityKey_Change
=== PAUSE TestAccMFAPolicy_SecurityKey_Change
=== RUN   TestAccMFAPolicy_Platform_Full
=== PAUSE TestAccMFAPolicy_Platform_Full
=== RUN   TestAccMFAPolicy_Platform_Minimal
=== PAUSE TestAccMFAPolicy_Platform_Minimal
=== RUN   TestAccMFAPolicy_Platform_Change
=== PAUSE TestAccMFAPolicy_Platform_Change
=== RUN   TestAccMFAPolicy_DataModel
=== PAUSE TestAccMFAPolicy_DataModel
=== CONT  TestAccMFAPolicy_RemovalDrift
=== CONT  TestAccMFAPolicy_Mobile_Change
=== CONT  TestAccMFAPolicy_SecurityKey_Full
=== CONT  TestAccMFAPolicy_Platform_Minimal
=== CONT  TestAccMFAPolicy_DataModel
=== CONT  TestAccMFAPolicy_FIDO2_Change
=== CONT  TestAccMFAPolicy_FIDO2_Minimal
=== CONT  TestAccMFAPolicy_FIDO2_Full
=== CONT  TestAccMFAPolicy_Mobile_Minimal
=== CONT  TestAccMFAPolicy_Mobile_BadApplicationErrors
=== CONT  TestAccMFAPolicy_Mobile_IntegrityDetectionErrors
=== CONT  TestAccMFAPolicy_Mobile_Full
=== CONT  TestAccMFAPolicy_Email_Change
=== CONT  TestAccMFAPolicy_Email_Minimal
=== CONT  TestAccMFAPolicy_SecurityKey_Change
=== CONT  TestAccMFAPolicy_Email_Full
=== NAME  TestAccMFAPolicy_SecurityKey_Full
    resource_mfa_policy_test.go:1287: Device method deprecated for new environments
--- SKIP: TestAccMFAPolicy_SecurityKey_Full (0.01s)
=== CONT  TestAccMFAPolicy_Platform_Full
=== NAME  TestAccMFAPolicy_Platform_Minimal
    resource_mfa_policy_test.go:1441: Device method deprecated for new environments
--- SKIP: TestAccMFAPolicy_Platform_Minimal (0.01s)
=== CONT  TestAccMFAPolicy_SMS_Full
=== NAME  TestAccMFAPolicy_SecurityKey_Change
    resource_mfa_policy_test.go:1351: Device method deprecated for new environments
--- SKIP: TestAccMFAPolicy_SecurityKey_Change (0.01s)
=== CONT  TestAccMFAPolicy_SMS_Minimal
=== NAME  TestAccMFAPolicy_Platform_Full
    resource_mfa_policy_test.go:1409: Device method deprecated for new environments
--- SKIP: TestAccMFAPolicy_Platform_Full (0.01s)
=== CONT  TestAccMFAPolicy_Totp_Minimal
--- PASS: TestAccMFAPolicy_Totp_Minimal (13.36s)
=== CONT  TestAccMFAPolicy_Totp_Change
--- PASS: TestAccMFAPolicy_SMS_Full (14.34s)
=== CONT  TestAccMFAPolicy_Totp_Full
--- PASS: TestAccMFAPolicy_Email_Minimal (14.35s)
=== CONT  TestAccMFAPolicy_Platform_Change
    resource_mfa_policy_test.go:1474: Device method deprecated for new environments
--- SKIP: TestAccMFAPolicy_Platform_Change (0.05s)
=== CONT  TestAccMFAPolicy_SecurityKey_Minimal
    resource_mfa_policy_test.go:1319: Device method deprecated for new environments
--- SKIP: TestAccMFAPolicy_SecurityKey_Minimal (0.07s)
=== CONT  TestAccMFAPolicy_Voice_Minimal
--- PASS: TestAccMFAPolicy_Email_Full (14.85s)
=== CONT  TestAccMFAPolicy_Voice_Change
--- PASS: TestAccMFAPolicy_FIDO2_Minimal (15.11s)
=== CONT  TestAccMFAPolicy_NewEnv
--- PASS: TestAccMFAPolicy_Mobile_IntegrityDetectionErrors (15.11s)
=== CONT  TestAccMFAPolicy_Voice_Full
--- PASS: TestAccMFAPolicy_SMS_Minimal (15.32s)
=== CONT  TestAccMFAPolicy_SMS_Change
--- PASS: TestAccMFAPolicy_Mobile_Minimal (15.33s)
--- PASS: TestAccMFAPolicy_FIDO2_Full (15.71s)
--- PASS: TestAccMFAPolicy_Mobile_Full (18.37s)
--- PASS: TestAccMFAPolicy_RemovalDrift (18.56s)
--- PASS: TestAccMFAPolicy_Mobile_BadApplicationErrors (23.31s)
--- PASS: TestAccMFAPolicy_Voice_Minimal (10.68s)
--- PASS: TestAccMFAPolicy_Totp_Full (11.56s)
--- PASS: TestAccMFAPolicy_Voice_Full (10.80s)
--- PASS: TestAccMFAPolicy_NewEnv (12.89s)
--- PASS: TestAccMFAPolicy_Email_Change (29.65s)
--- PASS: TestAccMFAPolicy_FIDO2_Change (30.80s)
--- PASS: TestAccMFAPolicy_Mobile_Change (34.76s)
--- PASS: TestAccMFAPolicy_Voice_Change (22.32s)
--- PASS: TestAccMFAPolicy_SMS_Change (21.98s)
--- PASS: TestAccMFAPolicy_Totp_Change (24.08s)
--- PASS: TestAccMFAPolicy_DataModel (51.26s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 51.752s
```