### PR TITLE
`resource/pingone_population_default`: Fix timeout logic

### DIFF
--- a/.changelog/600-2.txt
+++ b/.changelog/600-2.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`resource/pingone_environment`: The default population is no longer seeded automatically on environment creation.  Default population creation should be managed by the `pingone_population_default` resource going forward.
+```

--- a/docs/resources/population_default.md
+++ b/docs/resources/population_default.md
@@ -51,7 +51,7 @@ resource "pingone_population_default" "my_default_population" {
 
 Optional:
 
-- `create` (String) A timeout to apply to creation of the resource.  A timeout can be set in cases where there are delays in the platform seeding a default population in newly created environments.  The default value is 20 minutes.
+- `create` (String) A timeout to apply to creation of the resource.  There may be a short delay in provisioning this resource when creating the parent PingOne environment at the same time (referenced by the `environment_id` parameter), as the platform will create a default population automatically.  This resource will attempt to find and update the existing default population, and will wait if the default population cannot be found (for example, if it is in the process of being created automatically by the platform).  This timeout value can be used to override the wait time, and force the creation of a default population.  The default value is 20 minutes.
 
 ## Import
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -293,27 +293,44 @@ func PreCheckTestClient(ctx context.Context, t *testing.T) *client.Client {
 
 func MinimalSandboxEnvironment(resourceName, licenseID string) string {
 	return fmt.Sprintf(`
-		resource "pingone_environment" "%[1]s" {
-			name = "%[1]s"
-			type = "SANDBOX"
-			license_id = "%[2]s"
+	%[1]s
+		
+	resource "pingone_population_default" "%[2]s" {
+		environment_id = pingone_environment.%[2]s.id
 
-			service {
-				type = "SSO"
-			}
-			service {
-				type = "MFA"
-			}
-			service {
-				type = "Risk"
-			}
-			service {
-				type = "Credentials"
-			}
-			service {
-				type = "Verify"
-			}
-		}`, resourceName, licenseID)
+		name = "%[2]s"
+
+		timeouts = {
+			create = "1m"
+		}
+	}
+`, MinimalSandboxEnvironmentNoPopulation(resourceName, licenseID), resourceName)
+}
+
+func MinimalSandboxEnvironmentNoPopulation(resourceName, licenseID string) string {
+	return fmt.Sprintf(`
+	resource "pingone_environment" "%[1]s" {
+		name = "%[1]s"
+		type = "SANDBOX"
+		license_id = "%[2]s"
+
+		service {
+			type = "SSO"
+		}
+		service {
+			type = "MFA"
+		}
+		service {
+			type = "Risk"
+		}
+		service {
+			type = "Credentials"
+		}
+		service {
+			type = "Verify"
+		}
+	}
+`, resourceName, licenseID)
 }
 
 func GenericSandboxEnvironment() string {

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -206,7 +206,11 @@ resource "pingone_population_default" "%[3]s" {
   name               = "%[4]s"
   description        = "Test description"
   password_policy_id = pingone_password_policy.%[3]s.id
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+
+  timeouts = {
+	create = "5m"
+}
+}`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }
 
 func testAccPopulationDefaultConfig_Minimal(environmentName, licenseID, resourceName, name string) string {
@@ -216,5 +220,9 @@ func testAccPopulationDefaultConfig_Minimal(environmentName, licenseID, resource
 resource "pingone_population_default" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
   name           = "%[4]s"
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
+
+  timeouts = {
+	create = "5m"
+}
+}`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -208,8 +208,8 @@ resource "pingone_population_default" "%[3]s" {
   password_policy_id = pingone_password_policy.%[3]s.id
 
   timeouts = {
-	create = "5m"
-}
+    create = "5m"
+  }
 }`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }
 
@@ -222,7 +222,7 @@ resource "pingone_population_default" "%[3]s" {
   name           = "%[4]s"
 
   timeouts = {
-	create = "5m"
-}
+    create = "5m"
+  }
 }`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_population_default`: Fix timeout logic

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccPopulationDefault_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccPopulationDefault_RemovalDrift
=== PAUSE TestAccPopulationDefault_RemovalDrift
=== RUN   TestAccPopulationDefault_Full
=== PAUSE TestAccPopulationDefault_Full
=== RUN   TestAccPopulationDefault_Minimal
=== PAUSE TestAccPopulationDefault_Minimal
=== RUN   TestAccPopulationDefault_BadParameters
=== PAUSE TestAccPopulationDefault_BadParameters
=== CONT  TestAccPopulationDefault_RemovalDrift
=== CONT  TestAccPopulationDefault_Minimal
=== CONT  TestAccPopulationDefault_Full
=== CONT  TestAccPopulationDefault_BadParameters
--- PASS: TestAccPopulationDefault_RemovalDrift (313.24s)
--- PASS: TestAccPopulationDefault_Minimal (314.43s)
--- PASS: TestAccPopulationDefault_BadParameters (315.55s)
--- PASS: TestAccPopulationDefault_Full (319.20s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 319.992s
```