### PR TITLE
`resource/pingone_resource_grant`: Changed parameters `resource_id` and `scopes` to be read-only (`v1.0.0`)

### DIFF
--- a/.changelog/657.txt
+++ b/.changelog/657.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_resource_grant`: Changed parameters `resource_id` and `scopes` to be read-only.  Use the `resource_name` and `scope_names` parameters going forward.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -57,6 +57,16 @@ resource "pingone_application" "my_awesome_saml_app" {
 }
 ```
 
+## Resource: pingone_application_resource_grant
+
+### `resource_id` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the `resource_name` parameter going forward.
+
+### `scopes` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the `scope_names` parameter going forward.
+
 ## Resource: pingone_environment
 
 ### `default_population` optional parameter removed

--- a/docs/resources/application_resource_grant.md
+++ b/docs/resources/application_resource_grant.md
@@ -99,17 +99,14 @@ resource "pingone_application_resource_grant" "my_awesome_spa_custom_resource_gr
 
 - `application_id` (String) The ID of the application to create the resource grant for.  The value for `application_id` may come from the `id` attribute of the `pingone_application` or `pingone_system_application` resources or data sources.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `environment_id` (String) The ID of the environment to create the application resource grant in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
-
-### Optional
-
-- `resource_id` (String, Deprecated) **Deprecation Notice**: This parameter is deprecated and will be made read-only in a future release.  This attribute should be replaced with the `resource_name` parameter instead.  The ID of the resource to assign the resource attribute to.  At least one of the following must be defined: `resource_id`, `resource_name`.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
-- `resource_name` (String) The name of the resource to assign to the application.  The built-in OpenID Connect resource name is `openid` and the built-in PingOne API resource anem is `PingOne API`.  At least one of the following must be defined: `resource_id`, `resource_name`.  This field is immutable and will trigger a replace plan if changed.
-- `scope_names` (Set of String) A list of scopes by name that should be associated with this grant.  For example, `profile`, `email` etc.  When using the `openid` resource, the `openid` scope should not be included.  At least one of the following must be defined: `scopes`, `scope_names`.
-- `scopes` (Set of String, Deprecated) **Deprecation Notice**: This parameter is deprecated and will be made read-only in a future release.  This attribute should be replaced with the `scope_names` parameter instead.  A list of IDs of the scopes associated with this grant.  When using the `openid` resource, the `openid` scope should not be included.  At least one of the following must be defined: `scopes`, `scope_names`.
+- `resource_name` (String) The name of the resource to assign to the application.  The built-in OpenID Connect resource name is `openid` and the built-in PingOne API resource anem is `PingOne API`.  This field is immutable and will trigger a replace plan if changed.
+- `scope_names` (Set of String) A list of scopes by name that should be associated with this grant.  For example, `profile`, `email` etc.  When using the `openid` resource, the `openid` scope should not be included.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `resource_id` (String) The ID of the resource granted to the application.
+- `scopes` (Set of String) A list of IDs of the scopes associated with this grant.
 
 ## Import
 

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -57,6 +57,16 @@ resource "pingone_application" "my_awesome_saml_app" {
 }
 ```
 
+## Resource: pingone_application_resource_grant
+
+### `resource_id` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the `resource_name` parameter going forward.
+
+### `scopes` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the `scope_names` parameter going forward.
+
 ## Resource: pingone_environment
 
 ### `default_population` optional parameter removed


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_resource_grant`: Changed parameters `resource_id` and `scopes` to be read-only.
- 
### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccApplicationResourceGrant_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccApplicationResourceGrant_RemovalDrift
=== PAUSE TestAccApplicationResourceGrant_RemovalDrift
=== RUN   TestAccApplicationResourceGrant_OpenIDResource
=== PAUSE TestAccApplicationResourceGrant_OpenIDResource
=== RUN   TestAccApplicationResourceGrant_CustomResource
=== PAUSE TestAccApplicationResourceGrant_CustomResource
=== RUN   TestAccApplicationResourceGrant_SystemApplication
=== PAUSE TestAccApplicationResourceGrant_SystemApplication
=== RUN   TestAccApplicationResourceGrant_Change
=== PAUSE TestAccApplicationResourceGrant_Change
=== RUN   TestAccApplicationResourceGrant_BadParameters
=== PAUSE TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_RemovalDrift
=== CONT  TestAccApplicationResourceGrant_SystemApplication
=== CONT  TestAccApplicationResourceGrant_CustomResource
=== CONT  TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_OpenIDResource
=== CONT  TestAccApplicationResourceGrant_Change
--- PASS: TestAccApplicationResourceGrant_CustomResource (10.54s)
--- PASS: TestAccApplicationResourceGrant_BadParameters (10.76s)
--- PASS: TestAccApplicationResourceGrant_OpenIDResource (18.01s)
--- PASS: TestAccApplicationResourceGrant_Change (21.16s)
--- PASS: TestAccApplicationResourceGrant_RemovalDrift (55.24s)
--- PASS: TestAccApplicationResourceGrant_SystemApplication (58.72s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 59.412s
```

</details>