### PR TITLE
`resource/pingone_environment`: Removal of deprecated parameter `default_population` and computed attribute `default_population_id` (`v1.0.0`)

### DIFF
--- a/.changelog/629.txt
+++ b/.changelog/629.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_environment`: Removal of deprecated parameter `default_population` and computed attribute `default_population_id`.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -12,6 +12,16 @@ Version 1.0.0 of the PingOne Terraform provider is a major release that introduc
 ## Provider Configuration
 
 
+## Resource: pingone_environment
+
+### `default_population` optional parameter removed
+
+This parameter was previously deprecated and has been removed.  Default populations are managed with the `pingone_population_default` resource.
+
+### `default_population_id` computed attribute removed
+
+This attribute was previously deprecated and has been removed.  Default populations are managed with the `pingone_population_default` resource.
+
 ## Resource: pingone_image
 
 ### `uploaded_image` computed attribute data type change

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -47,7 +47,6 @@ resource "pingone_environment" "my_environment" {
 
 ### Optional
 
-- `default_population` (Block List, Deprecated) **Deprecation Message** The `default_population` block has been deprecated.  Default population functionality has moved to the `pingone_population_default` resource.  This attribute will be removed in the next major version of the provider.  To preserve user data, removal of this block from HCL will not delete the population from the service.  The default population configuration cannot be added after the environment has already been created, but will not trigger a replacement of the resource.  The environment's default population.  The values for this block will not be populated when importing the resource using `terraform import`. (see [below for nested schema](#nestedblock--default_population))
 - `description` (String) A description of the environment.
 - `region` (String) The region to create the environment in.  Should be consistent with the PingOne organisation region.  Valid options are `AsiaPacific` `Canada` `Europe` and `NorthAmerica`.  Default can be set with the `PINGONE_REGION` environment variable.
 - `service` (Block Set) The services to enable in the environment.  Defaults to `SSO`. (see [below for nested schema](#nestedblock--service))
@@ -57,18 +56,8 @@ resource "pingone_environment" "my_environment" {
 
 ### Read-Only
 
-- `default_population_id` (String, Deprecated) **Deprecation Message** The `default_population_id` attribute has been deprecated.  Default population functionality has moved to the `pingone_population_default` resource.  This attribute will be removed in the next major version of the provider.  The ID of the environment's default population.  This attribute is only populated when also using the `default_population` block to define a default population, but will not be populated when importing the resource using `terraform import`.
 - `id` (String) The ID of this resource.
 - `organization_id` (String) The ID of the PingOne organization tenant to which the environment belongs.
-
-<a id="nestedblock--default_population"></a>
-### Nested Schema for `default_population`
-
-Optional:
-
-- `description` (String) A description to apply to the environment's default population.
-- `name` (String) The name of the environment's default population.  Defaults to `Default`.
-
 
 <a id="nestedblock--service"></a>
 ### Nested Schema for `service`

--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -82,9 +82,6 @@ func TestAccEnvironment_Full(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "license_id", licenseID),
 			resource.TestMatchResourceAttr(resourceFullName, "organization_id", verify.P1ResourceIDRegexpFullString),
 			resource.TestCheckResourceAttr(resourceFullName, "solution", "CUSTOMER"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population_id"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population.0.name"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population.0.description"),
 			resource.TestCheckResourceAttr(resourceFullName, "service.#", "2"),
 			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "service.*", map[string]string{
 				"type":        "SSO",
@@ -115,9 +112,6 @@ func TestAccEnvironment_Full(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "license_id", licenseID),
 			resource.TestMatchResourceAttr(resourceFullName, "organization_id", verify.P1ResourceIDRegexpFullString),
 			resource.TestCheckResourceAttr(resourceFullName, "solution", "CUSTOMER"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population_id"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population.0.name"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population.0.description"),
 			resource.TestCheckResourceAttr(resourceFullName, "service.#", "2"),
 			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "service.*", map[string]string{
 				"type":        "SSO",
@@ -191,9 +185,6 @@ func TestAccEnvironment_Minimal(t *testing.T) {
 			resource.TestCheckNoResourceAttr(resourceFullName, "solution"),
 			resource.TestCheckResourceAttr(resourceFullName, "license_id", licenseID),
 			resource.TestMatchResourceAttr(resourceFullName, "organization_id", verify.P1ResourceIDRegexpFullString),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population_id"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population.0.name"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "default_population.0.description"),
 			resource.TestCheckResourceAttr(resourceFullName, "service.#", "1"),
 			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "service.*", map[string]string{
 				"type":        "SSO",
@@ -303,43 +294,6 @@ func TestAccEnvironment_DeleteProductionEnvironment(t *testing.T) {
 		},
 	})
 }
-
-///////////////////
-// Deprecated start
-
-func TestAccEnvironment_MinimalWithPopulation(t *testing.T) {
-	t.Parallel()
-
-	resourceName := acctest.ResourceNameGenEnvironment()
-	resourceFullName := fmt.Sprintf("pingone_environment.%s", resourceName)
-
-	name := resourceName
-	licenseID := os.Getenv("PINGONE_LICENSE_ID")
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheckClient(t)
-			acctest.PreCheckNewEnvironment(t)
-			acctest.PreCheckNoFeatureFlag(t)
-		},
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy:             base.Environment_CheckDestroy,
-		ErrorCheck:               acctest.ErrorCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEnvironmentConfig_MinimalWithPopulation(resourceName, name, licenseID),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "default_population_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "default_population.0.name", name),
-					resource.TestCheckResourceAttr(resourceFullName, "default_population.0.description", fmt.Sprintf("%s description", name)),
-				),
-			},
-		},
-	})
-}
-
-// Deprecated end
-///////////////////
 
 func TestAccEnvironment_EnvironmentTypeSwitching(t *testing.T) {
 	t.Parallel()
@@ -620,19 +574,6 @@ resource "pingone_environment" "%[1]s" {
   service {
     type = "DaVinci"
     tags = ["DAVINCI_MINIMAL"]
-  }
-}`, resourceName, name, licenseID)
-}
-
-func testAccEnvironmentConfig_MinimalWithPopulation(resourceName, name, licenseID string) string {
-	return fmt.Sprintf(`
-resource "pingone_environment" "%[1]s" {
-  name       = "%[2]s"
-  license_id = "%[3]s"
-
-  default_population {
-    name        = "%[2]s"
-    description = "%[2]s description"
   }
 }`, resourceName, name, licenseID)
 }

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -12,6 +12,16 @@ Version 1.0.0 of the PingOne Terraform provider is a major release that introduc
 ## Provider Configuration
 
 
