### PR TITLE
Adjustments to default population user-configurable timeouts

### DIFF
--- a/.changelog/640.txt
+++ b/.changelog/640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_environment`: Fixed ineffectual `timeouts` block configuration.
+```

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -95,7 +95,7 @@ Required:
 
 Optional:
 
-- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `create` (String) A timeout to apply to creation of the resource.  Where the `default_population` block is configured, there may be a short delay in provisioning this resource, as the platform will create a default population automatically.  This resource will attempt to find and update the existing default population, and will wait if the default population cannot be found (for example, if it is in the process of being created automatically by the platform).  This timeout value can be used to override the wait time, and force the creation of a default population.  The value is expected to be a string that can be parsed as a duration consisting of numbers and unit suffixes, such as `30s` or `2h45m`. Valid time units are `s` (seconds), `m` (minutes), `h` (hours).  The default value is `20m` (20 minutes).
 
 ## Import
 

--- a/docs/resources/population_default.md
+++ b/docs/resources/population_default.md
@@ -51,7 +51,7 @@ resource "pingone_population_default" "my_default_population" {
 
 Optional:
 
-- `create` (String) A timeout to apply to creation of the resource.  There may be a short delay in provisioning this resource when creating the parent PingOne environment at the same time (referenced by the `environment_id` parameter), as the platform will create a default population automatically.  This resource will attempt to find and update the existing default population, and will wait if the default population cannot be found (for example, if it is in the process of being created automatically by the platform).  This timeout value can be used to override the wait time, and force the creation of a default population.  The default value is 20 minutes.
+- `create` (String) A timeout to apply to creation of the resource.  There may be a short delay in provisioning this resource when creating the parent PingOne environment at the same time (referenced by the `environment_id` parameter), as the platform will create a default population automatically.  This resource will attempt to find and update the existing default population, and will wait if the default population cannot be found (for example, if it is in the process of being created automatically by the platform).  This timeout value can be used to override the wait time, and force the creation of a default population.  The value is expected to be a string that can be parsed as a duration consisting of numbers and unit suffixes, such as `30s` or `2h45m`. Valid time units are `s` (seconds), `m` (minutes), `h` (hours).  The default value is `20m` (20 minutes).
 
 ## Import
 

--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -634,6 +634,10 @@ resource "pingone_environment" "%[1]s" {
     name        = "%[2]s"
     description = "%[2]s description"
   }
+
+  timeouts {
+	create = "5m"
+  }
 }`, resourceName, name, licenseID)
 }
 

--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -636,7 +636,7 @@ resource "pingone_environment" "%[1]s" {
   }
 
   timeouts {
-	create = "5m"
+    create = "5m"
   }
 }`, resourceName, name, licenseID)
 }

--- a/internal/service/sso/resource_population_default.go
+++ b/internal/service/sso/resource_population_default.go
@@ -95,7 +95,7 @@ func (r *PopulationDefaultResource) Schema(ctx context.Context, req resource.Sch
 
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create:            true,
-				CreateDescription: "A timeout to apply to creation of the resource.  There may be a short delay in provisioning this resource when creating the parent PingOne environment at the same time (referenced by the `environment_id` parameter), as the platform will create a default population automatically.  This resource will attempt to find and update the existing default population, and will wait if the default population cannot be found (for example, if it is in the process of being created automatically by the platform).  This timeout value can be used to override the wait time, and force the creation of a default population.  The default value is 20 minutes.",
+				CreateDescription: "A timeout to apply to creation of the resource.  There may be a short delay in provisioning this resource when creating the parent PingOne environment at the same time (referenced by the `environment_id` parameter), as the platform will create a default population automatically.  This resource will attempt to find and update the existing default population, and will wait if the default population cannot be found (for example, if it is in the process of being created automatically by the platform).  This timeout value can be used to override the wait time, and force the creation of a default population.  The value is expected to be a string that can be parsed as a duration consisting of numbers and unit suffixes, such as `30s` or `2h45m`. Valid time units are `s` (seconds), `m` (minutes), `h` (hours).  The default value is `20m` (20 minutes).",
 			}),
 		},
 	}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_environment`: Fixed ineffectual `timeouts` block configuration.

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccEnvironment_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccEnvironment_RemovalDrift
=== PAUSE TestAccEnvironment_RemovalDrift
=== RUN   TestAccEnvironment_Full
=== PAUSE TestAccEnvironment_Full
=== RUN   TestAccEnvironment_Minimal
=== PAUSE TestAccEnvironment_Minimal
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== RUN   TestAccEnvironment_DeleteProductionEnvironmentProtection
=== PAUSE TestAccEnvironment_DeleteProductionEnvironmentProtection
=== RUN   TestAccEnvironment_DeleteProductionEnvironment
=== PAUSE TestAccEnvironment_DeleteProductionEnvironment
=== RUN   TestAccEnvironment_MinimalWithPopulation
=== PAUSE TestAccEnvironment_MinimalWithPopulation
=== RUN   TestAccEnvironment_EnvironmentTypeSwitching
=== PAUSE TestAccEnvironment_EnvironmentTypeSwitching
=== RUN   TestAccEnvironment_ServiceSwitching
=== PAUSE TestAccEnvironment_ServiceSwitching
=== RUN   TestAccEnvironment_Services
=== PAUSE TestAccEnvironment_Services
=== RUN   TestAccEnvironment_ServicesTags
=== PAUSE TestAccEnvironment_ServicesTags
=== RUN   TestAccEnvironment_BadParameters
=== PAUSE TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_RemovalDrift
=== CONT  TestAccEnvironment_MinimalWithPopulation
=== CONT  TestAccEnvironment_Services
=== CONT  TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_ServiceSwitching
=== CONT  TestAccEnvironment_ServicesTags
=== CONT  TestAccEnvironment_EnvironmentTypeSwitching
=== CONT  TestAccEnvironment_Minimal
=== CONT  TestAccEnvironment_DeleteProductionEnvironmentProtection
=== CONT  TestAccEnvironment_Full
=== CONT  TestAccEnvironment_DeleteProductionEnvironment
=== NAME  TestAccEnvironment_ServicesTags
    acctest.go:124: Skipping feature flag test.  Flag required: "DAVINCI"
--- SKIP: TestAccEnvironment_ServicesTags (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironmentProtection
    resource_environment_test.go:267: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironmentProtection (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironment
    resource_environment_test.go:294: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironment (0.00s)
--- PASS: TestAccEnvironment_NonCompatibleRegion (2.19s)
--- PASS: TestAccEnvironment_RemovalDrift (5.41s)
--- PASS: TestAccEnvironment_Minimal (6.51s)
--- PASS: TestAccEnvironment_BadParameters (7.29s)
--- PASS: TestAccEnvironment_ServiceSwitching (11.62s)
--- PASS: TestAccEnvironment_EnvironmentTypeSwitching (13.25s)
--- PASS: TestAccEnvironment_Full (14.04s)
--- PASS: TestAccEnvironment_Services (18.39s)
--- PASS: TestAccEnvironment_MinimalWithPopulation (307.05s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        307.902s
```