### PR TITLE
`resource/pingone_resource_attribute`: Changed parameter `resource_id` to be read-only

### DIFF
--- a/.changelog/658.txt
+++ b/.changelog/658.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+`resource/pingone_resource_attribute`: Changed parameter `resource_id` to be read-only.  Use the `resource_name` parameter going forward.
+```
+
+```release-note:breaking-change
+`resource/pingone_resource_attribute`: Changed parameter `resource_name` to be a required parameter.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -269,6 +269,16 @@ This parameter was previously deprecated and has been removed.  Use the `fido2` 
 
 This parameter was previously deprecated and has been removed.  Device authentication parameters have moved to the `pingone_mfa_device_policy` resource.
 
+## Resource: pingone_resource_attribute
+
+### `resource_id` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the `resource_name` parameter going forward.
+
+### `resource_name` parameter changed
+
+This parameter was previously optional and has now been made a required field.
+
 ## Resource: pingone_user
 
 ### `status` optional parameter removed

--- a/docs/resources/resource_attribute.md
+++ b/docs/resources/resource_attribute.md
@@ -46,18 +46,18 @@ resource "pingone_resource_attribute" "my_openid_connect_resource_attribute" {
 
 - `environment_id` (String) The ID of the environment to create the resource attribute in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `name` (String) A string that specifies the name of the resource attribute to map a value for. When the resource's type property is `OPENID_CONNECT`, the following are reserved names and cannot be used: `acr`, `amr`, `aud`, `auth_time`, `client_id`, `env`, `exp`, `iat`, `iss`, `jti`, `org`, `p1.*`, `scope`, `sid`, `sub`.  The resource will also override the default configured values for a resource, rather than creating new attributes.  For resources of type `CUSTOM`, the `sub` name is overridden.  For resources of type `OPENID_CONNECT`, the following names are overridden: `address.country`, `address.formatted`, `address.locality`, `address.postal_code`, `address.region`, `address.street_address`, `birthdate`, `email`, `email_verified`, `family_name`, `gender`, `given_name`, `locale`, `middle_name`, `name`, `nickname`, `phone_number`, `phone_number_verified`, `picture`, `preferred_username`, `profile`, `updated_at`, `website`, `zoneinfo`.
+- `resource_name` (String) The name of the resource to assign the resource attribute to.  The built-in OpenID Connect resource name is `openid`.  This field is immutable and will trigger a replace plan if changed.
 - `value` (String) A string that specifies the value of the custom resource attribute. This value can be a placeholder that references an attribute in the user schema, expressed as `${user.path.to.value}`, or it can be an expression, or a static string. Placeholders must be valid, enabled attributes in the environment’s user schema. Examples of valid values are: `${user.email}`, `${user.name.family}`, and `myClaimValueString`.  Note that definition in HCL requires escaping with the `$` character when defining attribute paths, for example `value = "$${user.email}"`.
 
 ### Optional
 
 - `id_token_enabled` (Boolean) A boolean that specifies whether the attribute mapping should be available in the ID Token.  Only applies to resources that are of type `OPENID_CONNECT` and the `id_token_enabled` and `userinfo_enabled` properties cannot both be set to false. Defaults to `true`.
-- `resource_id` (String, Deprecated) **Deprecation Notice**: This parameter is deprecated and will be made read-only in a future release.  This attribute should be replaced with the `resource_name` parameter instead.  The ID of the resource to assign the resource attribute to.  At least one of the following must be defined: `resource_id`, `resource_name`.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
-- `resource_name` (String) The name of the resource to assign the resource attribute to.  The built-in OpenID Connect resource name is `openid`.  At least one of the following must be defined: `resource_id`, `resource_name`.  This field is immutable and will trigger a replace plan if changed.
 - `userinfo_enabled` (Boolean) A boolean that specifies whether the attribute mapping should be available through the /as/userinfo endpoint.  Only applies to resources that are of type `OPENID_CONNECT` and the `id_token_enabled` and `userinfo_enabled` properties cannot both be set to false. Defaults to `true`.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `resource_id` (String) The ID of the resource that the attribute is assigned to.
 - `type` (String) A string that specifies the type of resource attribute. Options are: `CORE` (The claim is required and cannot not be removed), `CUSTOM` (The claim is not a CORE attribute. All created attributes are of this type), `PREDEFINED` (A designation for predefined OIDC resource attributes such as given_name. These attributes cannot be removed; however, they can be modified).
 
 ## Import

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -269,6 +269,16 @@ This parameter was previously deprecated and has been removed.  Use the `fido2` 
 
 This parameter was previously deprecated and has been removed.  Device authentication parameters have moved to the `pingone_mfa_device_policy` resource.
 
+## Resource: pingone_resource_attribute
+
+### `resource_id` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the `resource_name` parameter going forward.
+
+### `resource_name` parameter changed
+
+This parameter was previously optional and has now been made a required field.
+
 ## Resource: pingone_user
 
 ### `status` optional parameter removed


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_resource_attribute`: Changed parameter `resource_id` to be read-only

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccResourceAttribute_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccResourceAttribute_RemovalDrift
=== PAUSE TestAccResourceAttribute_RemovalDrift
=== RUN   TestAccResourceAttribute_OIDC_Custom
=== PAUSE TestAccResourceAttribute_OIDC_Custom
=== RUN   TestAccResourceAttribute_OIDC_ReservedAttributeName
=== PAUSE TestAccResourceAttribute_OIDC_ReservedAttributeName
=== RUN   TestAccResourceAttribute_OIDC_Predefined
=== PAUSE TestAccResourceAttribute_OIDC_Predefined
=== RUN   TestAccResourceAttribute_Custom
=== PAUSE TestAccResourceAttribute_Custom
=== RUN   TestAccResourceAttribute_Custom_CoreAttribute
=== PAUSE TestAccResourceAttribute_Custom_CoreAttribute
=== RUN   TestAccResourceAttribute_BadResource
=== PAUSE TestAccResourceAttribute_BadResource
=== RUN   TestAccResourceAttribute_BadParameters
=== PAUSE TestAccResourceAttribute_BadParameters
=== CONT  TestAccResourceAttribute_RemovalDrift
=== CONT  TestAccResourceAttribute_Custom
=== CONT  TestAccResourceAttribute_OIDC_ReservedAttributeName
=== CONT  TestAccResourceAttribute_OIDC_Custom
=== CONT  TestAccResourceAttribute_OIDC_Predefined
=== CONT  TestAccResourceAttribute_Custom_CoreAttribute
=== CONT  TestAccResourceAttribute_BadParameters
=== CONT  TestAccResourceAttribute_BadResource
--- PASS: TestAccResourceAttribute_OIDC_ReservedAttributeName (3.45s)
--- PASS: TestAccResourceAttribute_BadResource (3.53s)
--- PASS: TestAccResourceAttribute_BadParameters (8.55s)
--- PASS: TestAccResourceAttribute_Custom_CoreAttribute (33.42s)
--- PASS: TestAccResourceAttribute_Custom (36.07s)
--- PASS: TestAccResourceAttribute_OIDC_Custom (39.71s)
--- PASS: TestAccResourceAttribute_OIDC_Predefined (42.67s)
--- PASS: TestAccResourceAttribute_RemovalDrift (52.77s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 54.292s
```

</details>