### PR TITLE
430-Added support for images in a verifiable credential configuration.

### DIFF
--- a/.changelog/579.txt
+++ b/.changelog/579.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+`resource/pingone_credential_type`: Added support for image attributes in a verifiable credential configuration.
+```
+
+```release-note:enhancement
+`data_source/pingone_credential_type`: Added support for image attributes in a verifiable credential configuration.
+```
+
+```release-note:note
+`resource/pingone_credential_type`: Improved test cases and migrated to dynamically-created test environments.
+```
+
+```release-note:note
+`data_source/pingone_credential_type`: Improved test cases and migrated to dynamically-created test environments.
+```

--- a/.changelog/579.txt
+++ b/.changelog/579.txt
@@ -5,11 +5,3 @@
 ```release-note:enhancement
 `data_source/pingone_credential_type`: Added support for image attributes in a verifiable credential configuration.
 ```
-
-```release-note:note
-`resource/pingone_credential_type`: Improved test cases and migrated to dynamically-created test environments.
-```
-
-```release-note:note
-`data_source/pingone_credential_type`: Improved test cases and migrated to dynamically-created test environments.
-```

--- a/docs/data-sources/credential_type.md
+++ b/docs/data-sources/credential_type.md
@@ -61,6 +61,7 @@ Read-Only:
 Read-Only:
 
 - `attribute` (String) Name of the PingOne Directory attribute. Present if field.type is Directory Attribute.
+- `file_support` (String) Specifies how an image is stored in the credential field.
 - `id` (String) Identifier of the field object.
 - `is_visible` (Boolean) Specifies whether the field should be visible to viewers of the credential.
 - `title` (String) Descriptive text when showing the field.

--- a/docs/resources/credential_type.md
+++ b/docs/resources/credential_type.md
@@ -97,6 +97,13 @@ EOT
         is_visible = false
       },
       {
+        type         = "Directory Attribute"
+        title        = "photo"
+        attribute    = "photo"
+        file_support = "REFERENCE_FILE"
+        is_visible   = true
+      },
+      {
         type       = "Directory Attribute"
         title      = "id"
         attribute  = "id"
@@ -158,11 +165,12 @@ Read-Only:
 
 Required:
 
-- `type` (String) Type of data in the credential field. The must contain one of the following types: `Directory Attribute`, `Alphanumeric Text`, or `Issued Timestamp`.
+- `type` (String) Specifies the type of data in the credential field.  Options are `Alphanumeric Text`, `Directory Attribute`, `Issued Timestamp`.
 
 Optional:
 
 - `attribute` (String) Name of the PingOne Directory attribute. Present if `field.type` is `Directory Attribute`.
+- `file_support` (String) Specifies how an image is stored in the credential field.  Options are `BASE64_STRING`, `INCLUDE_FILE`, `REFERENCE_FILE`.
 - `is_visible` (Boolean) Specifies whether the field should be visible to viewers of the credential.
 - `title` (String) Descriptive text when showing the field.
 - `value` (String) The text to appear on the credential for a `field.type` of `Alphanumeric Text`.

--- a/examples/resources/pingone_credential_type/resource.tf
+++ b/examples/resources/pingone_credential_type/resource.tf
@@ -80,6 +80,13 @@ EOT
         is_visible = false
       },
       {
+        type         = "Directory Attribute"
+        title        = "photo"
+        attribute    = "photo"
+        file_support = "REFERENCE_FILE"
+        is_visible   = true
+      },
+      {
         type       = "Directory Attribute"
         title      = "id"
         attribute  = "id"

--- a/internal/service/credentials/data_source_credential_type.go
+++ b/internal/service/credentials/data_source_credential_type.go
@@ -47,12 +47,13 @@ type MetadataDataSourceModel struct {
 }
 
 type FieldsDataSourceModel struct {
-	Id        types.String `tfsdk:"id"`
-	Type      types.String `tfsdk:"type"`
-	Title     types.String `tfsdk:"title"`
-	IsVisible types.Bool   `tfsdk:"is_visible"`
-	Attribute types.String `tfsdk:"attribute"`
-	Value     types.String `tfsdk:"value"`
+	Id          types.String `tfsdk:"id"`
+	Type        types.String `tfsdk:"type"`
+	Title       types.String `tfsdk:"title"`
+	FileSupport types.String `tfsdk:"file_support"`
+	IsVisible   types.Bool   `tfsdk:"is_visible"`
+	Attribute   types.String `tfsdk:"attribute"`
+	Value       types.String `tfsdk:"value"`
 }
 
 var (
@@ -70,12 +71,13 @@ var (
 	}
 
 	innerFieldsDataSourceServiceTFObjectTypes = map[string]attr.Type{
-		"id":         types.StringType,
-		"type":       types.StringType,
-		"title":      types.StringType,
-		"is_visible": types.BoolType,
-		"attribute":  types.StringType,
-		"value":      types.StringType,
+		"id":           types.StringType,
+		"type":         types.StringType,
+		"title":        types.StringType,
+		"file_support": types.StringType,
+		"is_visible":   types.BoolType,
+		"attribute":    types.StringType,
+		"value":        types.StringType,
 	}
 )
 
@@ -207,16 +209,20 @@ func (r *CredentialTypeDataSource) Schema(ctx context.Context, req datasource.Sc
 									Description: "Descriptive text when showing the field.",
 									Computed:    true,
 								},
+								"file_support": schema.StringAttribute{
+									Description: "Specifies how an image is stored in the credential field.",
+									Computed:    true,
+								},
+								"is_visible": schema.BoolAttribute{
+									Description: "Specifies whether the field should be visible to viewers of the credential.",
+									Computed:    true,
+								},
 								"attribute": schema.StringAttribute{
 									Description: "Name of the PingOne Directory attribute. Present if field.type is Directory Attribute.",
 									Computed:    true,
 								},
 								"value": schema.StringAttribute{
 									Description: "The text to appear on the credential for a field.type of Alphanumeric Text.",
-									Computed:    true,
-								},
-								"is_visible": schema.BoolAttribute{
-									Description: "Specifies whether the field should be visible to viewers of the credential.",
 									Computed:    true,
 								},
 							},
@@ -377,12 +383,13 @@ func toStateFieldsDataSource(innerFields []credentials.CredentialTypeMetaDataFie
 	for _, v := range innerFields {
 
 		fieldsMap := map[string]attr.Value{
-			"id":         framework.StringOkToTF(v.GetIdOk()),
-			"title":      framework.StringOkToTF(v.GetTitleOk()),
-			"attribute":  framework.StringOkToTF(v.GetAttributeOk()),
-			"value":      framework.StringOkToTF(v.GetValueOk()),
-			"is_visible": framework.BoolOkToTF(v.GetIsVisibleOk()),
-			"type":       framework.EnumOkToTF(v.GetTypeOk()),
+			"id":           framework.StringOkToTF(v.GetIdOk()),
+			"type":         framework.EnumOkToTF(v.GetTypeOk()),
+			"title":        framework.StringOkToTF(v.GetTitleOk()),
+			"file_support": framework.EnumOkToTF(v.GetFileSupportOk()),
+			"is_visible":   framework.BoolOkToTF(v.GetIsVisibleOk()),
+			"attribute":    framework.StringOkToTF(v.GetAttributeOk()),
+			"value":        framework.StringOkToTF(v.GetValueOk()),
 		}
 		innerflattenedObj, d := types.ObjectValue(innerFieldsDataSourceServiceTFObjectTypes, fieldsMap)
 		diags.Append(d...)

--- a/internal/service/credentials/data_source_credential_type_test.go
+++ b/internal/service/credentials/data_source_credential_type_test.go
@@ -2,6 +2,7 @@ package credentials_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -19,6 +20,9 @@ func TestAccCredentialTypeDataSource_ByIDFull(t *testing.T) {
 
 	name := acctest.ResourceNameGen()
 
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -26,7 +30,7 @@ func TestAccCredentialTypeDataSource_ByIDFull(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCredentialTypeDataSource_ByIDFull(resourceName, name),
+				Config: testAccCredentialTypeDataSource_ByIDFull(environmentName, licenseID, resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceFullName, "id", verify.P1ResourceIDRegexp),
 					resource.TestMatchResourceAttr(dataSourceFullName, "environment_id", verify.P1ResourceIDRegexp),
@@ -44,7 +48,7 @@ func TestAccCredentialTypeDataSource_ByIDFull(t *testing.T) {
 				),
 			},
 			{
-				Config:  testAccCredentialTypeDataSource_ByIDFull(resourceName, name),
+				Config:  testAccCredentialTypeDataSource_ByIDFull(environmentName, licenseID, resourceName, name),
 				Destroy: true,
 			},
 		},
@@ -56,6 +60,9 @@ func TestAccCredentialTypeDataSource_NotFound(t *testing.T) {
 
 	resourceName := acctest.ResourceNameGen()
 
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -63,7 +70,7 @@ func TestAccCredentialTypeDataSource_NotFound(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCredentialTypeDataSource_NotFoundByID(resourceName),
+				Config:      testAccCredentialTypeDataSource_NotFoundByID(environmentName, licenseID, resourceName),
 				ExpectError: regexp.MustCompile("Error: Error when calling `ReadOneCredentialType`: The request could not be completed. The requested resource was not found."),
 			},
 		},
@@ -75,6 +82,9 @@ func TestAccCredentialTypeDataSource_InvalidConfig(t *testing.T) {
 
 	resourceName := acctest.ResourceNameGen()
 
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -82,33 +92,33 @@ func TestAccCredentialTypeDataSource_InvalidConfig(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCredentialTypeDataSource_NoEnvironmentID(resourceName),
+				Config:      testAccCredentialTypeDataSource_NoEnvironmentID(environmentName, licenseID, resourceName),
 				ExpectError: regexp.MustCompile("Error: Missing required argument"),
 			},
 			{
-				Config:      testAccCredentialTypeDataSource_NoCredentialTypeID(resourceName),
+				Config:      testAccCredentialTypeDataSource_NoCredentialTypeID(environmentName, licenseID, resourceName),
 				ExpectError: regexp.MustCompile("Error: Missing required argument"),
 			},
 		},
 	})
 }
 
-func testAccCredentialTypeDataSource_ByIDFull(resourceName, name string) string {
+func testAccCredentialTypeDataSource_ByIDFull(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_credential_type" "%[2]s" {
-  environment_id       = data.pingone_environment.general_test.id
-  title                = "%[3]s"
-  description          = "%[3]s Example Description"
-  card_type            = "%[3]s"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id       = pingone_environment.%[2]s.id
+  title                = "%[4]s"
+  description          = "%[4]s Example Description"
+  card_type            = "%[4]s"
   card_design_template = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 740 480\"><rect fill=\"none\" width=\"736\" height=\"476\" stroke=\"#CACED3\" stroke-width=\"3\" rx=\"10\" ry=\"10\" x=\"2\" y=\"2\"></rect><rect fill=\"$${cardColor}\" height=\"476\" rx=\"10\" ry=\"10\" width=\"736\" x=\"2\" y=\"2\" opacity=\"$${bgOpacityPercent}\"></rect><line y2=\"160\" x2=\"695\" y1=\"160\" x1=\"42.5\" stroke=\"$${textColor}\"></line><text fill=\"$${textColor}\" font-weight=\"450\" font-size=\"30\" x=\"160\" y=\"90\">$${cardTitle}</text><text fill=\"$${textColor}\" font-size=\"25\" font-weight=\"300\" x=\"160\" y=\"130\">$${cardSubtitle}</text></svg>"
   revoke_on_delete     = false
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     columns            = 2
-    description        = "%[3]s Example Description"
+    description        = "%[4]s Example Description"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#eff0f1"
@@ -155,45 +165,52 @@ resource "pingone_credential_type" "%[2]s" {
         title      = "id"
         attribute  = "id"
         is_visible = false
+      },
+      {
+        type         = "Directory Attribute"
+        title        = "photo"
+        attribute    = "photo"
+        is_visible   = false
+        file_support = "REFERENCE_FILE"
       }
     ]
   }
 }
 
-data "pingone_credential_type" "%[2]s" {
-  environment_id     = data.pingone_environment.general_test.id
-  credential_type_id = resource.pingone_credential_type.%[2]s.id
+data "pingone_credential_type" "%[3]s" {
+  environment_id     = pingone_environment.%[2]s.id
+  credential_type_id = resource.pingone_credential_type.%[3]s.id
 
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeDataSource_NotFoundByID(resourceName string) string {
+func testAccCredentialTypeDataSource_NotFoundByID(environmentName, licenseID, resourceName string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-data "pingone_credential_type" "%[2]s" {
-  environment_id     = data.pingone_environment.general_test.id
+data "pingone_credential_type" "%[3]s" {
+  environment_id     = pingone_environment.%[2]s.id
   credential_type_id = "9c052a8a-14be-44e4-8f07-2662569994ce" // dummy ID that conforms to UUID v4
 
-}`, acctest.GenericSandboxEnvironment(), resourceName)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }
 
