### PR TITLE
`data-source/pingone_role`: Migrate to plugin framework

### DIFF
--- a/.changelog/592.txt
+++ b/.changelog/592.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`data-source/pingone_role`: Migrated to plugin framework.
+```

--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -2,12 +2,12 @@
 page_title: "pingone_role Data Source - terraform-provider-pingone"
 subcategory: "Platform"
 description: |-
-  Datasource to read PingOne admin role data
+  Datasource to read PingOne admin role data for a tenant.
 ---
 
 # pingone_role (Data Source)
 
-Datasource to read PingOne admin role data
+Datasource to read PingOne admin role data for a tenant.
 
 ## Example Usage
 
@@ -46,9 +46,9 @@ data "pingone_role" "davinci_admin_ro" {
 
 ### Required
 
-- `name` (String) The name of the role.
+- `name` (String) The name of the role to look up.  Options are `Client Application Developer`, `Configuration Read Only`, `DaVinci Admin`, `DaVinci Admin Read Only`, `Environment Admin`, `Identity Data Admin`, `Identity Data Read Only`, `Organization Admin`, `PingFederate Administrator`, `PingFederate Auditor`, `PingFederate Crypto Administrator`, `PingFederate Expression Administrator`, `PingFederate User Administrator`.
 
 ### Read-Only
 
-- `description` (String) A description of the role.
+- `description` (String) The description of the role.
 - `id` (String) The ID of this resource.

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -103,7 +103,6 @@ func New(version string) func() *schema.Provider {
 				"pingone_language":                       base.DatasourceLanguage(),
 				"pingone_license":                        base.DatasourceLicense(),
 				"pingone_licenses":                       base.DatasourceLicenses(),
-				"pingone_role":                           base.DatasourceRole(),
 				"pingone_trusted_email_domain_dkim":      base.DatasourceTrustedEmailDomainDKIM(),
 				"pingone_trusted_email_domain_ownership": base.DatasourceTrustedEmailDomainOwnership(),
 				"pingone_trusted_email_domain_spf":       base.DatasourceTrustedEmailDomainSPF(),

--- a/internal/service/base/data_source_role.go
+++ b/internal/service/base/data_source_role.go
@@ -14,6 +14,7 @@ import (
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
+	"github.com/pingidentity/terraform-provider-pingone/internal/utils"
 )
 
 // Types
@@ -45,6 +46,10 @@ func (r *RoleDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 
 	const minAttrLength = 1
 
+	nameDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The name of the role to look up.",
+	).AllowedValuesEnum(management.AllowedEnumRoleNameEnumValues)
+
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		Description: "Datasource to read PingOne admin role data for a tenant.",
@@ -53,10 +58,11 @@ func (r *RoleDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 			"id": framework.Attr_ID(),
 
 			"name": schema.StringAttribute{
-				Description: framework.SchemaAttributeDescriptionFromMarkdown("The name of the role to look up.").Description,
-				Required:    true,
+				MarkdownDescription: nameDescription.MarkdownDescription,
+				Description:         nameDescription.Description,
+				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(minAttrLength),
+					stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumRoleNameEnumValues)...),
 				},
 			},
 

--- a/internal/service/base/data_source_role.go
+++ b/internal/service/base/data_source_role.go
@@ -5,85 +5,172 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
-	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
 )
 
-func DatasourceRole() *schema.Resource {
-	return &schema.Resource{
+// Types
+type RoleDataSource serviceClientType
 
+type RoleDataSourceModel struct {
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	Id          types.String `tfsdk:"id"`
+}
+
+// Framework interfaces
+var (
+	_ datasource.DataSource = &RoleDataSource{}
+)
+
+// New Object
+func NewRoleDataSource() datasource.DataSource {
+	return &RoleDataSource{}
+}
+
+// Metadata
+func (r *RoleDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_role"
+}
+
+// Schema
+func (r *RoleDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+
+	const minAttrLength = 1
+
+	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		Description: "Datasource to read PingOne admin role data",
+		Description: "Datasource to read PingOne admin role data for a tenant.",
 
-		ReadContext: datasourcePingOneRoleRead,
+		Attributes: map[string]schema.Attribute{
+			"id": framework.Attr_ID(),
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Description:      "The name of the role.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+			"name": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The name of the role to look up.").Description,
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(minAttrLength),
+				},
 			},
-			"description": {
-				Description: "A description of the role.",
-				Type:        schema.TypeString,
+
+			"description": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The description of the role.").Description,
 				Computed:    true,
 			},
 		},
 	}
 }
 
-func datasourcePingOneRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.ManagementAPIClient
-
-	var diags diag.Diagnostics
-
-	var resp management.Role
-
-	respList, diags := sdk.ParseResponse(
-		ctx,
-		func() (any, *http.Response, error) {
-			return apiClient.RolesApi.ReadAllRoles(ctx).Execute()
-		},
-		"ReadAllRoles",
-		sdk.DefaultCustomError,
-		sdk.DefaultCreateReadRetryable,
-	)
-	if diags.HasError() {
-		return diags
+func (r *RoleDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
 	}
 
-	if roles, ok := respList.(*management.EntityArray).Embedded.GetRolesOk(); ok {
+	resourceConfig, ok := req.ProviderData.(framework.ResourceType)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected the provider client, got: %T. Please report this issue to the provider maintainers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.Client = resourceConfig.Client.API
+	if r.Client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialised",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.",
+		)
+		return
+	}
+}
+
+func (r *RoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *RoleDataSourceModel
+
+	if r.Client.ManagementAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var role management.Role
+
+	// Run the API call
+	var entityArray *management.EntityArray
+	resp.Diagnostics.Append(framework.ParseResponse(
+		ctx,
+
+		func() (any, *http.Response, error) {
+			return r.Client.ManagementAPIClient.RolesApi.ReadAllRoles(ctx).Execute()
+		},
+		"ReadAllRoles",
+		framework.DefaultCustomError,
+		sdk.DefaultCreateReadRetryable,
+		&entityArray,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if roles, ok := entityArray.Embedded.GetRolesOk(); ok {
 
 		found := false
-		for _, role := range roles {
+		for _, roleItem := range roles {
 
-			if role.GetName() == management.EnumRoleName(d.Get("name").(string)) {
-				resp = role
+			if string(roleItem.GetName()) == data.Name.ValueString() {
+				role = roleItem
 				found = true
 				break
 			}
 		}
 
 		if !found {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("Cannot find role %s", d.Get("name")),
-			})
-
-			return diags
+			resp.Diagnostics.AddError(
+				"Cannot find role from name",
+				fmt.Sprintf("The role %s cannot be found in the tenant", data.Name.String()),
+			)
+			return
 		}
 
 	}
 
-	d.SetId(resp.GetId())
-	d.Set("name", resp.GetName())
-	d.Set("description", resp.GetDescription())
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(data.toState(&role)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (p *RoleDataSourceModel) toState(v *management.Role) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if v == nil {
+		diags.AddError(
+			"Data object missing",
+			"Cannot convert the data object to state as the data object is nil.  Please report this to the provider maintainers.",
+		)
+
+		return diags
+	}
+
+	p.Id = framework.StringOkToTF(v.GetIdOk())
+	p.Name = framework.EnumOkToTF(v.GetNameOk())
+	p.Description = framework.StringOkToTF(v.GetDescriptionOk())
 
 	return diags
 }

--- a/internal/service/base/data_source_role_test.go
+++ b/internal/service/base/data_source_role_test.go
@@ -107,7 +107,7 @@ func TestAccRoleDataSource_NotFound(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRoleDataSourceConfig_NotFoundByName(resourceName),
-				ExpectError: regexp.MustCompile("Cannot find role doesnotexist"),
+				ExpectError: regexp.MustCompile("Cannot find role from name"),
 			},
 			// {
 			// 	Config:      testAccRoleDataSourceConfig_NotFoundByID(resourceName),

--- a/internal/service/base/data_source_role_test.go
+++ b/internal/service/base/data_source_role_test.go
@@ -107,7 +107,7 @@ func TestAccRoleDataSource_NotFound(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccRoleDataSourceConfig_NotFoundByName(resourceName),
-				ExpectError: regexp.MustCompile("Cannot find role from name"),
+				ExpectError: regexp.MustCompile("Invalid Attribute Value Match"),
 			},
 			// {
 			// 	Config:      testAccRoleDataSourceConfig_NotFoundByID(resourceName),

--- a/internal/service/base/service.go
+++ b/internal/service/base/service.go
@@ -45,6 +45,7 @@ func DataSources() []func() datasource.DataSource {
 		NewEnvironmentsDataSource,
 		NewOrganizationDataSource,
 		NewPhoneDeliverySettingsListDataSource,
+		NewRoleDataSource,
 		NewTrustedEmailDomainDataSource,
 		NewUserRoleAssignmentsDataSource,
 	}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `data-source/pingone_role`: Migrated to plugin framework.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccRoleDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccRoleDataSource_ByNameFull
=== PAUSE TestAccRoleDataSource_ByNameFull
=== RUN   TestAccRoleDataSource_NotFound
=== PAUSE TestAccRoleDataSource_NotFound
=== CONT  TestAccRoleDataSource_ByNameFull
=== CONT  TestAccRoleDataSource_NotFound
--- PASS: TestAccRoleDataSource_NotFound (1.18s)
--- PASS: TestAccRoleDataSource_ByNameFull (29.90s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        30.901s
```