### PR TITLE
`resource/pingone_sign_on_policy_action`: Fix potential slice out of bounds issues

### DIFF
--- a/.changelog/525.txt
+++ b/.changelog/525.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_sign_on_policy_action`: Fix potential "slice out of bounds" issues.
+```

--- a/internal/service/sso/resource_sign_on_policy_action.go
+++ b/internal/service/sso/resource_sign_on_policy_action.go
@@ -1060,9 +1060,9 @@ func buildAttributeEqualsCondition(v []attributeEquality, tfSchemaAttribute stri
 				SignOnPolicyActionCommonConditionOr: &management.SignOnPolicyActionCommonConditionOr{
 					Or: conditionList,
 				},
-			}, nil
+			}, diags
 
-		} else {
+		} else if len(v) == 1 {
 
 			return &management.SignOnPolicyActionCommonConditionOrOrInner{
 				SignOnPolicyActionCommonConditionAggregate: &management.SignOnPolicyActionCommonConditionAggregate{
@@ -1071,7 +1071,9 @@ func buildAttributeEqualsCondition(v []attributeEquality, tfSchemaAttribute stri
 						String: v[0].attributeValueString,
 					}),
 				},
-			}, nil
+			}, diags
+		} else {
+			return nil, diags
 		}
 	}
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG= TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 600s -run ^TestAccSignOnPolicyAction_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccSignOnPolicyAction_RemovalDrift
=== PAUSE TestAccSignOnPolicyAction_RemovalDrift
=== RUN   TestAccSignOnPolicyAction_LoginAction
=== PAUSE TestAccSignOnPolicyAction_LoginAction
=== RUN   TestAccSignOnPolicyAction_LoginAction_Gateway
=== PAUSE TestAccSignOnPolicyAction_LoginAction_Gateway
=== RUN   TestAccSignOnPolicyAction_IDFirstAction
=== PAUSE TestAccSignOnPolicyAction_IDFirstAction
=== RUN   TestAccSignOnPolicyAction_MFAAction
=== PAUSE TestAccSignOnPolicyAction_MFAAction
=== RUN   TestAccSignOnPolicyAction_IDPAction
=== PAUSE TestAccSignOnPolicyAction_IDPAction
=== RUN   TestAccSignOnPolicyAction_AgreementAction
=== PAUSE TestAccSignOnPolicyAction_AgreementAction
=== RUN   TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== PAUSE TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== RUN   TestAccSignOnPolicyAction_PingIDAction
=== PAUSE TestAccSignOnPolicyAction_PingIDAction
=== RUN   TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
=== PAUSE TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
=== RUN   TestAccSignOnPolicyAction_MultipleActionChange
=== PAUSE TestAccSignOnPolicyAction_MultipleActionChange
=== RUN   TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== PAUSE TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== RUN   TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== PAUSE TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== RUN   TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== PAUSE TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== RUN   TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== PAUSE TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== RUN   TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== RUN   TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== RUN   TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== RUN   TestAccSignOnPolicyAction_ConditionsGeovelocity
=== PAUSE TestAccSignOnPolicyAction_ConditionsGeovelocity
=== RUN   TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== PAUSE TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== RUN   TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== PAUSE TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== RUN   TestAccSignOnPolicyAction_ConditionsCompound
=== PAUSE TestAccSignOnPolicyAction_ConditionsCompound
=== RUN   TestAccSignOnPolicyAction_BadParameters
=== PAUSE TestAccSignOnPolicyAction_BadParameters
=== CONT  TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== CONT  TestAccSignOnPolicyAction_RemovalDrift
=== CONT  TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== CONT  TestAccSignOnPolicyAction_ConditionsGeovelocity
=== CONT  TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== CONT  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== CONT  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== CONT  TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== CONT  TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== CONT  TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== CONT  TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== NAME  TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
    resource_sign_on_policy_action_test.go:1478: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsAnonymousNetwork (0.00s)
=== NAME  TestAccSignOnPolicyAction_ConditionsIPHighRisk
    resource_sign_on_policy_action_test.go:1362: Test to be re-defined
=== CONT  TestAccSignOnPolicyAction_IDFirstAction
=== NAME  TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
    resource_sign_on_policy_action_test.go:1538: Test to be re-defined
=== CONT  TestAccSignOnPolicyAction_LoginAction_Gateway
=== CONT  TestAccSignOnPolicyAction_LoginAction
=== CONT  TestAccSignOnPolicyAction_MultipleActionChange
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPHighRisk (0.00s)
--- SKIP: TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed (0.00s)
=== CONT  TestAccSignOnPolicyAction_MFAAction
=== NAME  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
    resource_sign_on_policy_action_test.go:1300: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple (0.00s)
=== CONT  TestAccSignOnPolicyAction_BadParameters
=== NAME  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
    resource_sign_on_policy_action_test.go:1240: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle (0.00s)
=== CONT  TestAccSignOnPolicyAction_PingIDAction
=== NAME  TestAccSignOnPolicyAction_ConditionsGeovelocity
    resource_sign_on_policy_action_test.go:1420: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsGeovelocity (0.00s)
=== CONT  TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
=== NAME  TestAccSignOnPolicyAction_MFAAction
    resource_sign_on_policy_action_test.go:411: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_MFAAction (0.00s)
=== CONT  TestAccSignOnPolicyAction_ProgressiveProfilingAction
--- PASS: TestAccSignOnPolicyAction_ConditionsInvalidPriority1 (12.10s)
=== CONT  TestAccSignOnPolicyAction_AgreementAction
--- PASS: TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction (16.81s)
=== CONT  TestAccSignOnPolicyAction_ConditionsCompound
--- PASS: TestAccSignOnPolicyAction_PingIDAction (17.00s)
=== CONT  TestAccSignOnPolicyAction_IDPAction
--- PASS: TestAccSignOnPolicyAction_RemovalDrift (18.75s)
--- PASS: TestAccSignOnPolicyAction_BadParameters (20.86s)
--- PASS: TestAccSignOnPolicyAction_ConditionsCompound (13.42s)
--- PASS: TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle (32.22s)
--- PASS: TestAccSignOnPolicyAction_MultipleActionChange (32.55s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString (32.95s)
--- PASS: TestAccSignOnPolicyAction_ConditionsMemberOfPopulations (33.49s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple (33.88s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool (33.88s)
--- PASS: TestAccSignOnPolicyAction_ProgressiveProfilingAction (34.48s)
--- PASS: TestAccSignOnPolicyAction_ConditionsMemberOfPopulation (35.01s)
--- PASS: TestAccSignOnPolicyAction_LoginAction_Gateway (39.80s)
--- PASS: TestAccSignOnPolicyAction_LoginAction (41.21s)
--- PASS: TestAccSignOnPolicyAction_IDFirstAction (41.25s)
--- PASS: TestAccSignOnPolicyAction_IDPAction (26.70s)
--- PASS: TestAccSignOnPolicyAction_AgreementAction (64.83s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 77.477s
```