### PR TITLE
`resource/pingone_mfa_application_push_credential`: Removal of deprecated parameter `fcm.key` (`v1.0.0`)

### DIFF
--- a/.changelog/630.txt
+++ b/.changelog/630.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_mfa_application_push_credential`: Removal of deprecated parameter `fcm.key`.  Use the `fcm.google_service_account_credentials` parameter going forward.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -88,6 +88,12 @@ resource "pingone_branding_theme" "my_awesome_theme" {
 }
 ```
 
+## Resource: pingone_mfa_application_push_credential
+
+### `fcm.key` optional parameter removed
+
+This parameter was previously deprecated and has been removed.  Use the `fcm.google_service_account_credentials` parameter going forward.
+
 ## Resource: pingone_mfa_fido_policy
 
 This resource was previously deprecated and has been removed.  Use the `pingone_mfa_fido2_policy` resource going forward.

--- a/docs/resources/mfa_application_push_credential.md
+++ b/docs/resources/mfa_application_push_credential.md
@@ -9,7 +9,7 @@ description: |-
 
 Resource to create and manage push credentials for a mobile MFA application configured in PingOne.
 
-~> If the type of credential is changed (e.g., FCM to APNS, or `fcm.key` to `fcm.google_service_account_credentials`), this will trigger a replacement plan.
+~> If the type of credential is changed (e.g., FCM to APNS), this will trigger a replacement plan.
 
 ## Example Usage
 
@@ -111,10 +111,9 @@ Required:
 <a id="nestedblock--fcm"></a>
 ### Nested Schema for `fcm`
 
-Optional:
+Required:
 
-- `google_service_account_credentials` (String, Sensitive) A string in JSON format that represents the service account credentials of Firebase cloud messaging service.  At least one of the following must be defined: `key`, `google_service_account_credentials`.
-- `key` (String, Sensitive, Deprecated) A string that represents the server key of the Firebase cloud messaging service.  At least one of the following must be defined: `key`, `google_service_account_credentials`.
+- `google_service_account_credentials` (String, Sensitive) A string in JSON format that represents the service account credentials of Firebase cloud messaging service.
 
 
 <a id="nestedblock--hms"></a>

--- a/internal/service/mfa/resource_application_push_credential_test.go
+++ b/internal/service/mfa/resource_application_push_credential_test.go
@@ -29,6 +29,8 @@ func TestAccApplicationPushCredential_RemovalDrift(t *testing.T) {
 
 	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
+	firebaseCredentials := os.Getenv("PINGONE_GOOGLE_FIREBASE_CREDENTIALS")
+
 	var applicationPushCredentialID, applicationID, environmentID string
 
 	var p1Client *client.Client
@@ -48,7 +50,7 @@ func TestAccApplicationPushCredential_RemovalDrift(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test removal of the resource
 			{
-				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, fmt.Sprintf("%s1", name)),
+				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, firebaseCredentials),
 				Check:  mfa.ApplicationPushCredential_GetIDs(resourceFullName, &environmentID, &applicationID, &applicationPushCredentialID),
 			},
 			{
@@ -60,7 +62,7 @@ func TestAccApplicationPushCredential_RemovalDrift(t *testing.T) {
 			},
 			// Test removal of the application
 			{
-				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, fmt.Sprintf("%s1", name)),
+				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, firebaseCredentials),
 				Check:  mfa.ApplicationPushCredential_GetIDs(resourceFullName, &environmentID, &applicationID, &applicationPushCredentialID),
 			},
 			{
@@ -72,7 +74,7 @@ func TestAccApplicationPushCredential_RemovalDrift(t *testing.T) {
 			},
 			// Test removal of the environment
 			{
-				Config: testAccApplicationPushCredentialConfig_NewEnv(environmentName, licenseID, resourceName, name),
+				Config: testAccApplicationPushCredentialConfig_NewEnv(environmentName, licenseID, resourceName, name, firebaseCredentials),
 				Check:  mfa.ApplicationPushCredential_GetIDs(resourceFullName, &environmentID, &applicationID, &applicationPushCredentialID),
 			},
 			{
@@ -115,30 +117,9 @@ func TestAccApplicationPushCredential_FCM(t *testing.T) {
 		CheckDestroy:             mfa.ApplicationPushCredential_CheckDestroy,
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
-			// FCM (deprecated)
-			{
-				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, fmt.Sprintf("%s1", name)),
-				Check:  fullFCMCheck,
-			},
-			{
-				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, fmt.Sprintf("%s2", name)),
-				Check:  fullFCMCheck,
-			},
-			{
-				Config:  testAccApplicationPushCredentialConfig_FCM(resourceName, name, fmt.Sprintf("%s2", name)),
-				Destroy: true,
-			},
 			// FCM new
 			{
-				Config: testAccApplicationPushCredentialConfig_FCMHTTPV1(resourceName, name, firebaseCredentials),
-				Check:  fullFCMCheck,
-			},
-			{
-				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, fmt.Sprintf("%s1", name)),
-				Check:  fullFCMCheck,
-			},
-			{
-				Config: testAccApplicationPushCredentialConfig_FCMHTTPV1(resourceName, name, firebaseCredentials),
+				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, firebaseCredentials),
 				Check:  fullFCMCheck,
 			},
 			// Test importing the resource
