### PR TITLE
Adjust code to no longer use deprecated API parameter `composition`

### DIFF
--- a/.changelog/590.txt
+++ b/.changelog/590.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_risk_predictor`: Adjust code to no longer use deprecated API parameter `composition`.  Full support of multiple risk composition policies is planned for a future release.
+```

--- a/internal/service/risk/resource_risk_predictor.go
+++ b/internal/service/risk/resource_risk_predictor.go
@@ -1913,11 +1913,14 @@ func (p *riskPredictorResourceModel) expandPredictorComposite(ctx context.Contex
 
 		}
 
-		dataComposition := risk.NewRiskPredictorCompositeAllOfComposition(
+		dataCompositons := make([]risk.RiskPredictorCompositeAllOfCompositionsInner, 0)
+
+		dataComposition := risk.NewRiskPredictorCompositeAllOfCompositionsInner(
 			condition,
 			level,
 		)
-		data.SetComposition(*dataComposition)
+
+		data.SetCompositions(append(dataCompositons, *dataComposition))
 	}
 
 	return &data, diags
@@ -3009,14 +3012,14 @@ func (p *riskPredictorResourceModel) toStateRiskPredictorComposite(apiObject *ri
 
 	compositionObject := types.ObjectNull(predictorCompositionTFObjectTypes)
 
-	if v, ok := apiObject.GetCompositionOk(); ok {
+	if v, ok := apiObject.GetCompositionsOk(); ok && len(v) > 0 {
 
 		o := map[string]attr.Value{
-			"level":          framework.EnumOkToTF(v.GetLevelOk()),
+			"level":          framework.EnumOkToTF(v[0].GetLevelOk()),
 			"condition_json": compositeConditionJSON,
 		}
 
-		if v1, ok := v.GetConditionOk(); ok {
+		if v1, ok := v[0].GetConditionOk(); ok {
 			jsonString, err := json.Marshal(v1)
 			if err != nil {
 				diags.AddError(


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_risk_predictor`: Adjust code to no longer use deprecated API parameter `composition`.  Full support of multiple risk composition policies is planned for a future release.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccRiskPredictor_Composite github.com/pingidentity/terraform-provider-pingone/internal/service/risk
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccRiskPredictor_Composite
=== PAUSE TestAccRiskPredictor_Composite
=== CONT  TestAccRiskPredictor_Composite
--- PASS: TestAccRiskPredictor_Composite (36.35s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/risk        37.158s
```