### PR TITLE
Align provider to bootstrap routine

### DIFF
--- a/.changelog/600.txt
+++ b/.changelog/600.txt
@@ -1,11 +1,3 @@
 ```release-note:new-resource
 pingone_population_default
 ```
-
-```release-note:bug
-`resource/pingone_environment`: Fixed situations where configuring a default population conflicts with the platform bootstrap, resulting in the created population not becoming the default for the environment.
-```
-
-```release-note:breaking-change
-`resource/pingone_environment`: The default population is no longer seeded automatically on environment creation.  Default population creation should be managed by the `pingone_population_default` resource going forward.
-```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 0.23.0 (Unreleased)
 
-BREAKING CHANGES:
-
-* `resource/pingone_environment`: The default population is no longer seeded automatically on environment creation.  Default population creation should be managed by the `pingone_population_default` resource going forward. ([#600](https://github.com/pingidentity/terraform-provider-pingone/issues/600))
-
 NOTES:
 
 * Updated documentation examples to remove reference to deprecated parameters/attributes. ([#603](https://github.com/pingidentity/terraform-provider-pingone/issues/603))
@@ -39,7 +35,6 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * `resource/pingone_environment`: Fixed ineffectual `timeouts` block configuration. ([#640](https://github.com/pingidentity/terraform-provider-pingone/issues/640))
-* `resource/pingone_environment`: Fixed situations where configuring a default population conflicts with the platform bootstrap, resulting in the created population not becoming the default for the environment. ([#600](https://github.com/pingidentity/terraform-provider-pingone/issues/600))
 
 ## 0.22.0 (17 October 2023)
 

--- a/docs/resources/population_default.md
+++ b/docs/resources/population_default.md
@@ -40,18 +40,10 @@ resource "pingone_population_default" "my_default_population" {
 
 - `description` (String) A description to apply to the default population.
 - `password_policy_id` (String) The ID of a password policy to assign to the default population.
-- `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-<a id="nestedatt--timeouts"></a>
-### Nested Schema for `timeouts`
-
-Optional:
-
-- `create` (String) A timeout to apply to creation of the resource.  There may be a short delay in provisioning this resource when creating the parent PingOne environment at the same time (referenced by the `environment_id` parameter), as the platform will create a default population automatically.  This resource will attempt to find and update the existing default population, and will wait if the default population cannot be found (for example, if it is in the process of being created automatically by the platform).  This timeout value can be used to override the wait time, and force the creation of a default population.  The value is expected to be a string that can be parsed as a duration consisting of numbers and unit suffixes, such as `30s` or `2h45m`. Valid time units are `s` (seconds), `m` (minutes), `h` (hours).  The default value is `20m` (20 minutes).
 
 ## Import
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -299,10 +299,6 @@ func MinimalSandboxEnvironment(resourceName, licenseID string) string {
 		environment_id = pingone_environment.%[2]s.id
 
 		name = "%[2]s"
-
-		timeouts = {
-			create = "1m"
-		}
 	}
 `, MinimalSandboxEnvironmentNoPopulation(resourceName, licenseID), resourceName)
 }

--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -634,10 +634,6 @@ resource "pingone_environment" "%[1]s" {
     name        = "%[2]s"
     description = "%[2]s description"
   }
-
-  timeouts {
-    create = "5m"
-  }
 }`, resourceName, name, licenseID)
 }
 

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -206,10 +206,6 @@ resource "pingone_population_default" "%[3]s" {
   name               = "%[4]s"
   description        = "Test description"
   password_policy_id = pingone_password_policy.%[3]s.id
-
-  timeouts = {
-    create = "5m"
-  }
 }`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }
 
@@ -220,9 +216,5 @@ func testAccPopulationDefaultConfig_Minimal(environmentName, licenseID, resource
 resource "pingone_population_default" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
   name           = "%[4]s"
-
-  timeouts = {
-    create = "5m"
-  }
 }`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Revert unreleased change that removed default environment creation from the `pingone_environment` resource
- Revert unreleased changes for timeout configuration on the `pingone_population_default` resource
- Revert bug fix for default population creation conflict when the DaVinci service is added to the `pingone_environment` resource

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

Deferred to nightly testing