@@ -305,17 +286,20 @@ func TestAccApplicationPushCredential_Change(t *testing.T) {
 
 	name := resourceName
 
+	firebaseCredentials := os.Getenv("PINGONE_GOOGLE_FIREBASE_CREDENTIALS")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheckClient(t)
 			acctest.PreCheckNoFeatureFlag(t)
+			acctest.PreCheckGoogleFirebaseCredentials(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             mfa.ApplicationPushCredential_CheckDestroy,
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, name),
+				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, firebaseCredentials),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
@@ -359,10 +343,13 @@ func TestAccApplicationPushCredential_BadParameters(t *testing.T) {
 
 	name := resourceName
 
+	firebaseCredentials := os.Getenv("PINGONE_GOOGLE_FIREBASE_CREDENTIALS")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheckClient(t)
 			acctest.PreCheckNoFeatureFlag(t)
+			acctest.PreCheckGoogleFirebaseCredentials(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             mfa.ApplicationPushCredential_CheckDestroy,
@@ -370,7 +357,7 @@ func TestAccApplicationPushCredential_BadParameters(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, fmt.Sprintf("%s1", name)),
+				Config: testAccApplicationPushCredentialConfig_FCM(resourceName, name, firebaseCredentials),
 			},
 			// Errors
 			{
@@ -394,7 +381,7 @@ func TestAccApplicationPushCredential_BadParameters(t *testing.T) {
 	})
 }
 
-func testAccApplicationPushCredentialConfig_NewEnv(environmentName, licenseID, resourceName, name string) string {
+func testAccApplicationPushCredentialConfig_NewEnv(environmentName, licenseID, resourceName, name, key string) string {
 	return fmt.Sprintf(`
 		%[1]s
 
@@ -440,63 +427,12 @@ resource "pingone_mfa_application_push_credential" "%[3]s" {
   application_id = pingone_application.%[3]s.id
 
   fcm {
-    key = "%[4]s"
+    google_service_account_credentials = jsonencode(%[5]s)
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, key)
 }
 
 func testAccApplicationPushCredentialConfig_FCM(resourceName, name, key string) string {
-	return fmt.Sprintf(`
-		%[1]s
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  description    = "My test OIDC app for MFA Policy"
-  tags           = []
-  login_page_url = "https://www.pingidentity.com"
-
-  enabled = true
-
-  oidc_options {
-    type                        = "NATIVE_APP"
-    grant_types                 = ["CLIENT_CREDENTIALS"]
-    token_endpoint_authn_method = "CLIENT_SECRET_BASIC"
-
-    mobile_app {
-      package_name = "com.%[2]s.package"
-
-      passcode_refresh_seconds = 45
-
-      integrity_detection {
-        enabled = true
-        cache_duration {
-          amount = 30
-          units  = "HOURS"
-        }
-        google_play {
-          verification_type = "INTERNAL"
-          decryption_key    = "dummykeydoesnotexist"
-          verification_key  = "dummykeydoesnotexist"
-        }
-      }
-    }
-
-    package_name = "com.%[2]s.package"
-  }
-}
-
-resource "pingone_mfa_application_push_credential" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  application_id = pingone_application.%[2]s.id
-
-  fcm {
-    key = "%[4]s"
-  }
-}`, acctest.GenericSandboxEnvironment(), resourceName, name, key)
-}
-
-func testAccApplicationPushCredentialConfig_FCMHTTPV1(resourceName, name, key string) string {
 	return fmt.Sprintf(`
 		%[1]s
 

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -88,6 +88,12 @@ resource "pingone_branding_theme" "my_awesome_theme" {
 }
 ```
 
+## Resource: pingone_mfa_application_push_credential
+
+### `fcm.key` optional parameter removed
+
+This parameter was previously deprecated and has been removed.  Use the `fcm.google_service_account_credentials` parameter going forward.
+
 ## Resource: pingone_mfa_fido_policy
 
 This resource was previously deprecated and has been removed.  Use the `pingone_mfa_fido2_policy` resource going forward.

--- a/templates/resources/mfa_application_push_credential.md.tmpl
+++ b/templates/resources/mfa_application_push_credential.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> If the type of credential is changed (e.g., FCM to APNS, or `fcm.key` to `fcm.google_service_account_credentials`), this will trigger a replacement plan.
+~> If the type of credential is changed (e.g., FCM to APNS), this will trigger a replacement plan.
 
 {{ if .HasExample -}}
 ## Example Usage


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_mfa_application_push_credential`: Removal of deprecated parameter `fcm.key`

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccApplicationPushCredential_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccApplicationPushCredential_RemovalDrift
=== PAUSE TestAccApplicationPushCredential_RemovalDrift
=== RUN   TestAccApplicationPushCredential_FCM
=== PAUSE TestAccApplicationPushCredential_FCM
=== RUN   TestAccApplicationPushCredential_APNS
=== PAUSE TestAccApplicationPushCredential_APNS
=== RUN   TestAccApplicationPushCredential_HMS
=== PAUSE TestAccApplicationPushCredential_HMS
=== RUN   TestAccApplicationPushCredential_Change
=== PAUSE TestAccApplicationPushCredential_Change
=== RUN   TestAccApplicationPushCredential_BadParameters
=== PAUSE TestAccApplicationPushCredential_BadParameters
=== CONT  TestAccApplicationPushCredential_RemovalDrift
=== CONT  TestAccApplicationPushCredential_BadParameters
=== CONT  TestAccApplicationPushCredential_HMS
=== CONT  TestAccApplicationPushCredential_Change
=== CONT  TestAccApplicationPushCredential_APNS
=== CONT  TestAccApplicationPushCredential_FCM
--- PASS: TestAccApplicationPushCredential_FCM (8.20s)
--- PASS: TestAccApplicationPushCredential_BadParameters (9.30s)
--- PASS: TestAccApplicationPushCredential_APNS (12.38s)
--- PASS: TestAccApplicationPushCredential_HMS (12.77s)
--- PASS: TestAccApplicationPushCredential_Change (18.46s)
--- PASS: TestAccApplicationPushCredential_RemovalDrift (23.32s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 26.068s
```