### PR TITLE
Fixed "Incompatible environment region for the organization tenant" error when the `region` parameter is defaulted from the client connection

### DIFF
--- a/.changelog/535.txt
+++ b/.changelog/535.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_environment`: Fixed "Incompatible environment region for the organization tenant" error when the `region` parameter is defaulted from the client connection.
+```


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

* `resource/pingone_environment`: Fixed "Incompatible environment region for the organization tenant" error when the `region` parameter is defaulted from the client connection.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 2400s -run ^TestAccEnvironment_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccEnvironment_RemovalDrift
=== PAUSE TestAccEnvironment_RemovalDrift
=== RUN   TestAccEnvironment_Full
=== PAUSE TestAccEnvironment_Full
=== RUN   TestAccEnvironment_Minimal
=== PAUSE TestAccEnvironment_Minimal
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== RUN   TestAccEnvironment_DeleteProductionEnvironmentProtection
=== PAUSE TestAccEnvironment_DeleteProductionEnvironmentProtection
=== RUN   TestAccEnvironment_DeleteProductionEnvironment
=== PAUSE TestAccEnvironment_DeleteProductionEnvironment
=== RUN   TestAccEnvironment_NonPopulationServices
=== PAUSE TestAccEnvironment_NonPopulationServices
=== RUN   TestAccEnvironment_EnvironmentTypeSwitching
=== PAUSE TestAccEnvironment_EnvironmentTypeSwitching
=== RUN   TestAccEnvironment_ServiceAndPopulationSwitching
=== PAUSE TestAccEnvironment_ServiceAndPopulationSwitching
=== RUN   TestAccEnvironment_Services
=== PAUSE TestAccEnvironment_Services
=== RUN   TestAccEnvironment_BadParameters
=== PAUSE TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_RemovalDrift
=== CONT  TestAccEnvironment_NonPopulationServices
=== CONT  TestAccEnvironment_Services
=== CONT  TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_ServiceAndPopulationSwitching
=== CONT  TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_DeleteProductionEnvironment
=== CONT  TestAccEnvironment_DeleteProductionEnvironmentProtection
=== CONT  TestAccEnvironment_Minimal
=== CONT  TestAccEnvironment_Full
=== CONT  TestAccEnvironment_EnvironmentTypeSwitching
=== NAME  TestAccEnvironment_DeleteProductionEnvironment
    resource_environment_test.go:336: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironment (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironmentProtection
    resource_environment_test.go:309: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironmentProtection (0.00s)
--- PASS: TestAccEnvironment_NonCompatibleRegion (3.48s)
--- PASS: TestAccEnvironment_RemovalDrift (8.53s)
--- PASS: TestAccEnvironment_Minimal (9.69s)
--- PASS: TestAccEnvironment_NonPopulationServices (10.29s)
--- PASS: TestAccEnvironment_BadParameters (10.71s)
--- PASS: TestAccEnvironment_EnvironmentTypeSwitching (19.98s)
--- PASS: TestAccEnvironment_ServiceAndPopulationSwitching (24.18s)
--- PASS: TestAccEnvironment_Full (27.73s)
--- PASS: TestAccEnvironment_Services (36.53s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        37.119s
```