### PR TITLE
`resource/pingone_mfa_settings`: Removal of deprecated parameter `authentication`

### DIFF
--- a/.changelog/645.txt
+++ b/.changelog/645.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_mfa_settings`: Removed deprecated parameter `authentication`.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -208,6 +208,12 @@ This parameter was previously deprecated and has been removed.  Use the `fido2` 
 
 This parameter was previously deprecated and has been removed.  Use the `fido2` parameter going forward.
 
+## Resource: pingone_mfa_settings
+
+### `authentication` optional parameter removed
+
+This parameter was previously deprecated and has been removed.  Device authentication parameters have moved to the `pingone_mfa_device_policy` resource.
+
 ## Data Source: pingone_organization
 
 ### `base_url_agreement_management` computed attribute removed

--- a/docs/resources/mfa_settings.md
+++ b/docs/resources/mfa_settings.md
@@ -42,7 +42,6 @@ resource "pingone_mfa_settings" "mfa_settings" {
 
 ### Optional
 
-- `authentication` (Block List, Max: 1, Deprecated) **This property is deprecated.**  Device selection settings should now be configured on the device policy, the `pingone_mfa_policy` resource. An object that contains the device selection settings. (see [below for nested schema](#nestedblock--authentication))
 - `lockout` (Block List, Max: 1) An object that contains lockout settings. (see [below for nested schema](#nestedblock--lockout))
 - `phone_extensions_enabled` (Boolean) A boolean when set to `true` allows one-time passwords to be delivered via voice to phone numbers that include extensions. Set to `false` to disable support for extensions. Defaults to `false`.
 
@@ -60,14 +59,6 @@ Required:
 Optional:
 
 - `max_allowed_devices` (Number) An integer that defines the maximum number of MFA devices each user can have. This can be any number up to 15. The default value is 5. Defaults to `5`.
-
-
-<a id="nestedblock--authentication"></a>
-### Nested Schema for `authentication`
-
-Required:
-
-- `device_selection` (String, Deprecated) **This property is deprecated.**  Device selection settings should now be configured on the device policy, the `pingone_mfa_policy` resource.  A string that defines the device selection method. Options are `DEFAULT_TO_FIRST` (this is the default setting for new environments) and `PROMPT_TO_SELECT`.
 
 
 <a id="nestedblock--lockout"></a>

--- a/internal/service/mfa/resource_mfa_settings_test.go
+++ b/internal/service/mfa/resource_mfa_settings_test.go
@@ -103,8 +103,6 @@ func TestAccMFASettings_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "8"),
 					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.#", "1"),
-					// resource.TestCheckResourceAttr(resourceFullName, "authentication.0.device_selection", "PROMPT_TO_SELECT"),
 				),
 			},
 			// Test importing the resource
@@ -157,8 +155,6 @@ func TestAccMFASettings_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.0.device_selection", "DEFAULT_TO_FIRST"),
 				),
 			},
 			{
@@ -173,8 +169,6 @@ func TestAccMFASettings_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.0.device_selection", "DEFAULT_TO_FIRST"),
 				),
 			},
 		},
@@ -213,8 +207,6 @@ func TestAccMFASettings_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "8"),
 					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.#", "1"),
-					// resource.TestCheckResourceAttr(resourceFullName, "authentication.0.device_selection", "PROMPT_TO_SELECT"),
 				),
 			},
 			{
@@ -227,8 +219,6 @@ func TestAccMFASettings_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.0.device_selection", "DEFAULT_TO_FIRST"),
 				),
 			},
 			{
@@ -243,8 +233,6 @@ func TestAccMFASettings_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
 					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "8"),
 					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "authentication.#", "1"),
-					// resource.TestCheckResourceAttr(resourceFullName, "authentication.0.device_selection", "PROMPT_TO_SELECT"),
 				),
 			},
 		},
@@ -309,10 +297,6 @@ resource "pingone_mfa_settings" "%[3]s" {
   }
 
   phone_extensions_enabled = true
-
-  //   authentication {
-  //     device_selection = "PROMPT_TO_SELECT"
-  //   }
 
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -208,6 +208,12 @@ This parameter was previously deprecated and has been removed.  Use the `fido2` 
 
 This parameter was previously deprecated and has been removed.  Use the `fido2` parameter going forward.
 
+## Resource: pingone_mfa_settings
+
+### `authentication` optional parameter removed
+
+This parameter was previously deprecated and has been removed.  Device authentication parameters have moved to the `pingone_mfa_device_policy` resource.
+
 ## Data Source: pingone_organization
 
 ### `base_url_agreement_management` computed attribute removed


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

### Testing Results
<!-- Use the following subsections to demonstrate any testing evidences.  Can be removed if the changes don't require it. -->

- `resource/pingone_mfa_settings`: Removal of deprecated parameter `authentication`.

#### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccMFASettings_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa
```

#### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->
```shell
=== RUN   TestAccMFASettings_RemovalDrift
=== PAUSE TestAccMFASettings_RemovalDrift
=== RUN   TestAccMFASettings_Full
=== PAUSE TestAccMFASettings_Full
=== RUN   TestAccMFASettings_Minimal
=== PAUSE TestAccMFASettings_Minimal
=== RUN   TestAccMFASettings_Change
=== PAUSE TestAccMFASettings_Change
=== RUN   TestAccMFASettings_BadParameters
=== PAUSE TestAccMFASettings_BadParameters
=== CONT  TestAccMFASettings_RemovalDrift
=== CONT  TestAccMFASettings_Change
=== CONT  TestAccMFASettings_Minimal
=== CONT  TestAccMFASettings_Full
=== CONT  TestAccMFASettings_BadParameters
--- PASS: TestAccMFASettings_BadParameters (45.10s)
--- PASS: TestAccMFASettings_Full (45.24s)
--- PASS: TestAccMFASettings_Minimal (53.72s)
--- PASS: TestAccMFASettings_RemovalDrift (57.04s)
--- PASS: TestAccMFASettings_Change (63.83s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 64.848s
```