### PR TITLE
`resource/pingone_gateway`: Fixed incorrect unchanged plan when updating the `user_type` parameter.

### DIFF
--- a/.changelog/586.txt
+++ b/.changelog/586.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_gateway`: Fixed incorrect unchanged plan when updating the `user_type` parameter.
+```

--- a/internal/service/base/resource_gateway.go
+++ b/internal/service/base/resource_gateway.go
@@ -3,7 +3,6 @@ package base
 import (
 	"context"
 	"fmt"
-	"hash/crc32"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -136,7 +135,6 @@ func ResourceGateway() *schema.Resource {
 				Description: "For LDAP gateways only: A collection of properties that define how users should be provisioned in PingOne. The `user_type` block specifies which user properties in PingOne correspond to the user properties in an external LDAP directory. You can use an LDAP browser to view the user properties in the external LDAP directory.",
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Set:         userItemsHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -766,22 +764,9 @@ func expandLDAPUserLookupAttributeMappings(c []interface{}) []management.Gateway
 	return mappings
 }
 
-func userItemsHash(v interface{}) int {
+func flattenUserType(c []management.GatewayTypeLDAPAllOfUserTypes) []map[string]interface{} {
 
-	c := int(crc32.ChecksumIEEE([]byte(v.(map[string]interface{})["name"].(string))))
-	if c >= 0 {
-		return c
-	}
-	if -c >= 0 {
-		return -c
-	}
-	// v == MinInt
-	return 0
-}
-
-func flattenUserType(c []management.GatewayTypeLDAPAllOfUserTypes) *schema.Set {
-
-	items := schema.NewSet(userItemsHash, nil)
+	items := make([]map[string]interface{}, 0)
 
 	for _, v := range c {
 		// Required
@@ -816,8 +801,7 @@ func flattenUserType(c []management.GatewayTypeLDAPAllOfUserTypes) *schema.Set {
 			item["user_migration"] = nil
 		}
 
-		items.Add(item)
-
+		items = append(items, item)
 	}
 
 	return items

--- a/internal/service/base/resource_gateway_test.go
+++ b/internal/service/base/resource_gateway_test.go
@@ -419,17 +419,17 @@ func TestAccGateway_LDAP(t *testing.T) {
 
 	name := resourceName
 
-	fullStep := resource.TestStep{
-		Config: testAccGatewayConfig_LDAPFull(resourceName, name),
+	fullStep1 := resource.TestStep{
+		Config: testAccGatewayConfig_LDAPFull1(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 			resource.TestCheckResourceAttr(resourceFullName, "name", name),
 			resource.TestCheckResourceAttr(resourceFullName, "description", ""),
-			resource.TestCheckResourceAttr(resourceFullName, "enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "enabled", "true"),
 			resource.TestCheckResourceAttr(resourceFullName, "type", "LDAP"),
-			resource.TestCheckResourceAttr(resourceFullName, "bind_dn", "ou=test,dc=example,dc=com"),
-			resource.TestCheckResourceAttr(resourceFullName, "bind_password", "dummyPasswordValue"),
+			resource.TestCheckResourceAttr(resourceFullName, "bind_dn", "ou=test1,dc=example,dc=com"),
+			resource.TestCheckResourceAttr(resourceFullName, "bind_password", "dummyPasswordValue1"),
 			resource.TestCheckResourceAttr(resourceFullName, "connection_security", "TLS"),
 			resource.TestCheckResourceAttr(resourceFullName, "kerberos_service_account_upn", "username@domainname"),
 			resource.TestCheckResourceAttr(resourceFullName, "kerberos_service_account_password", "dummyKerberosPasswordValue"),
@@ -455,21 +455,6 @@ func TestAccGateway_LDAP(t *testing.T) {
 				"user_migration.0.attribute_mapping.#":   "3",
 				"push_password_changes_to_ldap":          "true",
 			}),
-
-			/*
-				resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.0.user_migration.0.attribute_mapping.*", map[string]string{
-					"name":  "username",
-					"value": "${ldapAttributes.uid}",
-				}),
-				resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.0.user_migration.0.attribute_mapping.*", map[string]string{
-					"name":  "email",
-					"value": "${ldapAttributes.mail}",
-				}),
-				resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.0.user_migration.0.attribute_mapping.*", map[string]string{
-					"name":  "name.family",
-					"value": "${ldapAttributes.sn}",
-				}),
-			*/
 			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.*", map[string]string{
 				"name":                                   "User Set 1",
 				"password_authority":                     "LDAP",
@@ -482,16 +467,55 @@ func TestAccGateway_LDAP(t *testing.T) {
 				"user_migration.0.attribute_mapping.#":   "2",
 				"push_password_changes_to_ldap":          "true",
 			}),
-			/*
-				resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.1.user_migration.0.attribute_mapping.*", map[string]string{
-					"name":  "username",
-					"value": "${ldapAttributes.uid}",
-				}),
-				resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.1.user_migration.0.attribute_mapping.*", map[string]string{
-					"name":  "email",
-					"value": "${ldapAttributes.mail}",
-				}),
-			*/
+		),
+	}
+
+	fullStep2 := resource.TestStep{
+		Config: testAccGatewayConfig_LDAPFull2(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
+			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "name", name),
+			resource.TestCheckResourceAttr(resourceFullName, "description", ""),
+			resource.TestCheckResourceAttr(resourceFullName, "enabled", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "type", "LDAP"),
+			resource.TestCheckResourceAttr(resourceFullName, "bind_dn", "ou=test1,dc=example,dc=com"),
+			resource.TestCheckResourceAttr(resourceFullName, "bind_password", "dummyPasswordValue1"),
+			resource.TestCheckResourceAttr(resourceFullName, "connection_security", "TLS"),
+			resource.TestCheckResourceAttr(resourceFullName, "kerberos_service_account_upn", "username@domainname"),
+			resource.TestCheckResourceAttr(resourceFullName, "kerberos_service_account_password", "dummyKerberosPasswordValue"),
+			resource.TestCheckResourceAttr(resourceFullName, "kerberos_retain_previous_credentials_mins", "20"),
+			resource.TestCheckResourceAttr(resourceFullName, "servers.#", "3"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "servers.*", "ds2.dummyldapservice.com:636"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "servers.*", "ds3.dummyldapservice.com:636"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "servers.*", "ds1.dummyldapservice.com:636"),
+			resource.TestCheckResourceAttr(resourceFullName, "validate_tls_certificates", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "vendor", "Microsoft Active Directory"),
+			resource.TestCheckResourceAttr(resourceFullName, "user_type.#", "2"),
+
+			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.*", map[string]string{
+				"name":                                   "User Set 2",
+				"password_authority":                     "PING_ONE",
+				"search_base_dn":                         "ou=users,dc=example,dc=com",
+				"user_link_attributes.#":                 "3",
+				"user_link_attributes.0":                 "objectGUID",
+				"user_link_attributes.1":                 "dn",
+				"user_link_attributes.2":                 "objectSid",
+				"user_migration.#":                       "1",
+				"user_migration.0.lookup_filter_pattern": "(|(uid=${identifier})(mail=${identifier}))",
+				"user_migration.0.attribute_mapping.#":   "3",
+				"push_password_changes_to_ldap":          "true",
+			}),
+			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "user_type.*", map[string]string{
+				"name":                          "User Set 1",
+				"password_authority":            "LDAP",
+				"search_base_dn":                "ou=users1,dc=example,dc=com",
+				"user_link_attributes.#":        "2",
+				"user_link_attributes.0":        "objectGUID",
+				"user_link_attributes.1":        "objectSid",
+				"user_migration.#":              "0",
+				"push_password_changes_to_ldap": "true",
+			}),
 		),
 	}
 