-func testAccCredentialTypeDataSource_NoEnvironmentID(resourceName string) string {
+func testAccCredentialTypeDataSource_NoEnvironmentID(environmentName, licenseID, resourceName string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-data "pingone_credential_type" "%[2]s" {
+data "pingone_credential_type" "%[3]s" {
   credential_type_id = "9c052a8a-14be-44e4-8f07-2662569994ce" // dummy ID that conforms to UUID v4
 
-}`, acctest.GenericSandboxEnvironment(), resourceName)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }
 
-func testAccCredentialTypeDataSource_NoCredentialTypeID(resourceName string) string {
+func testAccCredentialTypeDataSource_NoCredentialTypeID(environmentName, licenseID, resourceName string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-data "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+data "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
 
-}`, acctest.GenericSandboxEnvironment(), resourceName)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }

--- a/internal/service/credentials/resource_credential_type_test.go
+++ b/internal/service/credentials/resource_credential_type_test.go
@@ -102,9 +102,6 @@ func TestAccCredentialType_RemovalDrift(t *testing.T) {
 
 	name := resourceName
 
-	environmentName := acctest.ResourceNameGenEnvironment()
-	licenseID := os.Getenv("PINGONE_LICENSE_ID")
-
 	var resourceID, environmentID string
 
 	resource.Test(t, resource.TestCase{
@@ -115,7 +112,7 @@ func TestAccCredentialType_RemovalDrift(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, name),
+				Config: testAccCredentialTypeConfig_Minimal(resourceName, name),
 				Check:  testAccGetCredentialTypeIDs(resourceFullName, &environmentID, &resourceID),
 			},
 			// Replan after removal preconfig
@@ -182,9 +179,6 @@ func TestAccCredentialType_Full(t *testing.T) {
 
 	name := acctest.ResourceNameGen()
 
-	environmentName := acctest.ResourceNameGenEnvironment()
-	licenseID := os.Getenv("PINGONE_LICENSE_ID")
-
 	data, _ := os.ReadFile("../../acctest/test_assets/image/credential_background.png")
 	backgroundImage := base64.StdEncoding.EncodeToString(data)
 
@@ -203,7 +197,7 @@ func TestAccCredentialType_Full(t *testing.T) {
 `
 
 	fullStep := resource.TestStep{
-		Config: testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage),
+		Config: testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
@@ -227,11 +221,6 @@ func TestAccCredentialType_Full(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.title", "displayName"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.attribute", "name.formatted"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.is_visible", "false"),
-			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.id", "Directory Attribute -> photo"),
-			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.type", "Directory Attribute"),
-			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.title", "photo"),
-			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.attribute", "photo"),
-			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.is_visible", "false"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.file_support", "REFERENCE_FILE"),
 			resource.TestCheckResourceAttr(resourceFullName, "revoke_on_delete", "true"),
 			resource.TestMatchResourceAttr(resourceFullName, "created_at", verify.RFC3339Regexp),
@@ -250,7 +239,7 @@ func TestAccCredentialType_Full(t *testing.T) {
 `
 
 	minimalStep := resource.TestStep{
-		Config: testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, updatedName),
+		Config: testAccCredentialTypeConfig_Minimal(resourceName, updatedName),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
@@ -285,13 +274,13 @@ func TestAccCredentialType_Full(t *testing.T) {
 			// full - new
 			fullStep,
 			{
-				Config:  testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage),
+				Config:  testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage),
 				Destroy: true,
 			},
 			// minimal - new
 			minimalStep,
 			{
-				Config:  testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, updatedName),
+				Config:  testAccCredentialTypeConfig_Minimal(resourceName, updatedName),
 				Destroy: true,
 			},
 			// update
@@ -316,11 +305,11 @@ func TestAccCredentialType_Full(t *testing.T) {
 			},
 			// clear
 			{
-				Config:  testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, updatedName),
+				Config:  testAccCredentialTypeConfig_Minimal(resourceName, updatedName),
 				Destroy: true,
 			},
 			{
-				Config:  testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage),
+				Config:  testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage),
 				Destroy: true,
 			},
 		},
