### PR TITLE
`resource/pingone_application`: Added support for whether `requestedAuthnContext` is taken into account in SAML application policy decision-making

### DIFF
--- a/.changelog/542.txt
+++ b/.changelog/542.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_application`: Added support for whether `requestedAuthnContext` is taken into account in SAML application policy decision-making.
+```

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -316,6 +316,7 @@ Required:
 Optional:
 
 - `assertion_signed_enabled` (Boolean) A boolean that specifies whether the SAML assertion itself should be signed. Defaults to `true`.
+- `enable_requested_authn_context` (Boolean) A boolean that specifies whether `requestedAuthnContext` is taken into account in policy decision-making.
 - `home_page_url` (String) A string that specifies the custom home page URL for the application.
 - `idp_signing_key` (Block List, Max: 1) SAML application assertion/response signing key settings.  Use with `assertion_signed_enabled` to enable assertion signing and/or `response_is_signed` to enable response signing.  It's highly recommended, and best practice, to define signing key settings for the configured SAML application.  However if this property is omitted, the default signing certificate for the environment is used.  This parameter will become a required field in the next major release of the provider. (see [below for nested schema](#nestedblock--saml_options--idp_signing_key))
 - `idp_signing_key_id` (String, Deprecated) An ID for the certificate key pair to be used by the identity provider to sign assertions and responses. If this property is omitted, the default signing certificate for the environment is used.

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -556,6 +556,11 @@ func ResourceApplication() *schema.Resource {
 								},
 							},
 						},