+## Resource: pingone_environment
+
+### `default_population` optional parameter removed
+
+This parameter was previously deprecated and has been removed.  Default populations are managed with the `pingone_population_default` resource.
+
+### `default_population_id` computed attribute removed
+
+This attribute was previously deprecated and has been removed.  Default populations are managed with the `pingone_population_default` resource.
+
 ## Resource: pingone_image
 
 ### `uploaded_image` computed attribute data type change


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_environment`: Removal of deprecated parameter `default_population` and computed attribute `default_population_id`.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccEnvironment_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccEnvironment_RemovalDrift
=== PAUSE TestAccEnvironment_RemovalDrift
=== RUN   TestAccEnvironment_Full
=== PAUSE TestAccEnvironment_Full
=== RUN   TestAccEnvironment_Minimal
=== PAUSE TestAccEnvironment_Minimal
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== RUN   TestAccEnvironment_DeleteProductionEnvironmentProtection
=== PAUSE TestAccEnvironment_DeleteProductionEnvironmentProtection
=== RUN   TestAccEnvironment_DeleteProductionEnvironment
=== PAUSE TestAccEnvironment_DeleteProductionEnvironment
=== RUN   TestAccEnvironment_EnvironmentTypeSwitching
=== PAUSE TestAccEnvironment_EnvironmentTypeSwitching
=== RUN   TestAccEnvironment_ServiceSwitching
=== PAUSE TestAccEnvironment_ServiceSwitching
=== RUN   TestAccEnvironment_Services
=== PAUSE TestAccEnvironment_Services
=== RUN   TestAccEnvironment_ServicesTags
=== PAUSE TestAccEnvironment_ServicesTags
=== RUN   TestAccEnvironment_BadParameters
=== PAUSE TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_RemovalDrift
=== CONT  TestAccEnvironment_EnvironmentTypeSwitching
=== CONT  TestAccEnvironment_ServicesTags
=== CONT  TestAccEnvironment_Services
=== CONT  TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_Minimal
=== CONT  TestAccEnvironment_DeleteProductionEnvironment
=== CONT  TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_ServiceSwitching
=== CONT  TestAccEnvironment_DeleteProductionEnvironmentProtection
=== CONT  TestAccEnvironment_Full
=== NAME  TestAccEnvironment_ServicesTags
    acctest.go:124: Skipping feature flag test.  Flag required: "DAVINCI"
--- SKIP: TestAccEnvironment_ServicesTags (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironment
    resource_environment_test.go:285: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironment (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironmentProtection
    resource_environment_test.go:258: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironmentProtection (0.00s)
--- PASS: TestAccEnvironment_NonCompatibleRegion (2.28s)
--- PASS: TestAccEnvironment_RemovalDrift (5.80s)
--- PASS: TestAccEnvironment_Minimal (7.30s)
--- PASS: TestAccEnvironment_BadParameters (7.68s)
--- PASS: TestAccEnvironment_ServiceSwitching (12.71s)
--- PASS: TestAccEnvironment_EnvironmentTypeSwitching (13.73s)
--- PASS: TestAccEnvironment_Full (14.71s)
--- PASS: TestAccEnvironment_Services (20.39s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        23.014s
```