### PR TITLE
Migrate group resources to plugin framework

### DIFF
--- a/.changelog/543.txt
+++ b/.changelog/543.txt
@@ -1,0 +1,7 @@
+```release-note:note
+`resource/pingone_group`: Migrated to plugin framework.
+```
+
+```release-note:note
+`resource/pingone_group_nesting`: Migrated to plugin framework.
+```

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -2,12 +2,12 @@
 page_title: "pingone_group Resource - terraform-provider-pingone"
 subcategory: "SSO"
 description: |-
-  Resource to create and manage PingOne groups
+  Resource to create and manage PingOne groups.
 ---
 
 # pingone_group (Resource)
 
-Resource to create and manage PingOne groups
+Resource to create and manage PingOne groups.
 
 ## Example Usage
 
@@ -29,14 +29,14 @@ resource "pingone_group" "my_awesome_group" {
 
 ### Required
 
-- `environment_id` (String) The ID of the environment to create the group in.
+- `environment_id` (String) The ID of the environment to manage the group in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `name` (String) The name of the group.
 
 ### Optional
 
 - `description` (String) A description to apply to the group.
 - `external_id` (String) A user defined ID that represents the counterpart group in an external system.
-- `population_id` (String) The ID of the population that the group should be assigned to.
+- `population_id` (String) The ID of the population that the group should be assigned to.  This field is immutable and will trigger a replace plan if changed.
 - `user_filter` (String) A SCIM filter to dynamically assign users to the group.  Examples are found in the [PingOne online documentation](https://docs.pingidentity.com/bundle/pingone/page/kti1564020489340.html).
 
 ### Read-Only

--- a/docs/resources/group_nesting.md
+++ b/docs/resources/group_nesting.md
@@ -40,9 +40,9 @@ resource "pingone_group_nesting" "my_group_nesting" {
 
 ### Required
 
-- `environment_id` (String) The ID of the environment to create the group in.
-- `group_id` (String) The ID of the parent group to assign the nested group to.
-- `nested_group_id` (String) The ID of the group to configure as a nested group.
+- `environment_id` (String) The ID of the environment to manage the group nesting in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `group_id` (String) The ID of the parent group to assign the nested group to.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `nested_group_id` (String) The ID of the group to configure as a nested group.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 
 ### Read-Only
 

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -131,7 +131,6 @@ func New(version string) func() *schema.Provider {
 				"pingone_application":                           sso.ResourceApplication(),
 				"pingone_application_sign_on_policy_assignment": sso.ResourceApplicationSignOnPolicyAssignment(),
 				"pingone_application_role_assignment":           sso.ResourceApplicationRoleAssignment(),
-				"pingone_group_nesting":                         sso.ResourceGroupNesting(),
 				"pingone_identity_provider":                     sso.ResourceIdentityProvider(),
 				"pingone_password_policy":                       sso.ResourcePasswordPolicy(),
 				"pingone_resource":                              sso.ResourceResource(),

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -131,7 +131,6 @@ func New(version string) func() *schema.Provider {
 				"pingone_application":                           sso.ResourceApplication(),
 				"pingone_application_sign_on_policy_assignment": sso.ResourceApplicationSignOnPolicyAssignment(),
 				"pingone_application_role_assignment":           sso.ResourceApplicationRoleAssignment(),
-				"pingone_group":                                 sso.ResourceGroup(),
 				"pingone_group_nesting":                         sso.ResourceGroupNesting(),
 				"pingone_identity_provider":                     sso.ResourceIdentityProvider(),
 				"pingone_password_policy":                       sso.ResourcePasswordPolicy(),

--- a/internal/service/sso/resource_group_nesting_test.go
+++ b/internal/service/sso/resource_group_nesting_test.go
@@ -182,19 +182,19 @@ func TestAccGroupNesting_BadParameters(t *testing.T) {
 			{
 				ResourceName: resourceFullName,
 				ImportState:  true,
-				ExpectError:  regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/group_id/group_nesting_id" and must match regex: .*`),
+				ExpectError:  regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 			{
 				ResourceName:  resourceFullName,
 				ImportStateId: "/",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/group_id/group_nesting_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 			{
 				ResourceName:  resourceFullName,
 				ImportStateId: "badformat/badformat/badformat",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/group_id/group_nesting_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 		},
 	})

--- a/internal/service/sso/service.go
+++ b/internal/service/sso/service.go
@@ -21,6 +21,7 @@ func Resources() []func() resource.Resource {
 		NewApplicationFlowPolicyAssignmentResource,
 		NewApplicationResourceGrantResource,
 		NewGroupResource,
+		NewGroupNestingResource,
 		NewIdentityProviderAttributeResource,
 		NewPopulationResource,
 		NewResourceAttributeResource,

--- a/internal/service/sso/service.go
+++ b/internal/service/sso/service.go
@@ -20,6 +20,7 @@ func Resources() []func() resource.Resource {
 		NewApplicationAttributeMappingResource,
 		NewApplicationFlowPolicyAssignmentResource,
 		NewApplicationResourceGrantResource,
+		NewGroupResource,
 		NewIdentityProviderAttributeResource,
 		NewPopulationResource,
 		NewResourceAttributeResource,


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_group`: Migrated to plugin framework.
- `resource/pingone_group_nesting`: Migrated to plugin framework.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 2400s -run ^TestAccGroupNesting_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso && \
TF_ACC=1 go test -v -timeout 2400s -run ^TestAccGroup_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccGroupNesting_RemovalDrift
=== PAUSE TestAccGroupNesting_RemovalDrift
=== RUN   TestAccGroupNesting_Full
=== PAUSE TestAccGroupNesting_Full
=== RUN   TestAccGroupNesting_BadParameters
=== PAUSE TestAccGroupNesting_BadParameters
=== CONT  TestAccGroupNesting_RemovalDrift
=== CONT  TestAccGroupNesting_BadParameters
=== CONT  TestAccGroupNesting_Full
--- PASS: TestAccGroupNesting_Full (8.76s)
--- PASS: TestAccGroupNesting_RemovalDrift (9.55s)
--- PASS: TestAccGroupNesting_BadParameters (9.86s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 10.336s
=== RUN   TestAccGroup_RemovalDrift
=== PAUSE TestAccGroup_RemovalDrift
=== RUN   TestAccGroup_NewEnv
=== PAUSE TestAccGroup_NewEnv
=== RUN   TestAccGroup_Full
=== PAUSE TestAccGroup_Full
=== RUN   TestAccGroup_BadParameters
=== PAUSE TestAccGroup_BadParameters
=== CONT  TestAccGroup_RemovalDrift
=== CONT  TestAccGroup_Full
=== CONT  TestAccGroup_NewEnv
=== CONT  TestAccGroup_BadParameters
--- PASS: TestAccGroup_NewEnv (7.94s)
--- PASS: TestAccGroup_RemovalDrift (8.81s)
--- PASS: TestAccGroup_BadParameters (9.01s)
--- PASS: TestAccGroup_Full (36.56s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 37.037s
```