### PR TITLE
Support for additional refresh token replay protection on OIDC applications

### DIFF
--- a/.changelog/560.txt
+++ b/.changelog/560.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_application`: Added support for additional refresh token replay protection configuration on OIDC applications.
+```

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -222,6 +222,7 @@ Required:
 
 Optional:
 
+- `additional_refresh_token_replay_protection_enabled` (Boolean) A boolean that, when set to `true` (the default), if you attempt to reuse the refresh token, the authorization server immediately revokes the reused refresh token, as well as all descendant tokens. Setting this to null equates to a `false` setting. Defaults to `true`.
 - `allow_wildcards_in_redirect_uris` (Boolean) A boolean to specify whether wildcards are allowed in redirect URIs. For more information, see [Wildcards in Redirect URIs](https://docs.pingidentity.com/csh?context=p1_c_wildcard_redirect_uri). Defaults to `false`.
 - `bundle_id` (String, Deprecated) **Deprecation Notice** This field is deprecated and will be removed in a future release. Use `oidc_options.mobile_app.bundle_id` instead. A string that specifies the bundle associated with the application, for push notifications in native apps. The value of the `bundle_id` property is unique per environment, and once defined, is immutable; any change will force recreation of the application resource.
 - `certificate_based_authentication` (Block List, Max: 1) Certificate based authentication settings. This parameter block can only be set where the application's `type` parameter is set to `NATIVE_APP`. (see [below for nested schema](#nestedblock--oidc_options--certificate_based_authentication))

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -260,6 +260,12 @@ func ResourceApplication() *schema.Resource {
 							Optional:         true,
 							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(0, 86400)),
 						},