@@ -515,7 +539,7 @@ func TestAccGateway_LDAP(t *testing.T) {
 			resource.TestCheckTypeSetElemAttr(resourceFullName, "servers.*", "ds3.dummyldapservice.com:389"),
 			resource.TestCheckTypeSetElemAttr(resourceFullName, "servers.*", "ds1.dummyldapservice.com:389"),
 			resource.TestCheckResourceAttr(resourceFullName, "validate_tls_certificates", "true"),
-			resource.TestCheckResourceAttr(resourceFullName, "vendor", "PingDirectory"),
+			resource.TestCheckResourceAttr(resourceFullName, "vendor", "Microsoft Active Directory"),
 			resource.TestCheckResourceAttr(resourceFullName, "user_type.#", "0"),
 		),
 	}
@@ -527,9 +551,9 @@ func TestAccGateway_LDAP(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			// Full
-			fullStep,
+			fullStep1,
 			{
-				Config:  testAccGatewayConfig_LDAPFull(resourceName, name),
+				Config:  testAccGatewayConfig_LDAPFull1(resourceName, name),
 				Destroy: true,
 			},
 			// Minimal
@@ -538,10 +562,14 @@ func TestAccGateway_LDAP(t *testing.T) {
 				Config:  testAccGatewayConfig_LDAPMinimal(resourceName, name),
 				Destroy: true,
 			},
+			// Full Change
+			fullStep1,
+			fullStep2,
+			fullStep1,
 			// Change
-			fullStep,
+			fullStep1,
 			minimalStep,
-			fullStep,
+			fullStep1,
 			// Test importing the resource
 			{
 				ResourceName: resourceFullName,
@@ -852,7 +880,7 @@ resource "pingone_gateway" "%[2]s" {
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
-func testAccGatewayConfig_LDAPFull(resourceName, name string) string {
+func testAccGatewayConfig_LDAPFull1(resourceName, name string) string {
 	return fmt.Sprintf(`
 		%[1]s
 
@@ -865,11 +893,11 @@ resource "pingone_population" "%[2]s" {
 resource "pingone_gateway" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
-  enabled        = false
+  enabled        = true
   type           = "LDAP"
 
-  bind_dn       = "ou=test,dc=example,dc=com"
-  bind_password = "dummyPasswordValue"
+  bind_dn       = "ou=test1,dc=example,dc=com"
+  bind_password = "dummyPasswordValue1"
 
   connection_security = "TLS"
   vendor              = "Microsoft Active Directory"
@@ -887,7 +915,6 @@ resource "pingone_gateway" "%[2]s" {
   validate_tls_certificates = false
 
   user_type {
-    // id = "59e24997-f829-4206-b1b7-9b6a8a25c0b4"
     name               = "User Set 1"
     password_authority = "LDAP"
     search_base_dn     = "ou=users1,dc=example,dc=com"
@@ -914,7 +941,85 @@ resource "pingone_gateway" "%[2]s" {
   }
 
   user_type {
-    // id = "59e24997-f829-4206-b1b7-9b6a8a25c0b3"
+    name               = "User Set 2"
+    password_authority = "PING_ONE"
+    search_base_dn     = "ou=users,dc=example,dc=com"
+
+    user_link_attributes = ["objectGUID", "dn", "objectSid"]
+
+    user_migration {
+      lookup_filter_pattern = "(|(uid=$${identifier})(mail=$${identifier}))"
+
+      population_id = pingone_population.%[2]s.id
+
+      attribute_mapping {
+        name  = "username"
+        value = "$${ldapAttributes.uid}"
+      }
+
+      attribute_mapping {
+        name  = "email"
+        value = "$${ldapAttributes.mail}"
+      }
+
+      attribute_mapping {
+        name  = "name.family"
+        value = "$${ldapAttributes.sn}"
+      }
+    }
+
+    push_password_changes_to_ldap = true
+  }
+
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccGatewayConfig_LDAPFull2(resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_population" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+}
+
+resource "pingone_gateway" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+  type           = "LDAP"
+
+  bind_dn       = "ou=test1,dc=example,dc=com"
+  bind_password = "dummyPasswordValue1"
+
+  connection_security = "TLS"
+  vendor              = "Microsoft Active Directory"
+
+  kerberos_service_account_upn              = "username@domainname"
+  kerberos_service_account_password         = "dummyKerberosPasswordValue"
+  kerberos_retain_previous_credentials_mins = 20
+
+  servers = [
+    "ds1.dummyldapservice.com:636",
+    "ds3.dummyldapservice.com:636",
+    "ds2.dummyldapservice.com:636",
+  ]
+
+  validate_tls_certificates = false
+
+  user_type {
+    name               = "User Set 1"
+    password_authority = "LDAP"
+    search_base_dn     = "ou=users1,dc=example,dc=com"
+
+    user_link_attributes = ["objectGUID", "objectSid"]
+
+    push_password_changes_to_ldap = true
+  }
+
+  user_type {
     name               = "User Set 2"
     password_authority = "PING_ONE"
     search_base_dn     = "ou=users,dc=example,dc=com"
@@ -963,7 +1068,7 @@ resource "pingone_gateway" "%[2]s" {
   bind_dn       = "ou=test,dc=example,dc=com"
   bind_password = "dummyPasswordValue"
 
-  vendor = "PingDirectory"
+  vendor = "Microsoft Active Directory"
 
   servers = [
     "ds1.dummyldapservice.com:389",


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccGateway_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccGateway_RemovalDrift
=== PAUSE TestAccGateway_RemovalDrift
=== RUN   TestAccGateway_NewEnv
=== PAUSE TestAccGateway_NewEnv
=== RUN   TestAccGateway_Full
=== PAUSE TestAccGateway_Full
=== RUN   TestAccGateway_Minimal
=== PAUSE TestAccGateway_Minimal
=== RUN   TestAccGateway_Change
=== PAUSE TestAccGateway_Change
=== RUN   TestAccGateway_PF
=== PAUSE TestAccGateway_PF
=== RUN   TestAccGateway_APIG
=== PAUSE TestAccGateway_APIG
=== RUN   TestAccGateway_Intelligence
=== PAUSE TestAccGateway_Intelligence
=== RUN   TestAccGateway_LDAP
=== PAUSE TestAccGateway_LDAP
=== RUN   TestAccGateway_RADIUS
=== PAUSE TestAccGateway_RADIUS
=== RUN   TestAccGateway_RADIUSSharedSecrets
=== PAUSE TestAccGateway_RADIUSSharedSecrets
=== RUN   TestAccGateway_BadParameter
=== PAUSE TestAccGateway_BadParameter
=== CONT  TestAccGateway_RemovalDrift
=== CONT  TestAccGateway_APIG
=== CONT  TestAccGateway_Minimal
=== CONT  TestAccGateway_PF
=== CONT  TestAccGateway_Change
=== CONT  TestAccGateway_RADIUS
=== CONT  TestAccGateway_BadParameter
=== CONT  TestAccGateway_NewEnv
=== CONT  TestAccGateway_RADIUSSharedSecrets
=== CONT  TestAccGateway_LDAP
=== CONT  TestAccGateway_Full
=== CONT  TestAccGateway_Intelligence
--- PASS: TestAccGateway_Minimal (6.95s)
--- PASS: TestAccGateway_Full (7.13s)
--- PASS: TestAccGateway_Intelligence (7.95s)
--- PASS: TestAccGateway_PF (8.22s)
--- PASS: TestAccGateway_APIG (8.29s)
--- PASS: TestAccGateway_RemovalDrift (8.45s)
--- PASS: TestAccGateway_NewEnv (8.68s)
--- PASS: TestAccGateway_BadParameter (11.52s)
--- PASS: TestAccGateway_Change (19.29s)
--- PASS: TestAccGateway_RADIUS (34.63s)
--- PASS: TestAccGateway_RADIUSSharedSecrets (35.19s)
--- PASS: TestAccGateway_LDAP (48.86s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        50.592s
```