@@ -333,9 +322,6 @@ func TestAccCredentialType_MetaData(t *testing.T) {
 	resourceName := acctest.ResourceNameGen()
 	name := acctest.ResourceNameGen()
 
-	environmentName := acctest.ResourceNameGenEnvironment()
-	licenseID := os.Getenv("PINGONE_LICENSE_ID")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -343,32 +329,32 @@ func TestAccCredentialType_MetaData(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCredentialTypeConfig_InvalidTitle(environmentName, licenseID, resourceName, ""),
+				Config:      testAccCredentialTypeConfig_InvalidTitle(resourceName, ""),
 				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value Length"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_InvalidCardColorHexValue(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_InvalidCardColorHexValue(resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute metadata.card_color expected value to contain a valid 6-digit\nhexadecimal color code"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_InvalidTextColorHexValue(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_InvalidTextColorHexValue(resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute metadata.text_color expected value to contain a valid 6-digit\nhexadecimal color code"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute metadata.bg_opacity_percent value must be between 0 and 100"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_EmptyFieldsArray(environmentName, licenseID, resourceName, name),
-				ExpectError: regexp.MustCompile("Attribute metadata.fields list must contain at least 1 elements"),
+				Config:      testAccCredentialTypeConfig_EmptyFieldsArray(resourceName, name),
+				ExpectError: regexp.MustCompile("ttribute metadata.fields list must contain at least 1 elements"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_InvalidFileSupportValue(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_InvalidFileSupportValue(resourceName, name),
 				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value Match"),
 				Destroy:     true,
 			},
@@ -381,9 +367,6 @@ func TestAccCredentialType_CardDesignTemplate(t *testing.T) {
 
 	resourceName := acctest.ResourceNameGen()
 	name := acctest.ResourceNameGen()
-
-	environmentName := acctest.ResourceNameGenEnvironment()
-	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
 	data, _ := os.ReadFile("../../acctest/test_assets/image/credential_background.png")
 	backgroundImage := base64.StdEncoding.EncodeToString(data)
@@ -405,32 +388,32 @@ func TestAccCredentialType_CardDesignTemplate(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute card_design_template expected value to contain a valid PingOne\nCredentials SVG card template."),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(environmentName, licenseID, resourceName, name, backgroundImage),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(resourceName, name, backgroundImage),
 				ExpectError: regexp.MustCompile(noBackgroundImageErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(resourceName, name),
 				ExpectError: regexp.MustCompile(noCardColorErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(environmentName, licenseID, resourceName, name, logoImage),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(resourceName, name, logoImage),
 				ExpectError: regexp.MustCompile(noLogoImageErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(resourceName, name),
 				ExpectError: regexp.MustCompile(noSubTitleErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(environmentName, licenseID, resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(resourceName, name),
 				ExpectError: regexp.MustCompile(noTextColorErrorMsg),
 				Destroy:     true,
 			},
@@ -446,9 +429,6 @@ func TestAccCredentialType_BadParameters(t *testing.T) {
 
 	name := resourceName
 
-	environmentName := acctest.ResourceNameGenEnvironment()
-	licenseID := os.Getenv("PINGONE_LICENSE_ID")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -457,7 +437,7 @@ func TestAccCredentialType_BadParameters(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, name),
+				Config: testAccCredentialTypeConfig_Minimal(resourceName, name),
 			},
 			// Errors
 			{
@@ -514,24 +494,24 @@ resource "pingone_credential_type" "%[3]s" {
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage string) string {
+func testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_image" "%[3]s-background_image" {
-  environment_id    = pingone_environment.%[2]s.id
+resource "pingone_image" "%[2]s-background_image" {
+  environment_id    = data.pingone_environment.general_test.id
+  image_file_base64 = "%[4]s"
+}
+
+resource "pingone_image" "%[2]s-logo_image" {
+  environment_id    = data.pingone_environment.general_test.id
   image_file_base64 = "%[5]s"
 }
 
-resource "pingone_image" "%[3]s-logo_image" {
-  environment_id    = pingone_environment.%[2]s.id
-  image_file_base64 = "%[6]s"
-}
-
-resource "pingone_credential_type" "%[3]s" {
-  environment_id   = pingone_environment.%[2]s.id
-  title            = "%[4]s"
-  description      = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id   = data.pingone_environment.general_test.id
+  title            = "%[3]s"
+  description      = "%[3]s Example Description"
   card_type        = "VerifiedEmployee"
   revoke_on_delete = true
 
@@ -548,11 +528,11 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name               = "%[4]s"
-    description        = "%[4]s Example Description"
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
     columns            = 1
-    background_image   = pingone_image.%[3]s-background_image.uploaded_image[0].href
-    logo_image         = pingone_image.%[3]s-logo_image.uploaded_image[0].href
+    background_image   = pingone_image.%[2]s-background_image.uploaded_image[0].href
+    logo_image         = pingone_image.%[2]s-logo_image.uploaded_image[0].href
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#eff0f1"
@@ -609,17 +589,17 @@ EOT
       }
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, backgroundImage, logoImage)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name, backgroundImage, logoImage)
 }
 
-func testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_Minimal(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_credential_type" "%[3]s" {
-  environment_id   = pingone_environment.%[2]s.id
-  title            = "%[4]s"
-  description      = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id   = data.pingone_environment.general_test.id
+  title            = "%[3]s"
+  description      = "%[3]s Example Description"
   card_type        = "DemonstrationCard"
   revoke_on_delete = false
 
@@ -634,7 +614,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name = "%[4]s"
+    name = "%[3]s"
 
     fields = [
       {
@@ -644,17 +624,17 @@ EOT
       }
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidTitle(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidTitle(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -667,7 +647,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#eff0f1"
@@ -692,17 +672,17 @@ EOT
       }
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidCardColorHexValue(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidCardColorHexValue(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -716,7 +696,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "InvalidColor"
     text_color         = "#eff0f1"
@@ -729,16 +709,16 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidTextColorHexValue(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidTextColorHexValue(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -752,7 +732,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT  
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "InvalidColor"
@@ -765,16 +745,16 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -788,7 +768,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 101
     card_color         = "#000000"
     text_color         = "#000000"
@@ -801,16 +781,16 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_EmptyFieldsArray(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_EmptyFieldsArray(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -824,7 +804,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT  
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
@@ -832,17 +812,17 @@ EOT
     fields = [
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidFileSupportValue(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidFileSupportValue(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_credential_type" "%[3]s" {
-  environment_id   = pingone_environment.%[2]s.id
-  title            = "%[4]s"
-  description      = "%[4]s Example Description"
+  environment_id   = data.pingone_environment.general_test.id
+  title            = "%[3]s"
+  description      = "%[3]s Example Description"
   card_type        = "DemonstrationCard"
   revoke_on_delete = true
 
@@ -857,7 +837,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name = "%[4]s"
+    name = "%[3]s"
 
     fields = [
       {
@@ -868,16 +848,16 @@ EOT
       }
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   # missing svg tags
@@ -892,7 +872,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
@@ -905,22 +885,22 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(environmentName, licenseID, resourceName, name, backgroundImage string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(resourceName, name, backgroundImage string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_image" "%[3]s-background_image" {
-  environment_id    = pingone_environment.%[2]s.id
-  image_file_base64 = "%[5]s"
+resource "pingone_image" "%[2]s-background_image" {
+  environment_id    = data.pingone_environment.general_test.id
+  image_file_base64 = "%[4]s"
 }
 
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -934,11 +914,11 @@ resource "pingone_credential_type" "%[3]s" {
 EOT  
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
-    background_image   = pingone_image.%[3]s-background_image.uploaded_image[0].href
+    background_image   = pingone_image.%[2]s-background_image.uploaded_image[0].href
     //background_image = "https://wtf.example.com"
 
     fields = [
@@ -949,17 +929,17 @@ EOT
       },
     ]
   }
-  depends_on = [pingone_image.%[3]s-background_image]
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, backgroundImage)
+  depends_on = [pingone_image.%[2]s-background_image]
+}`, acctest.GenericSandboxEnvironment(), resourceName, name, backgroundImage)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -973,7 +953,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT  
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "#000000" # {cardColor} is missing from card_design_template
     text_color         = "#000000"
@@ -986,21 +966,21 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(environmentName, licenseID, resourceName, name, logoImage string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(resourceName, name, logoImage string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_image" "%[3]s-logo_image" {
-  environment_id    = pingone_environment.%[2]s.id
-  image_file_base64 = "%[5]s"
+resource "pingone_image" "%[2]s-logo_image" {
+  environment_id    = data.pingone_environment.general_test.id
+  image_file_base64 = "%[4]s"
 }
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -1014,12 +994,12 @@ resource "pingone_credential_type" "%[3]s" {
 EOT  
 
   metadata = {
-    name               = "%[4]s"
-    description        = "%[4]s Example Description"
+    name               = "%[3]s"
+    description        = "%[3]s Example Description"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
-    logo_image         = pingone_image.%[3]s-logo_image.uploaded_image[0].href # {logoImage} is missing from card_design_template
+    logo_image         = pingone_image.%[2]s-logo_image.uploaded_image[0].href # {logoImage} is missing from card_design_template
 
     fields = [
       {
@@ -1029,16 +1009,16 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, logoImage)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name, logoImage)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -1053,8 +1033,8 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name               = "%[4]s"
-    description        = "%[4]s Example Description" # {subTitle} missing from template - description maps to card subtitle value
+    name               = "%[3]s"
+    description        = "%[3]s Example Description" # {subTitle} missing from template - description maps to card subtitle value
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
@@ -1067,16 +1047,16 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(environmentName, licenseID, resourceName, name string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  title          = "%[4]s"
-  description    = "%[4]s Example Description"
+resource "pingone_credential_type" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  title          = "%[3]s"
+  description    = "%[3]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -1090,7 +1070,7 @@ resource "pingone_credential_type" "%[3]s" {
 EOT
 
   metadata = {
-    name               = "%[4]s"
+    name               = "%[3]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000" # {textColor} is missing from card_design_template
@@ -1103,5 +1083,5 @@ EOT
       },
     ]
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }

--- a/internal/service/credentials/resource_credential_type_test.go
+++ b/internal/service/credentials/resource_credential_type_test.go
@@ -102,6 +102,9 @@ func TestAccCredentialType_RemovalDrift(t *testing.T) {
 
 	name := resourceName
 
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
 	var resourceID, environmentID string
 
 	resource.Test(t, resource.TestCase{
@@ -112,7 +115,7 @@ func TestAccCredentialType_RemovalDrift(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccCredentialTypeConfig_Minimal(resourceName, name),
+				Config: testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, name),
 				Check:  testAccGetCredentialTypeIDs(resourceFullName, &environmentID, &resourceID),
 			},
 			// Replan after removal preconfig
@@ -179,6 +182,9 @@ func TestAccCredentialType_Full(t *testing.T) {
 
 	name := acctest.ResourceNameGen()
 
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
 	data, _ := os.ReadFile("../../acctest/test_assets/image/credential_background.png")
 	backgroundImage := base64.StdEncoding.EncodeToString(data)
 
@@ -197,7 +203,7 @@ func TestAccCredentialType_Full(t *testing.T) {
 `
 
 	fullStep := resource.TestStep{
-		Config: testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage),
+		Config: testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
@@ -215,12 +221,18 @@ func TestAccCredentialType_Full(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.bg_opacity_percent", "100"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.card_color", "#000000"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.text_color", "#eff0f1"),
-			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.#", "7"),
+			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.#", "8"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.id", "Directory Attribute -> displayName"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.type", "Directory Attribute"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.title", "displayName"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.attribute", "name.formatted"),
 			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.3.is_visible", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.id", "Directory Attribute -> photo"),
+			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.type", "Directory Attribute"),
+			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.title", "photo"),
+			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.attribute", "photo"),
+			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.is_visible", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "metadata.fields.7.file_support", "REFERENCE_FILE"),
 			resource.TestCheckResourceAttr(resourceFullName, "revoke_on_delete", "true"),
 			resource.TestMatchResourceAttr(resourceFullName, "created_at", verify.RFC3339Regexp),
 			resource.TestMatchResourceAttr(resourceFullName, "updated_at", verify.RFC3339Regexp),
@@ -238,7 +250,7 @@ func TestAccCredentialType_Full(t *testing.T) {
 `
 
 	minimalStep := resource.TestStep{
-		Config: testAccCredentialTypeConfig_Minimal(resourceName, updatedName),
+		Config: testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, updatedName),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
@@ -273,13 +285,13 @@ func TestAccCredentialType_Full(t *testing.T) {
 			// full - new
 			fullStep,
 			{
-				Config:  testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage),
+				Config:  testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage),
 				Destroy: true,
 			},
 			// minimal - new
 			minimalStep,
 			{
-				Config:  testAccCredentialTypeConfig_Minimal(resourceName, updatedName),
+				Config:  testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, updatedName),
 				Destroy: true,
 			},
 			// update
@@ -304,11 +316,11 @@ func TestAccCredentialType_Full(t *testing.T) {
 			},
 			// clear
 			{
-				Config:  testAccCredentialTypeConfig_Minimal(resourceName, updatedName),
+				Config:  testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, updatedName),
 				Destroy: true,
 			},
 			{
-				Config:  testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage),
+				Config:  testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage),
 				Destroy: true,
 			},
 		},
@@ -321,6 +333,9 @@ func TestAccCredentialType_MetaData(t *testing.T) {
 	resourceName := acctest.ResourceNameGen()
 	name := acctest.ResourceNameGen()
 
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -328,28 +343,33 @@ func TestAccCredentialType_MetaData(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCredentialTypeConfig_InvalidTitle(resourceName, ""),
+				Config:      testAccCredentialTypeConfig_InvalidTitle(environmentName, licenseID, resourceName, ""),
 				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value Length"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_InvalidCardColorHexValue(resourceName, name),
+				Config:      testAccCredentialTypeConfig_InvalidCardColorHexValue(environmentName, licenseID, resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute metadata.card_color expected value to contain a valid 6-digit\nhexadecimal color code"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_InvalidTextColorHexValue(resourceName, name),
+				Config:      testAccCredentialTypeConfig_InvalidTextColorHexValue(environmentName, licenseID, resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute metadata.text_color expected value to contain a valid 6-digit\nhexadecimal color code"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(resourceName, name),
+				Config:      testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(environmentName, licenseID, resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute metadata.bg_opacity_percent value must be between 0 and 100"),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_EmptyFieldsArray(resourceName, name),
-				ExpectError: regexp.MustCompile("ttribute metadata.fields list must contain at least 1 elements"),
+				Config:      testAccCredentialTypeConfig_EmptyFieldsArray(environmentName, licenseID, resourceName, name),
+				ExpectError: regexp.MustCompile("Attribute metadata.fields list must contain at least 1 elements"),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccCredentialTypeConfig_InvalidFileSupportValue(environmentName, licenseID, resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value Match"),
 				Destroy:     true,
 			},
 		},
@@ -361,6 +381,9 @@ func TestAccCredentialType_CardDesignTemplate(t *testing.T) {
 
 	resourceName := acctest.ResourceNameGen()
 	name := acctest.ResourceNameGen()
+
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
 	data, _ := os.ReadFile("../../acctest/test_assets/image/credential_background.png")
 	backgroundImage := base64.StdEncoding.EncodeToString(data)
@@ -382,32 +405,32 @@ func TestAccCredentialType_CardDesignTemplate(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(environmentName, licenseID, resourceName, name),
 				ExpectError: regexp.MustCompile("Attribute card_design_template expected value to contain a valid PingOne\nCredentials SVG card template."),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(resourceName, name, backgroundImage),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(environmentName, licenseID, resourceName, name, backgroundImage),
 				ExpectError: regexp.MustCompile(noBackgroundImageErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(environmentName, licenseID, resourceName, name),
 				ExpectError: regexp.MustCompile(noCardColorErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(resourceName, name, logoImage),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(environmentName, licenseID, resourceName, name, logoImage),
 				ExpectError: regexp.MustCompile(noLogoImageErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(environmentName, licenseID, resourceName, name),
 				ExpectError: regexp.MustCompile(noSubTitleErrorMsg),
 				Destroy:     true,
 			},
 			{
-				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(resourceName, name),
+				Config:      testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(environmentName, licenseID, resourceName, name),
 				ExpectError: regexp.MustCompile(noTextColorErrorMsg),
 				Destroy:     true,
 			},
@@ -423,6 +446,9 @@ func TestAccCredentialType_BadParameters(t *testing.T) {
 
 	name := resourceName
 
+	environmentName := acctest.ResourceNameGenEnvironment()
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheckEnvironment(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -431,7 +457,7 @@ func TestAccCredentialType_BadParameters(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccCredentialTypeConfig_Minimal(resourceName, name),
+				Config: testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, name),
 			},
 			// Errors
 			{
@@ -488,24 +514,24 @@ resource "pingone_credential_type" "%[3]s" {
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_Full(resourceName, name, backgroundImage, logoImage string) string {
+func testAccCredentialTypeConfig_Full(environmentName, licenseID, resourceName, name, backgroundImage, logoImage string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_image" "%[2]s-background_image" {
-  environment_id    = data.pingone_environment.general_test.id
-  image_file_base64 = "%[4]s"
-}
-
-resource "pingone_image" "%[2]s-logo_image" {
-  environment_id    = data.pingone_environment.general_test.id
+resource "pingone_image" "%[3]s-background_image" {
+  environment_id    = pingone_environment.%[2]s.id
   image_file_base64 = "%[5]s"
 }
 
-resource "pingone_credential_type" "%[2]s" {
-  environment_id   = data.pingone_environment.general_test.id
-  title            = "%[3]s"
-  description      = "%[3]s Example Description"
+resource "pingone_image" "%[3]s-logo_image" {
+  environment_id    = pingone_environment.%[2]s.id
+  image_file_base64 = "%[6]s"
+}
+
+resource "pingone_credential_type" "%[3]s" {
+  environment_id   = pingone_environment.%[2]s.id
+  title            = "%[4]s"
+  description      = "%[4]s Example Description"
   card_type        = "VerifiedEmployee"
   revoke_on_delete = true
 
@@ -522,11 +548,11 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
+    name               = "%[4]s"
+    description        = "%[4]s Example Description"
     columns            = 1
-    background_image   = pingone_image.%[2]s-background_image.uploaded_image[0].href
-    logo_image         = pingone_image.%[2]s-logo_image.uploaded_image[0].href
+    background_image   = pingone_image.%[3]s-background_image.uploaded_image[0].href
+    logo_image         = pingone_image.%[3]s-logo_image.uploaded_image[0].href
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#eff0f1"
@@ -573,20 +599,27 @@ EOT
         title      = "id"
         attribute  = "id"
         is_visible = false
+      },
+      {
+        type         = "Directory Attribute"
+        title        = "photo"
+        attribute    = "photo"
+        is_visible   = false
+        file_support = "REFERENCE_FILE"
       }
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name, backgroundImage, logoImage)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, backgroundImage, logoImage)
 }
 
-func testAccCredentialTypeConfig_Minimal(resourceName, name string) string {
+func testAccCredentialTypeConfig_Minimal(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_credential_type" "%[2]s" {
-  environment_id   = data.pingone_environment.general_test.id
-  title            = "%[3]s"
-  description      = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id   = pingone_environment.%[2]s.id
+  title            = "%[4]s"
+  description      = "%[4]s Example Description"
   card_type        = "DemonstrationCard"
   revoke_on_delete = false
 
@@ -601,7 +634,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name = "%[3]s"
+    name = "%[4]s"
 
     fields = [
       {
@@ -611,17 +644,17 @@ EOT
       }
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidTitle(resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidTitle(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -634,7 +667,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#eff0f1"
@@ -659,17 +692,17 @@ EOT
       }
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidCardColorHexValue(resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidCardColorHexValue(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -683,7 +716,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "InvalidColor"
     text_color         = "#eff0f1"
@@ -696,16 +729,16 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidTextColorHexValue(resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidTextColorHexValue(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -719,7 +752,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT  
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "InvalidColor"
@@ -732,16 +765,16 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidBackgroundOpacityValue(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -755,7 +788,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 101
     card_color         = "#000000"
     text_color         = "#000000"
@@ -768,16 +801,16 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_EmptyFieldsArray(resourceName, name string) string {
+func testAccCredentialTypeConfig_EmptyFieldsArray(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -791,7 +824,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT  
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
@@ -799,16 +832,52 @@ EOT
     fields = [
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(resourceName, name string) string {
+func testAccCredentialTypeConfig_InvalidFileSupportValue(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+
+resource "pingone_credential_type" "%[3]s" {
+  environment_id   = pingone_environment.%[2]s.id
+  title            = "%[4]s"
+  description      = "%[4]s Example Description"
+  card_type        = "DemonstrationCard"
+  revoke_on_delete = true
+
+  card_design_template = <<-EOT
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 740 480">
+<rect fill="none" width="736" height="476" stroke="#CACED3" stroke-width="3" rx="10" ry="10" x="2" y="2"></rect>
+<rect fill="" height="476" rx="10" ry="10" width="736" x="2" y="2" opacity=""></rect>
+<line y2="160" x2="695" y1="160" x1="42.5" stroke=""></line>
+<text fill="" font-weight="450" font-size="30" x="160" y="90">$${cardTitle}</text>
+<text font-size="25" font-weight="300" x="160" y="130">$${cardSubtitle}</text>
+</svg>
+EOT
+
+  metadata = {
+    name = "%[4]s"
+
+    fields = [
+      {
+        type         = "Issued Timestamp"
+        title        = "timestamp"
+        is_visible   = false
+        file_support = "REFERENCE_FILE"
+      }
+    ]
+  }
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}
+
+func testAccCredentialTypeConfig_CardDesignTemplate_NoSVG(environmentName, licenseID, resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   # missing svg tags
@@ -823,7 +892,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
@@ -836,22 +905,22 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(resourceName, name, backgroundImage string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoBackgroundImage(environmentName, licenseID, resourceName, name, backgroundImage string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_image" "%[2]s-background_image" {
-  environment_id    = data.pingone_environment.general_test.id
-  image_file_base64 = "%[4]s"
+resource "pingone_image" "%[3]s-background_image" {
+  environment_id    = pingone_environment.%[2]s.id
+  image_file_base64 = "%[5]s"
 }
 
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -865,11 +934,11 @@ resource "pingone_credential_type" "%[2]s" {
 EOT  
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
-    background_image   = pingone_image.%[2]s-background_image.uploaded_image[0].href
+    background_image   = pingone_image.%[3]s-background_image.uploaded_image[0].href
     //background_image = "https://wtf.example.com"
 
     fields = [
@@ -880,17 +949,17 @@ EOT
       },
     ]
   }
-  depends_on = [pingone_image.%[2]s-background_image]
-}`, acctest.GenericSandboxEnvironment(), resourceName, name, backgroundImage)
+  depends_on = [pingone_image.%[3]s-background_image]
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, backgroundImage)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(resourceName, name string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoCardColor(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -904,7 +973,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT  
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "#000000" # {cardColor} is missing from card_design_template
     text_color         = "#000000"
@@ -917,21 +986,21 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(resourceName, name, logoImage string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoLogoImage(environmentName, licenseID, resourceName, name, logoImage string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
-resource "pingone_image" "%[2]s-logo_image" {
-  environment_id    = data.pingone_environment.general_test.id
-  image_file_base64 = "%[4]s"
+resource "pingone_image" "%[3]s-logo_image" {
+  environment_id    = pingone_environment.%[2]s.id
+  image_file_base64 = "%[5]s"
 }
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -945,12 +1014,12 @@ resource "pingone_credential_type" "%[2]s" {
 EOT  
 
   metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description"
+    name               = "%[4]s"
+    description        = "%[4]s Example Description"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
-    logo_image         = pingone_image.%[2]s-logo_image.uploaded_image[0].href # {logoImage} is missing from card_design_template
+    logo_image         = pingone_image.%[3]s-logo_image.uploaded_image[0].href # {logoImage} is missing from card_design_template
 
     fields = [
       {
@@ -960,16 +1029,16 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name, logoImage)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, logoImage)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(resourceName, name string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoSubtitle(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -984,8 +1053,8 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name               = "%[3]s"
-    description        = "%[3]s Example Description" # {subTitle} missing from template - description maps to card subtitle value
+    name               = "%[4]s"
+    description        = "%[4]s Example Description" # {subTitle} missing from template - description maps to card subtitle value
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000"
@@ -998,16 +1067,16 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }
 
-func testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(resourceName, name string) string {
+func testAccCredentialTypeConfig_CardDesignTemplate_NoTextColor(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
-resource "pingone_credential_type" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  title          = "%[3]s"
-  description    = "%[3]s Example Description"
+resource "pingone_credential_type" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  title          = "%[4]s"
+  description    = "%[4]s Example Description"
   card_type      = "DemonstrationCard"
 
   card_design_template = <<-EOT
@@ -1021,7 +1090,7 @@ resource "pingone_credential_type" "%[2]s" {
 EOT
 
   metadata = {
-    name               = "%[3]s"
+    name               = "%[4]s"
     bg_opacity_percent = 100
     card_color         = "#000000"
     text_color         = "#000000" # {textColor} is missing from card_design_template
@@ -1034,5 +1103,5 @@ EOT
       },
     ]
   }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

`resource/pingone_credential_type`: 
- Added support for image attributes in a verifiable credential configuration.
- Improved test cases and migrated to dynamically-created test environments.

`data_source/pingone_credential_type`: 
- Added support for image attributes in a verifiable credential configuration.
- Improved test cases and migrated to dynamically-created test environments.

Reference:  [API Documentation](https://apidocs.pingidentity.com/pingone/platform/v1/api/#credentialing-fields-filesupport-types)

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG=WARN TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s -run TestAccCredentialType_ github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccCredentialType_RemovalDrift
=== PAUSE TestAccCredentialType_RemovalDrift
=== RUN   TestAccCredentialType_NewEnv
=== PAUSE TestAccCredentialType_NewEnv
=== RUN   TestAccCredentialType_Full
=== PAUSE TestAccCredentialType_Full
=== RUN   TestAccCredentialType_MetaData
=== PAUSE TestAccCredentialType_MetaData
=== RUN   TestAccCredentialType_CardDesignTemplate
=== PAUSE TestAccCredentialType_CardDesignTemplate
=== RUN   TestAccCredentialType_BadParameters
=== PAUSE TestAccCredentialType_BadParameters
=== CONT  TestAccCredentialType_RemovalDrift
=== CONT  TestAccCredentialType_CardDesignTemplate
=== CONT  TestAccCredentialType_Full
=== CONT  TestAccCredentialType_BadParameters
=== CONT  TestAccCredentialType_NewEnv
=== CONT  TestAccCredentialType_MetaData
--- PASS: TestAccCredentialType_MetaData (0.52s)
--- PASS: TestAccCredentialType_CardDesignTemplate (0.52s)
--- PASS: TestAccCredentialType_NewEnv (8.20s)
--- PASS: TestAccCredentialType_BadParameters (9.29s)
--- PASS: TestAccCredentialType_RemovalDrift (9.74s)
--- PASS: TestAccCredentialType_Full (41.23s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials

```