### PR TITLE
`resource/pingone_environment`: Fixed `Value Conversion Error` when attempting to create an environment using calculated (unknown) `service` blocks.

### DIFF
--- a/.changelog/652.txt
+++ b/.changelog/652.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_environment`: Fixed `Value Conversion Error` when attempting to create an environment using calculated `service` blocks.
+```

--- a/.changelog/652.txt
+++ b/.changelog/652.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/pingone_environment`: Fixed `Value Conversion Error` when attempting to create an environment using calculated `service` blocks.
+`resource/pingone_environment`: Fixed `Value Conversion Error` when attempting to create an environment using calculated (unknown) `service` blocks.
 ```

--- a/internal/service/base/resource_environment.go
+++ b/internal/service/base/resource_environment.go
@@ -548,41 +548,7 @@ func (r *EnvironmentResource) ValidateConfig(ctx context.Context, req resource.V
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
-	if !data.Services.IsNull() {
-
-		var servicesPlan []environmentServiceModel
-		resp.Diagnostics.Append(data.Services.ElementsAs(ctx, &servicesPlan, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		if len(servicesPlan) > 0 {
-
-			daVinciService, err := model.FindProductByAPICode(management.ENUMPRODUCTTYPE_ONE_DAVINCI)
-			if err != nil {
-				resp.Diagnostics.AddAttributeError(
-					path.Root("service").AtName("tags"),
-					"Cannot find DaVinci product",
-					"In validating the configuration, the DaVinci product could not be found.  This is always a bug in the provider.  Please report this issue to the provider maintainers.",
-				)
-
-				return
-			}
-
-			for _, service := range servicesPlan {
-				if !service.Type.Equal(types.StringValue(daVinciService.ProductCode)) {
-					if !service.Tags.IsNull() {
-						resp.Diagnostics.AddAttributeError(
-							path.Root("service").AtName("tags"),
-							"Invalid configuration",
-							fmt.Sprintf("The `tags` parameter is only configurable where the `type` is set to `%s`.  Please unset the `tags` to an empty set or remove the `tags` parameter for the service.", daVinciService.ProductCode),
-						)
-					}
-				}
-			}
-		}
-	}
-
+	resp.Diagnostics.Append(environmentServicesValidateTags(ctx, data.Services)...)
 }
 
 func (r *EnvironmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -1159,6 +1125,11 @@ func (p *environmentResourceModel) expand(ctx context.Context) (*management.Envi
 		environment.SetDescription(p.Description.ValueString())
 	}
 
+	diags.Append(environmentServicesValidateTags(ctx, p.Services)...)
+	if diags.HasError() {
+		return nil, nil, diags
+	}
+
 	if !p.Services.IsNull() {
 
 		var servicesPlan []environmentServiceModel
@@ -1539,4 +1510,44 @@ var retryEnvironmentDefault = func(ctx context.Context, r *http.Response, p1erro
 	}
 
 	return false
+}
+
+func environmentServicesValidateTags(ctx context.Context, services basetypes.SetValue) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !services.IsNull() && !services.IsUnknown() {
+
+		var servicesPlan []environmentServiceModel
+		diags.Append(services.ElementsAs(ctx, &servicesPlan, false)...)
+		if diags.HasError() {
+			return diags
+		}
+
+		if len(servicesPlan) > 0 {
+			daVinciService, err := model.FindProductByAPICode(management.ENUMPRODUCTTYPE_ONE_DAVINCI)
+			if err != nil {
+				diags.AddAttributeError(
+					path.Root("service").AtName("tags"),
+					"Cannot find DaVinci product",
+					"In validating the configuration, the DaVinci product could not be found.  This is always a bug in the provider.  Please report this issue to the provider maintainers.",
+				)
+
+				return diags
+			}
+
+			for _, service := range servicesPlan {
+				if !service.Type.Equal(types.StringValue(daVinciService.ProductCode)) {
+					if !service.Tags.IsNull() {
+						diags.AddAttributeError(
+							path.Root("service").AtName("tags"),
+							"Invalid configuration",
+							fmt.Sprintf("The `tags` parameter is only configurable where the `type` is set to `%s`.  Please unset the `tags` to an empty set or remove the `tags` parameter for the service.", daVinciService.ProductCode),
+						)
+					}
+				}
+			}
+		}
+	}
+
+	return diags
 }

--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -595,16 +595,25 @@ resource "pingone_environment" "%[1]s" {
 }
 
 func testAccEnvironmentConfig_DynamicServices(resourceName, name, licenseID string, services []string) string {
-
-	composedServices := composeServices(services)
-
 	return fmt.Sprintf(`
+
+variable "services_%[1]s" {
+  type    = list(string)
+  default = ["%[4]s"]
+}
+
 resource "pingone_environment" "%[1]s" {
   name       = "%[2]s"
   license_id = "%[3]s"
 
-  %[4]s
-}`, resourceName, name, licenseID, composedServices)
+  dynamic "service" {
+    for_each = toset(var.services_%[1]s)
+
+    content {
+      type = service.key
+    }
+  }
+}`, resourceName, name, licenseID, strings.Join(services, "\",\""))
 }
 
 func testAccEnvironmentConfig_DVTags(resourceName, name, licenseID string) string {
@@ -661,12 +670,4 @@ resource "pingone_environment" "%[1]s" {
   region     = "%[3]s"
   license_id = "%[4]s"
 }`, resourceName, name, region, licenseID)
-}
-
-func composeServices(services []string) string {
-
-	var composedServices = fmt.Sprintf("service {\n  type = \"%s\"\n}", strings.Join(services, "\"\n}\nservice {\n  type = \""))
-
-	return composedServices
-
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_environment`: Fixed `Value Conversion Error` when attempting to create an environment using calculated `service` blocks.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccEnvironment_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccEnvironment_RemovalDrift
=== PAUSE TestAccEnvironment_RemovalDrift
=== RUN   TestAccEnvironment_Full
=== PAUSE TestAccEnvironment_Full
=== RUN   TestAccEnvironment_Minimal
=== PAUSE TestAccEnvironment_Minimal
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== RUN   TestAccEnvironment_DeleteProductionEnvironmentProtection
=== PAUSE TestAccEnvironment_DeleteProductionEnvironmentProtection
=== RUN   TestAccEnvironment_DeleteProductionEnvironment
=== PAUSE TestAccEnvironment_DeleteProductionEnvironment
=== RUN   TestAccEnvironment_MinimalWithPopulation
=== PAUSE TestAccEnvironment_MinimalWithPopulation
=== RUN   TestAccEnvironment_EnvironmentTypeSwitching
=== PAUSE TestAccEnvironment_EnvironmentTypeSwitching
=== RUN   TestAccEnvironment_ServiceSwitching
=== PAUSE TestAccEnvironment_ServiceSwitching
=== RUN   TestAccEnvironment_Services
=== PAUSE TestAccEnvironment_Services
=== RUN   TestAccEnvironment_ServicesTags
=== PAUSE TestAccEnvironment_ServicesTags
=== RUN   TestAccEnvironment_BadParameters
=== PAUSE TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_RemovalDrift
=== CONT  TestAccEnvironment_MinimalWithPopulation
=== CONT  TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_Services
=== CONT  TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_ServicesTags
=== CONT  TestAccEnvironment_DeleteProductionEnvironment
=== CONT  TestAccEnvironment_DeleteProductionEnvironmentProtection
=== NAME  TestAccEnvironment_ServicesTags
    acctest.go:124: Skipping feature flag test.  Flag required: "DAVINCI"
=== NAME  TestAccEnvironment_DeleteProductionEnvironment
    resource_environment_test.go:294: Test to be defined
=== CONT  TestAccEnvironment_Full
=== CONT  TestAccEnvironment_ServiceSwitching
=== CONT  TestAccEnvironment_EnvironmentTypeSwitching
=== CONT  TestAccEnvironment_Minimal
--- SKIP: TestAccEnvironment_ServicesTags (0.00s)
--- SKIP: TestAccEnvironment_DeleteProductionEnvironment (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironmentProtection
    resource_environment_test.go:267: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironmentProtection (0.00s)
--- PASS: TestAccEnvironment_NonCompatibleRegion (1.90s)
--- PASS: TestAccEnvironment_RemovalDrift (4.91s)
--- PASS: TestAccEnvironment_Minimal (6.51s)
--- PASS: TestAccEnvironment_BadParameters (6.78s)
--- PASS: TestAccEnvironment_MinimalWithPopulation (8.50s)
--- PASS: TestAccEnvironment_ServiceSwitching (11.35s)
--- PASS: TestAccEnvironment_Full (12.91s)
--- PASS: TestAccEnvironment_EnvironmentTypeSwitching (13.22s)
--- PASS: TestAccEnvironment_Services (17.98s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        18.625s
```

</details>