+						"additional_refresh_token_replay_protection_enabled": {
+							Description: "A boolean that, when set to `true` (the default), if you attempt to reuse the refresh token, the authorization server immediately revokes the reused refresh token, as well as all descendant tokens. Setting this to null equates to a `false` setting.",
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+						},
 						"client_id": {
 							Description: "A string that specifies the application ID used to authenticate to the authorization server.",
 							Type:        schema.TypeString,
@@ -1182,36 +1188,19 @@ func expandApplicationOIDC(d *schema.ResourceData) (*management.ApplicationOIDC,
 		}
 
 		if v1, ok := oidcOptions["refresh_token_duration"].(int); ok {
-			//if refreshTokenEnabled {
 			application.SetRefreshTokenDuration(int32(v1))
-			//} else {
-			//	diags = append(diags, diag.Diagnostic{
-			//		Severity: diag.Warning,
-			//		Summary:  fmt.Sprintf("`refresh_token_duration` has no effect when the %s grant type is not set", management.ENUMAPPLICATIONOIDCGRANTTYPE_REFRESH_TOKEN),
-			//	})
-			//}
 		}
 
 		if v1, ok := oidcOptions["refresh_token_rolling_duration"].(int); ok {
-			//if refreshTokenEnabled {
 			application.SetRefreshTokenRollingDuration(int32(v1))
-			//} else {
-			//	diags = append(diags, diag.Diagnostic{
-			//		Severity: diag.Warning,
-			//		Summary:  fmt.Sprintf("`refresh_token_rolling_duration` has no effect when the %s grant type is not set", management.ENUMAPPLICATIONOIDCGRANTTYPE_REFRESH_TOKEN),
-			//	})
-			//}
 		}
 
 		if v1, ok := oidcOptions["refresh_token_rolling_grace_period_duration"].(int); ok {
-			//if refreshTokenEnabled {
 			application.SetRefreshTokenRollingGracePeriodDuration(int32(v1))
-			//} else {
-			//	diags = append(diags, diag.Diagnostic{
-			//		Severity: diag.Warning,
-			//		Summary:  fmt.Sprintf("`refresh_token_rolling_duration` has no effect when the %s grant type is not set", management.ENUMAPPLICATIONOIDCGRANTTYPE_REFRESH_TOKEN),
-			//	})
-			//}
+		}
+
+		if v1, ok := oidcOptions["additional_refresh_token_replay_protection_enabled"].(bool); ok {
+			application.SetAdditionalRefreshTokenReplayProtectionEnabled(v1)
 		}
 
 		if v, ok := oidcOptions["tags"]; ok {
@@ -1780,6 +1769,12 @@ func flattenOIDCOptions(application *management.ApplicationOIDC, secret *managem
 		item["refresh_token_rolling_grace_period_duration"] = v
 	} else {
 		item["refresh_token_rolling_grace_period_duration"] = nil
+	}
+
+	if v, ok := application.GetAdditionalRefreshTokenReplayProtectionEnabledOk(); ok {
+		item["additional_refresh_token_replay_protection_enabled"] = v
+	} else {
+		item["additional_refresh_token_replay_protection_enabled"] = nil
 	}
 
 	if v, ok := secret.GetSecretOk(); ok {

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -221,6 +221,7 @@ func TestAccApplication_OIDCFullWeb(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "true"),
@@ -297,6 +298,7 @@ func TestAccApplication_OIDCMinimalWeb(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -360,6 +362,7 @@ func TestAccApplication_OIDCWebUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -416,6 +419,7 @@ func TestAccApplication_OIDCWebUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "true"),
@@ -458,6 +462,7 @@ func TestAccApplication_OIDCWebUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -529,6 +534,7 @@ func TestAccApplication_OIDCFullNative(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -619,6 +625,7 @@ func TestAccApplication_OIDCMinimalNative(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -699,6 +706,7 @@ func TestAccApplication_OIDCNativeUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -755,6 +763,7 @@ func TestAccApplication_OIDCNativeUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -814,6 +823,7 @@ func TestAccApplication_OIDCNativeUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1233,6 +1243,7 @@ func TestAccApplication_OIDCFullCustom(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1306,6 +1317,7 @@ func TestAccApplication_OIDCMinimalCustom(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1387,6 +1399,7 @@ func TestAccApplication_OIDCCustomUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1426,6 +1439,7 @@ func TestAccApplication_OIDCCustomUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1486,6 +1500,7 @@ func TestAccApplication_OIDCCustomUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1567,6 +1582,7 @@ func TestAccApplication_OIDCFullService(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1643,6 +1659,7 @@ func TestAccApplication_OIDCMinimalService(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1724,6 +1741,7 @@ func TestAccApplication_OIDCServiceUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1766,6 +1784,7 @@ func TestAccApplication_OIDCServiceUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1826,6 +1845,7 @@ func TestAccApplication_OIDCServiceUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "3000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "30000000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "80000"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "false"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -1902,6 +1922,7 @@ func TestAccApplication_OIDCFullSPA(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "true"),
@@ -1977,6 +1998,7 @@ func TestAccApplication_OIDCMinimalSPA(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -2039,6 +2061,7 @@ func TestAccApplication_OIDCSPAUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -2094,6 +2117,7 @@ func TestAccApplication_OIDCSPAUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "true"),
@@ -2135,6 +2159,7 @@ func TestAccApplication_OIDCSPAUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -2207,6 +2232,7 @@ func TestAccApplication_OIDCFullWorker(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -2282,6 +2308,7 @@ func TestAccApplication_OIDCMinimalWorker(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -2344,6 +2371,7 @@ func TestAccApplication_OIDCWorkerUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -2395,6 +2423,7 @@ func TestAccApplication_OIDCWorkerUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -2436,6 +2465,7 @@ func TestAccApplication_OIDCWorkerUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_duration", "2592000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_duration", "15552000"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.refresh_token_rolling_grace_period_duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.additional_refresh_token_replay_protection_enabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.0.client_secret", regexp.MustCompile(`[a-zA-Z0-9-~_]{10,}`)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.0.support_unsigned_request_object", "false"),
@@ -3017,9 +3047,10 @@ resource "pingone_application" "%[2]s" {
     allow_wildcards_in_redirect_uris = true
     post_logout_redirect_uris        = ["https://www.pingidentity.com/logout", "https://pingidentity.com/logout"]
 
-    refresh_token_duration                      = 3000000
-    refresh_token_rolling_duration              = 30000000
-    refresh_token_rolling_grace_period_duration = 80000
+    refresh_token_duration                             = 3000000
+    refresh_token_rolling_duration                     = 30000000
+    refresh_token_rolling_grace_period_duration        = 80000
+    additional_refresh_token_replay_protection_enabled = false
 
     home_page_url      = "https://www.pingidentity.com"
     initiate_login_uri = "https://www.pingidentity.com/initiate"
@@ -3549,9 +3580,10 @@ resource "pingone_application" "%[2]s" {
     allow_wildcards_in_redirect_uris = true
     post_logout_redirect_uris        = ["https://www.pingidentity.com/logout", "https://pingidentity.com/logout"]
 
-    refresh_token_duration                      = 3000000
-    refresh_token_rolling_duration              = 30000000
-    refresh_token_rolling_grace_period_duration = 80000
+    refresh_token_duration                             = 3000000
+    refresh_token_rolling_duration                     = 30000000
+    refresh_token_rolling_grace_period_duration        = 80000
+    additional_refresh_token_replay_protection_enabled = false
 
     home_page_url      = "https://www.pingidentity.com"
     initiate_login_uri = "https://www.pingidentity.com/initiate"
@@ -3641,9 +3673,10 @@ resource "pingone_application" "%[2]s" {
     allow_wildcards_in_redirect_uris = true
     post_logout_redirect_uris        = ["https://www.pingidentity.com/logout", "https://pingidentity.com/logout"]
 
-    refresh_token_duration                      = 3000000
-    refresh_token_rolling_duration              = 30000000
-    refresh_token_rolling_grace_period_duration = 80000
+    refresh_token_duration                             = 3000000
+    refresh_token_rolling_duration                     = 30000000
+    refresh_token_rolling_grace_period_duration        = 80000
+    additional_refresh_token_replay_protection_enabled = false
 
     home_page_url      = "https://www.pingidentity.com"
     initiate_login_uri = "https://www.pingidentity.com/initiate"


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_application`: Supports for additional refresh token replay protection on OIDC applications.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 2400s -run ^TestAccApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccApplication_RemovalDrift
=== PAUSE TestAccApplication_RemovalDrift
=== RUN   TestAccApplication_NewEnv
=== PAUSE TestAccApplication_NewEnv
=== RUN   TestAccApplication_OIDCFullWeb
=== PAUSE TestAccApplication_OIDCFullWeb
=== RUN   TestAccApplication_OIDCMinimalWeb
=== PAUSE TestAccApplication_OIDCMinimalWeb
=== RUN   TestAccApplication_OIDCWebUpdate
=== PAUSE TestAccApplication_OIDCWebUpdate
=== RUN   TestAccApplication_OIDCFullNative
=== PAUSE TestAccApplication_OIDCFullNative
=== RUN   TestAccApplication_OIDCMinimalNative
=== PAUSE TestAccApplication_OIDCMinimalNative
=== RUN   TestAccApplication_OIDCNativeUpdate
=== PAUSE TestAccApplication_OIDCNativeUpdate
=== RUN   TestAccApplication_NativeKerberos
=== PAUSE TestAccApplication_NativeKerberos
=== RUN   TestAccApplication_NativeMobile
=== PAUSE TestAccApplication_NativeMobile
=== RUN   TestAccApplication_NativeMobile_IntegrityDetection
=== PAUSE TestAccApplication_NativeMobile_IntegrityDetection
=== RUN   TestAccApplication_OIDCFullCustom
=== PAUSE TestAccApplication_OIDCFullCustom
=== RUN   TestAccApplication_OIDCMinimalCustom
=== PAUSE TestAccApplication_OIDCMinimalCustom
=== RUN   TestAccApplication_OIDCCustomUpdate
=== PAUSE TestAccApplication_OIDCCustomUpdate
=== RUN   TestAccApplication_OIDCFullService
=== PAUSE TestAccApplication_OIDCFullService
=== RUN   TestAccApplication_OIDCMinimalService
=== PAUSE TestAccApplication_OIDCMinimalService
=== RUN   TestAccApplication_OIDCServiceUpdate
=== PAUSE TestAccApplication_OIDCServiceUpdate
=== RUN   TestAccApplication_OIDCFullSPA
=== PAUSE TestAccApplication_OIDCFullSPA
=== RUN   TestAccApplication_OIDCMinimalSPA
=== PAUSE TestAccApplication_OIDCMinimalSPA
=== RUN   TestAccApplication_OIDCSPAUpdate
=== PAUSE TestAccApplication_OIDCSPAUpdate
=== RUN   TestAccApplication_OIDCFullWorker
=== PAUSE TestAccApplication_OIDCFullWorker
=== RUN   TestAccApplication_OIDCMinimalWorker
=== PAUSE TestAccApplication_OIDCMinimalWorker
=== RUN   TestAccApplication_OIDCWorkerUpdate
=== PAUSE TestAccApplication_OIDCWorkerUpdate
=== RUN   TestAccApplication_OIDC_WildcardInRedirectURI
=== PAUSE TestAccApplication_OIDC_WildcardInRedirectURI
=== RUN   TestAccApplication_OIDC_LocalhostAddresses
=== PAUSE TestAccApplication_OIDC_LocalhostAddresses
=== RUN   TestAccApplication_OIDC_NativeAppAddresses
=== PAUSE TestAccApplication_OIDC_NativeAppAddresses
=== RUN   TestAccApplication_SAMLFull
=== PAUSE TestAccApplication_SAMLFull
=== RUN   TestAccApplication_SAMLMinimal
=== PAUSE TestAccApplication_SAMLMinimal
=== RUN   TestAccApplication_SAMLSigningKey
=== PAUSE TestAccApplication_SAMLSigningKey
=== RUN   TestAccApplication_ExternalLinkFull
=== PAUSE TestAccApplication_ExternalLinkFull
=== RUN   TestAccApplication_ExternalLinkMinimal
=== PAUSE TestAccApplication_ExternalLinkMinimal
=== RUN   TestAccApplication_Enabled
=== PAUSE TestAccApplication_Enabled
=== RUN   TestAccApplication_BadParameters
=== PAUSE TestAccApplication_BadParameters
=== CONT  TestAccApplication_RemovalDrift
=== CONT  TestAccApplication_OIDCFullSPA
=== CONT  TestAccApplication_OIDC_NativeAppAddresses
=== CONT  TestAccApplication_NativeMobile
=== CONT  TestAccApplication_OIDCMinimalWorker
=== CONT  TestAccApplication_OIDCSPAUpdate
=== CONT  TestAccApplication_OIDCFullWorker
=== CONT  TestAccApplication_ExternalLinkFull
=== CONT  TestAccApplication_BadParameters
=== CONT  TestAccApplication_Enabled
=== CONT  TestAccApplication_ExternalLinkMinimal
=== CONT  TestAccApplication_OIDCFullNative
=== CONT  TestAccApplication_NativeKerberos
=== CONT  TestAccApplication_OIDCNativeUpdate
=== CONT  TestAccApplication_OIDCMinimalNative
=== CONT  TestAccApplication_OIDCMinimalSPA
--- PASS: TestAccApplication_ExternalLinkMinimal (11.11s)
=== CONT  TestAccApplication_OIDC_LocalhostAddresses
--- PASS: TestAccApplication_OIDCMinimalWorker (11.45s)
=== CONT  TestAccApplication_OIDCCustomUpdate
--- PASS: TestAccApplication_OIDC_NativeAppAddresses (11.72s)
=== CONT  TestAccApplication_OIDCServiceUpdate
--- PASS: TestAccApplication_OIDCMinimalNative (11.86s)
=== CONT  TestAccApplication_OIDCMinimalService
--- PASS: TestAccApplication_OIDCMinimalSPA (12.14s)
=== CONT  TestAccApplication_OIDCFullService
--- PASS: TestAccApplication_RemovalDrift (15.00s)
=== CONT  TestAccApplication_OIDCWorkerUpdate
--- PASS: TestAccApplication_OIDCFullNative (15.30s)
=== CONT  TestAccApplication_OIDCFullCustom
--- PASS: TestAccApplication_OIDCFullWorker (15.54s)
=== CONT  TestAccApplication_OIDCMinimalCustom
--- PASS: TestAccApplication_BadParameters (16.54s)
=== CONT  TestAccApplication_NativeMobile_IntegrityDetection
--- PASS: TestAccApplication_ExternalLinkFull (17.28s)
=== CONT  TestAccApplication_SAMLMinimal
--- PASS: TestAccApplication_OIDCFullSPA (17.44s)
=== CONT  TestAccApplication_SAMLSigningKey
--- PASS: TestAccApplication_OIDCMinimalService (10.23s)
=== CONT  TestAccApplication_OIDCMinimalWeb
--- PASS: TestAccApplication_OIDCMinimalCustom (9.90s)
=== CONT  TestAccApplication_OIDCWebUpdate
--- PASS: TestAccApplication_OIDCFullService (14.00s)
=== CONT  TestAccApplication_OIDCFullWeb
=== CONT  TestAccApplication_NewEnv
--- PASS: TestAccApplication_SAMLMinimal (9.51s)
--- PASS: TestAccApplication_Enabled (27.45s)
=== CONT  TestAccApplication_SAMLFull
--- PASS: TestAccApplication_OIDCFullCustom (13.48s)
=== CONT  TestAccApplication_OIDC_WildcardInRedirectURI
--- PASS: TestAccApplication_OIDCSPAUpdate (30.15s)
--- PASS: TestAccApplication_OIDCNativeUpdate (31.60s)
--- PASS: TestAccApplication_OIDCMinimalWeb (10.01s)
--- PASS: TestAccApplication_OIDCFullWeb (13.35s)
--- PASS: TestAccApplication_OIDCCustomUpdate (28.06s)
--- PASS: TestAccApplication_SAMLFull (12.22s)
--- PASS: TestAccApplication_OIDCServiceUpdate (28.23s)
--- PASS: TestAccApplication_OIDC_LocalhostAddresses (29.03s)
--- PASS: TestAccApplication_OIDC_WildcardInRedirectURI (13.60s)
--- PASS: TestAccApplication_OIDCWorkerUpdate (27.73s)
--- PASS: TestAccApplication_OIDCWebUpdate (23.65s)
--- PASS: TestAccApplication_NewEnv (25.01s)
--- PASS: TestAccApplication_NativeKerberos (63.76s)
--- PASS: TestAccApplication_NativeMobile (69.43s)
--- PASS: TestAccApplication_SAMLSigningKey (52.16s)
--- PASS: TestAccApplication_NativeMobile_IntegrityDetection (91.82s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 108.838s
```