### PR TITLE
Corrected deprecated retry method

### DIFF
--- a/.changelog/574.txt
+++ b/.changelog/574.txt
@@ -1,0 +1,11 @@
+```release-note:note
+`resource/pingone_environment`: Corrected deprecated retry method.
+```
+
+```release-note:note
+`resource/pingone_system_application`: Corrected deprecated retry method.
+```
+
+```release-note:note
+`data-source/pingone_population`: Corrected deprecated retry method.
+```

--- a/internal/service/base/resource_environment.go
+++ b/internal/service/base/resource_environment.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	sdkv2resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
@@ -885,7 +885,7 @@ func (r *EnvironmentResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	deleteStateConf := &sdkv2resource.StateChangeConf{
+	deleteStateConf := &retry.StateChangeConf{
 		Pending: []string{
 			"200",
 			"403",
@@ -904,7 +904,7 @@ func (r *EnvironmentResource) Delete(ctx context.Context, req resource.DeleteReq
 		MinTimeout:                500 * time.Millisecond,
 		ContinuousTargetOccurence: 2,
 	}
-	_, err := deleteStateConf.WaitForState()
+	_, err := deleteStateConf.WaitForStateContext(ctx)
 	if err != nil {
 		resp.Diagnostics.AddWarning(
 			"Environment Delete Timeout",

--- a/internal/service/base/resource_system_application.go
+++ b/internal/service/base/resource_system_application.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	sdkv2resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	boolvalidatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/boolvalidator"
@@ -771,7 +771,7 @@ func FetchApplicationsByType(ctx context.Context, apiClient *management.APIClien
 func FetchApplicationsByTypeWithTimeout(ctx context.Context, apiClient *management.APIClient, environmentID string, applicationType management.EnumApplicationType, expectAtLeastOneResult bool, timeout time.Duration) (*[]management.ReadOneApplication200Response, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	stateConf := &sdkv2resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			"false",
 		},
@@ -840,7 +840,7 @@ func FetchApplicationsByTypeWithTimeout(ctx context.Context, apiClient *manageme
 		MinTimeout:                2 * time.Second,
 		ContinuousTargetOccurence: 2,
 	}
-	applicationResponse, err := stateConf.WaitForState()
+	applicationResponse, err := stateConf.WaitForStateContext(ctx)
 
 	if err != nil {
 		diags.AddError(

--- a/internal/service/sso/data_source_population.go
+++ b/internal/service/sso/data_source_population.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	sdkv2resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/pingidentity/terraform-provider-pingone/internal/filter"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
@@ -238,7 +238,7 @@ func FetchDefaultPopulation(ctx context.Context, apiClient *management.APIClient
 func FetchDefaultPopulationWithTimeout(ctx context.Context, apiClient *management.APIClient, environmentID string, timeout time.Duration) (*management.Population, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	stateConf := &sdkv2resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			"false",
 		},
@@ -293,7 +293,7 @@ func FetchDefaultPopulationWithTimeout(ctx context.Context, apiClient *managemen
 		MinTimeout:                5 * time.Second,
 		ContinuousTargetOccurence: 2,
 	}
-	population, err := stateConf.WaitForState()
+	population, err := stateConf.WaitForStateContext(ctx)
 
 	if err != nil {
 		diags.AddWarning(


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_environment`: Corrected deprecated retry method.
- `resource/pingone_system_application`: Corrected deprecated retry method.
- `data-source/pingone_population`: Corrected deprecated retry method.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccEnvironment_ github.com/pingidentity/terraform-provider-pingone/internal/service/base && \
TF_ACC=1 go test -v -timeout 500s -run ^TestAccSystemApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/base && \
TF_ACC=1 go test -v -timeout 500s -run ^TestAccPopulationDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccEnvironment_RemovalDrift
=== PAUSE TestAccEnvironment_RemovalDrift
=== RUN   TestAccEnvironment_Full
=== PAUSE TestAccEnvironment_Full
=== RUN   TestAccEnvironment_Minimal
=== PAUSE TestAccEnvironment_Minimal
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== RUN   TestAccEnvironment_DeleteProductionEnvironmentProtection
=== PAUSE TestAccEnvironment_DeleteProductionEnvironmentProtection
=== RUN   TestAccEnvironment_DeleteProductionEnvironment
=== PAUSE TestAccEnvironment_DeleteProductionEnvironment
=== RUN   TestAccEnvironment_NonPopulationServices
=== PAUSE TestAccEnvironment_NonPopulationServices
=== RUN   TestAccEnvironment_EnvironmentTypeSwitching
=== PAUSE TestAccEnvironment_EnvironmentTypeSwitching
=== RUN   TestAccEnvironment_ServiceAndPopulationSwitching
=== PAUSE TestAccEnvironment_ServiceAndPopulationSwitching
=== RUN   TestAccEnvironment_Services
=== PAUSE TestAccEnvironment_Services
=== RUN   TestAccEnvironment_BadParameters
=== PAUSE TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_RemovalDrift
=== CONT  TestAccEnvironment_NonPopulationServices
=== CONT  TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_Services
=== CONT  TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_DeleteProductionEnvironmentProtection
=== CONT  TestAccEnvironment_Minimal
=== CONT  TestAccEnvironment_ServiceAndPopulationSwitching
=== CONT  TestAccEnvironment_EnvironmentTypeSwitching
=== CONT  TestAccEnvironment_DeleteProductionEnvironment
=== CONT  TestAccEnvironment_Full
=== NAME  TestAccEnvironment_DeleteProductionEnvironmentProtection
    resource_environment_test.go:309: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironmentProtection (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironment
    resource_environment_test.go:336: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironment (0.00s)
--- PASS: TestAccEnvironment_NonCompatibleRegion (2.17s)
--- PASS: TestAccEnvironment_RemovalDrift (5.60s)
--- PASS: TestAccEnvironment_Minimal (7.02s)
--- PASS: TestAccEnvironment_NonPopulationServices (7.25s)
--- PASS: TestAccEnvironment_BadParameters (8.60s)
--- PASS: TestAccEnvironment_EnvironmentTypeSwitching (14.27s)
--- PASS: TestAccEnvironment_ServiceAndPopulationSwitching (18.95s)
--- PASS: TestAccEnvironment_Full (23.97s)
--- PASS: TestAccEnvironment_Services (29.65s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        30.135s
=== RUN   TestAccSystemApplication_NewEnv
=== PAUSE TestAccSystemApplication_NewEnv
=== RUN   TestAccSystemApplication_Portal
=== PAUSE TestAccSystemApplication_Portal
=== RUN   TestAccSystemApplication_SelfService
=== PAUSE TestAccSystemApplication_SelfService
=== RUN   TestAccSystemApplication_BadParameters
=== PAUSE TestAccSystemApplication_BadParameters
=== CONT  TestAccSystemApplication_NewEnv
=== CONT  TestAccSystemApplication_SelfService
=== CONT  TestAccSystemApplication_BadParameters
=== CONT  TestAccSystemApplication_Portal
--- PASS: TestAccSystemApplication_NewEnv (13.18s)
--- PASS: TestAccSystemApplication_BadParameters (15.07s)
--- PASS: TestAccSystemApplication_Portal (56.80s)
--- PASS: TestAccSystemApplication_SelfService (60.18s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        60.658s
=== RUN   TestAccPopulationDataSource_ByNameFull
=== PAUSE TestAccPopulationDataSource_ByNameFull
=== RUN   TestAccPopulationDataSource_ByIDFull
=== PAUSE TestAccPopulationDataSource_ByIDFull
=== RUN   TestAccPopulationDataSource_NotFound
=== PAUSE TestAccPopulationDataSource_NotFound
=== CONT  TestAccPopulationDataSource_ByNameFull
=== CONT  TestAccPopulationDataSource_NotFound
=== CONT  TestAccPopulationDataSource_ByIDFull
--- PASS: TestAccPopulationDataSource_NotFound (1.94s)
--- PASS: TestAccPopulationDataSource_ByIDFull (7.24s)
--- PASS: TestAccPopulationDataSource_ByNameFull (7.38s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 7.931s
```