### PR TITLE
Fix inability to apply application grants to the Self-Service and Portal system applications

### DIFF
--- a/.changelog/573.txt
+++ b/.changelog/573.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_application_resource_grant`: Fixed inability to apply application grants to the Self-Service and Portal system applications.
+```


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_application_resource_grant`: Fixed inability to apply application grants to the Self-Service and Portal system applications.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccApplicationResourceGrant_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccApplicationResourceGrant_RemovalDrift
=== PAUSE TestAccApplicationResourceGrant_RemovalDrift
=== RUN   TestAccApplicationResourceGrant_OpenIDResource
=== PAUSE TestAccApplicationResourceGrant_OpenIDResource
=== RUN   TestAccApplicationResourceGrant_CustomResource
=== PAUSE TestAccApplicationResourceGrant_CustomResource
=== RUN   TestAccApplicationResourceGrant_SystemApplication
=== PAUSE TestAccApplicationResourceGrant_SystemApplication
=== RUN   TestAccApplicationResourceGrant_Change
=== PAUSE TestAccApplicationResourceGrant_Change
=== RUN   TestAccApplicationResourceGrant_BadParameters
=== PAUSE TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_RemovalDrift
=== CONT  TestAccApplicationResourceGrant_SystemApplication
=== CONT  TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_Change
=== CONT  TestAccApplicationResourceGrant_CustomResource
=== CONT  TestAccApplicationResourceGrant_OpenIDResource
--- PASS: TestAccApplicationResourceGrant_CustomResource (10.42s)
--- PASS: TestAccApplicationResourceGrant_BadParameters (11.52s)
--- PASS: TestAccApplicationResourceGrant_RemovalDrift (12.20s)
--- PASS: TestAccApplicationResourceGrant_OpenIDResource (17.67s)
--- PASS: TestAccApplicationResourceGrant_Change (21.90s)
--- PASS: TestAccApplicationResourceGrant_SystemApplication (27.90s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 28.459s
```