+						"enable_requested_authn_context": {
+							Description: "A boolean that specifies whether `requestedAuthnContext` is taken into account in policy decision-making.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+						},
 						"nameid_format": {
 							Description: "A string that specifies the format of the Subject NameID attibute in the SAML assertion.",
 							Type:        schema.TypeString,
@@ -1509,6 +1514,10 @@ func expandApplicationSAML(d *schema.ResourceData) (*management.ApplicationSAML,
 			application.SetIdpSigning(idpSigning)
 		}
 
+		if v1, ok := samlOptions["enable_requested_authn_context"].(bool); ok {
+			application.SetEnableRequestedAuthnContext(v1)
+		}
+
 		if v1, ok := samlOptions["nameid_format"].(string); ok && v1 != "" {
 			application.SetNameIdFormat(v1)
 		}
@@ -1982,6 +1991,12 @@ func flattenSAMLOptions(application *management.ApplicationSAML) interface{} {
 	} else {
 		item["idp_signing_key"] = nil
 		item["idp_signing_key_id"] = nil
+	}
+
+	if v, ok := application.GetEnableRequestedAuthnContextOk(); ok {
+		item["enable_requested_authn_context"] = v
+	} else {
+		item["enable_requested_authn_context"] = nil
 	}
 
 	if v, ok := application.GetNameIdFormatOk(); ok {

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -2592,6 +2592,7 @@ func TestAccApplication_SAMLFull(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.idp_signing_key.#", "1"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.idp_signing_key.0.algorithm", ""),
 					resource.TestMatchResourceAttr(resourceFullName, "saml_options.0.idp_signing_key.0.key_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.enable_requested_authn_context", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.nameid_format", "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.response_is_signed", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.slo_binding", "HTTP_REDIRECT"),
@@ -2659,6 +2660,7 @@ func TestAccApplication_SAMLMinimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.assertion_signed_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "saml_options.0.idp_signing_key_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.idp_signing_key.#", "1"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.enable_requested_authn_context", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.nameid_format", ""),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.response_is_signed", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "saml_options.0.slo_binding", "HTTP_POST"),
@@ -3934,14 +3936,15 @@ resource "pingone_application" "%[2]s" {
     assertion_duration = 3600
     sp_entity_id       = "sp:entity:%[2]s"
 
-    assertion_signed_enabled = false
-    idp_signing_key_id       = pingone_key.%[2]s.id
-    nameid_format            = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-    response_is_signed       = true
-    slo_binding              = "HTTP_REDIRECT"
-    slo_endpoint             = "https://www.pingidentity.com/sloendpoint"
-    slo_response_endpoint    = "https://www.pingidentity.com/sloresponseendpoint"
-    slo_window               = 3
+    assertion_signed_enabled       = false
+    idp_signing_key_id             = pingone_key.%[2]s.id
+    enable_requested_authn_context = true
+    nameid_format                  = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+    response_is_signed             = true
+    slo_binding                    = "HTTP_REDIRECT"
+    slo_endpoint                   = "https://www.pingidentity.com/sloendpoint"
+    slo_response_endpoint          = "https://www.pingidentity.com/sloresponseendpoint"
+    slo_window                     = 3
 
     // sp_verification_certificate_ids = []
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_application`: Added support for whether `requestedAuthnContext` is taken into account in SAML application policy decision-making.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 2400s -run ^TestAccApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccApplication_RemovalDrift
=== PAUSE TestAccApplication_RemovalDrift
=== RUN   TestAccApplication_NewEnv
=== PAUSE TestAccApplication_NewEnv
=== RUN   TestAccApplication_OIDCFullWeb
=== PAUSE TestAccApplication_OIDCFullWeb
=== RUN   TestAccApplication_OIDCMinimalWeb
=== PAUSE TestAccApplication_OIDCMinimalWeb
=== RUN   TestAccApplication_OIDCWebUpdate
=== PAUSE TestAccApplication_OIDCWebUpdate
=== RUN   TestAccApplication_OIDCFullNative
=== PAUSE TestAccApplication_OIDCFullNative
=== RUN   TestAccApplication_OIDCMinimalNative
=== PAUSE TestAccApplication_OIDCMinimalNative
=== RUN   TestAccApplication_OIDCNativeUpdate
=== PAUSE TestAccApplication_OIDCNativeUpdate
=== RUN   TestAccApplication_NativeKerberos
=== PAUSE TestAccApplication_NativeKerberos
=== RUN   TestAccApplication_NativeMobile
=== PAUSE TestAccApplication_NativeMobile
=== RUN   TestAccApplication_NativeMobile_IntegrityDetection
=== PAUSE TestAccApplication_NativeMobile_IntegrityDetection
=== RUN   TestAccApplication_OIDCFullCustom
=== PAUSE TestAccApplication_OIDCFullCustom
=== RUN   TestAccApplication_OIDCMinimalCustom
=== PAUSE TestAccApplication_OIDCMinimalCustom
=== RUN   TestAccApplication_OIDCCustomUpdate
=== PAUSE TestAccApplication_OIDCCustomUpdate
=== RUN   TestAccApplication_OIDCFullService
=== PAUSE TestAccApplication_OIDCFullService
=== RUN   TestAccApplication_OIDCMinimalService
=== PAUSE TestAccApplication_OIDCMinimalService
=== RUN   TestAccApplication_OIDCServiceUpdate
=== PAUSE TestAccApplication_OIDCServiceUpdate
=== RUN   TestAccApplication_OIDCFullSPA
=== PAUSE TestAccApplication_OIDCFullSPA
=== RUN   TestAccApplication_OIDCMinimalSPA
=== PAUSE TestAccApplication_OIDCMinimalSPA
=== RUN   TestAccApplication_OIDCSPAUpdate
=== PAUSE TestAccApplication_OIDCSPAUpdate
=== RUN   TestAccApplication_OIDCFullWorker
=== PAUSE TestAccApplication_OIDCFullWorker
=== RUN   TestAccApplication_OIDCMinimalWorker
=== PAUSE TestAccApplication_OIDCMinimalWorker
=== RUN   TestAccApplication_OIDCWorkerUpdate
=== PAUSE TestAccApplication_OIDCWorkerUpdate
=== RUN   TestAccApplication_OIDC_WildcardInRedirectURI
=== PAUSE TestAccApplication_OIDC_WildcardInRedirectURI
=== RUN   TestAccApplication_OIDC_LocalhostAddresses
=== PAUSE TestAccApplication_OIDC_LocalhostAddresses
=== RUN   TestAccApplication_OIDC_NativeAppAddresses
=== PAUSE TestAccApplication_OIDC_NativeAppAddresses
=== RUN   TestAccApplication_SAMLFull
=== PAUSE TestAccApplication_SAMLFull
=== RUN   TestAccApplication_SAMLMinimal
=== PAUSE TestAccApplication_SAMLMinimal
=== RUN   TestAccApplication_SAMLSigningKey
=== PAUSE TestAccApplication_SAMLSigningKey
=== RUN   TestAccApplication_ExternalLinkFull
=== PAUSE TestAccApplication_ExternalLinkFull
=== RUN   TestAccApplication_ExternalLinkMinimal
=== PAUSE TestAccApplication_ExternalLinkMinimal
=== RUN   TestAccApplication_Enabled
=== PAUSE TestAccApplication_Enabled
=== RUN   TestAccApplication_BadParameters
=== PAUSE TestAccApplication_BadParameters
=== CONT  TestAccApplication_RemovalDrift
=== CONT  TestAccApplication_OIDCFullSPA
=== CONT  TestAccApplication_OIDC_NativeAppAddresses
=== CONT  TestAccApplication_OIDCMinimalWorker
=== CONT  TestAccApplication_OIDCSPAUpdate
=== CONT  TestAccApplication_OIDCMinimalSPA
=== CONT  TestAccApplication_NativeMobile
=== CONT  TestAccApplication_OIDCServiceUpdate
=== CONT  TestAccApplication_SAMLMinimal
=== CONT  TestAccApplication_SAMLSigningKey
=== CONT  TestAccApplication_SAMLFull
=== CONT  TestAccApplication_OIDCFullNative
=== CONT  TestAccApplication_NativeKerberos
=== CONT  TestAccApplication_OIDCNativeUpdate
=== CONT  TestAccApplication_OIDCMinimalNative
=== CONT  TestAccApplication_OIDCFullWorker
--- PASS: TestAccApplication_OIDCMinimalSPA (11.68s)
=== CONT  TestAccApplication_OIDC_WildcardInRedirectURI
--- PASS: TestAccApplication_OIDCMinimalNative (12.78s)
=== CONT  TestAccApplication_OIDC_LocalhostAddresses
--- PASS: TestAccApplication_OIDC_NativeAppAddresses (12.88s)
=== CONT  TestAccApplication_OIDCWorkerUpdate
--- PASS: TestAccApplication_SAMLMinimal (12.88s)
=== CONT  TestAccApplication_OIDCMinimalWeb
--- PASS: TestAccApplication_OIDCMinimalWorker (12.88s)
=== CONT  TestAccApplication_OIDCWebUpdate
--- PASS: TestAccApplication_RemovalDrift (15.58s)
=== CONT  TestAccApplication_OIDCCustomUpdate
--- PASS: TestAccApplication_SAMLFull (15.75s)
=== CONT  TestAccApplication_OIDCMinimalService
--- PASS: TestAccApplication_OIDCFullNative (17.16s)
=== CONT  TestAccApplication_OIDCFullService
--- PASS: TestAccApplication_OIDCFullWorker (17.34s)
=== CONT  TestAccApplication_OIDCFullWeb
--- PASS: TestAccApplication_OIDCFullSPA (17.44s)
=== CONT  TestAccApplication_OIDCFullCustom
--- PASS: TestAccApplication_OIDCMinimalWeb (10.79s)
=== CONT  TestAccApplication_ExternalLinkFull
--- PASS: TestAccApplication_OIDC_WildcardInRedirectURI (13.60s)
=== CONT  TestAccApplication_OIDCMinimalCustom
--- PASS: TestAccApplication_OIDCMinimalService (10.94s)
=== CONT  TestAccApplication_BadParameters
--- PASS: TestAccApplication_OIDCSPAUpdate (31.47s)
=== CONT  TestAccApplication_Enabled
--- PASS: TestAccApplication_OIDCFullWeb (16.09s)
=== CONT  TestAccApplication_ExternalLinkMinimal
--- PASS: TestAccApplication_OIDCFullService (16.32s)
=== CONT  TestAccApplication_NewEnv
--- PASS: TestAccApplication_OIDCFullCustom (16.63s)
=== CONT  TestAccApplication_NativeMobile_IntegrityDetection
--- PASS: TestAccApplication_OIDCServiceUpdate (34.43s)
--- PASS: TestAccApplication_OIDCNativeUpdate (34.89s)
--- PASS: TestAccApplication_OIDCMinimalCustom (10.71s)
--- PASS: TestAccApplication_ExternalLinkFull (13.72s)
--- PASS: TestAccApplication_BadParameters (14.10s)
--- PASS: TestAccApplication_OIDCWebUpdate (29.10s)
--- PASS: TestAccApplication_ExternalLinkMinimal (8.85s)
--- PASS: TestAccApplication_OIDCWorkerUpdate (29.70s)
--- PASS: TestAccApplication_OIDC_LocalhostAddresses (30.64s)
--- PASS: TestAccApplication_OIDCCustomUpdate (29.37s)
--- PASS: TestAccApplication_NewEnv (13.82s)
--- PASS: TestAccApplication_Enabled (23.68s)
--- PASS: TestAccApplication_SAMLSigningKey (66.05s)
--- PASS: TestAccApplication_NativeKerberos (68.68s)
--- PASS: TestAccApplication_NativeMobile (74.40s)
--- PASS: TestAccApplication_NativeMobile_IntegrityDetection (92.53s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 127.441s
```