### PR TITLE
`resource/pingone_schema_attribute`: Changed parameter `schema_id` to be read-only

### DIFF
--- a/.changelog/660.txt
+++ b/.changelog/660.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`resource/pingone_schema_attribute`: Changed parameter `schema_id` to be read-only.  Use the optional `schema_name` parameter going forward.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -287,6 +287,12 @@ This parameter was previously deprecated and has now been made read only.  Use t
 
 This parameter was previously optional and has now been made a required field.
 
+## Resource: pingone_schema_attribute
+
+### `schema_id` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the optional `schema_name` parameter going forward.
+
 ## Resource: pingone_user
 
 ### `status` optional parameter removed

--- a/docs/resources/schema_attribute.md
+++ b/docs/resources/schema_attribute.md
@@ -71,8 +71,7 @@ resource "pingone_schema_attribute" "my_awesome_regex_attribute" {
 - `enumerated_values` (Attributes Set) A set of one or more enumerated values for the attribute. If provided, it must not be an empty set.  Can only be set where the attribute type is `STRING` and cannot be set alongside `regex_validation`.  If the attribute has been created without enumerated values and this parameter is added later, this will trigger a replacement plan of the attribute resource.  If the attribute has been created with enumerated values that are subsequently removed, this will update without needing to replace the attribute resource. (see [below for nested schema](#nestedatt--enumerated_values))
 - `multivalued` (Boolean) Indicates whether the attribute has multiple values or a single one. Maximum number of values stored is 1,000.  This field is immutable and will trigger a replace plan if changed.  Defaults to `false`.
 - `regex_validation` (Attributes) A single object representation of the optional regular expression representation of this attribute.  Can only be set where the attribute type is `STRING` and cannot be set alongside `enumerated_values`. (see [below for nested schema](#nestedatt--regex_validation))
-- `schema_id` (String, Deprecated) **Deprecation Notice**: This parameter is deprecated and will be made read-only in a future release.  This attribute can be removed (the resource will default to the `User` schema), or the `schema_name` parameter can be defined instead.  The ID of the schema to apply the schema attribute to.  Must be a valid PingOne resource ID.  Conflicts with `schema_name`.
-- `schema_name` (String) The name of the schema to apply the schema attribute to.  Options are `User`.  Defaults to `User`.  Conflicts with `schema_id`.
+- `schema_name` (String) The name of the schema to apply the schema attribute to.  Options are `User`.  Defaults to `User`.
 - `type` (String) The type of the attribute.  Options are `BOOLEAN`, `COMPLEX`, `JSON`, `STRING`.  `COMPLEX` and `BOOLEAN` attributes cannot be created, but standard attributes of those types may be updated. `JSON` attributes are limited by size (total size must not exceed 16KB).  This field is immutable and will trigger a replace plan if changed.  Defaults to `STRING`.
 - `unique` (Boolean) Indicates whether or not the attribute must have a unique value within the PingOne environment.  This field is immutable and will trigger a replace plan if changed.  Defaults to `false`.
 
@@ -81,6 +80,7 @@ resource "pingone_schema_attribute" "my_awesome_regex_attribute" {
 - `id` (String) The ID of this resource.
 - `ldap_attribute` (String) The unique identifier for the LDAP attribute.
 - `required` (Boolean) Indicates whether or not the attribute is required.
+- `schema_id` (String) The ID of the schema the schema attribute is applied to.
 - `schema_type` (String) The schema type of the attribute.  Options are `CORE`, `CUSTOM`, `STANDARD`.  `CORE` and `STANDARD` attributes are supplied by default. `CORE` attributes cannot be updated or deleted. `STANDARD` attributes cannot be deleted, but their mutable properties can be updated. `CUSTOM` attributes can be deleted, and their mutable properties can be updated. New attributes are created with a schema type of `CUSTOM`.
 
 <a id="nestedatt--enumerated_values"></a>

--- a/internal/service/sso/resource_schema_attribute.go
+++ b/internal/service/sso/resource_schema_attribute.go
@@ -108,12 +108,12 @@ func (r *SchemaAttributeResource) Schema(ctx context.Context, req resource.Schem
 	const schemaName = "User"
 
 	schemaIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"**Deprecation Notice**: This parameter is deprecated and will be made read-only in a future release.  This attribute can be removed (the resource will default to the `User` schema), or the `schema_name` parameter can be defined instead.  The ID of the schema to apply the schema attribute to.",
-	).AppendMarkdownString("Must be a valid PingOne resource ID.").ConflictsWith([]string{"schema_name"})
+		"The ID of the schema the schema attribute is applied to.",
+	)
 
 	schemaNameDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"The name of the schema to apply the schema attribute to.",
-	).AllowedValues(schemaName).DefaultValue(schemaName).ConflictsWith([]string{"schema_id"})
+	).AllowedValues(schemaName).DefaultValue(schemaName)
 
 	enabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"Indicates whether or not the attribute is enabled.",
@@ -164,20 +164,10 @@ func (r *SchemaAttributeResource) Schema(ctx context.Context, req resource.Schem
 			"schema_id": schema.StringAttribute{
 				Description:         schemaIdDescription.Description,
 				MarkdownDescription: schemaIdDescription.MarkdownDescription,
-				DeprecationMessage:  "This parameter is deprecated and will be made read-only in a future release.  This attribute can be removed (the resource will default to the `User` schema), or the `schema_name` parameter can be defined instead.",
-				Optional:            true,
 				Computed:            true,
 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-				},
-
-				Validators: []validator.String{
-					verify.P1ResourceIDValidator(),
-					stringvalidator.ConflictsWith(
-						path.MatchRoot("schema_id"),
-						path.MatchRoot("schema_name"),
-					),
 				},
 			},
 
@@ -195,10 +185,6 @@ func (r *SchemaAttributeResource) Schema(ctx context.Context, req resource.Schem
 
 				Validators: []validator.String{
 					stringvalidator.OneOf(schemaName),
-					stringvalidator.ConflictsWith(
-						path.MatchRoot("schema_id"),
-						path.MatchRoot("schema_name"),
-					),
 				},
 			},
 

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -287,6 +287,12 @@ This parameter was previously deprecated and has now been made read only.  Use t
 
 This parameter was previously optional and has now been made a required field.
 
+## Resource: pingone_schema_attribute
+
+### `schema_id` parameter changed
+
+This parameter was previously deprecated and has now been made read only.  Use the optional `schema_name` parameter going forward.
+
 ## Resource: pingone_user
 
 ### `status` optional parameter removed


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_schema_attribute`: Changed parameter `schema_id` to be read-only

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccSchemaAttribute_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccSchemaAttribute_RemovalDrift
=== PAUSE TestAccSchemaAttribute_RemovalDrift
=== RUN   TestAccSchemaAttribute_NewEnv
=== PAUSE TestAccSchemaAttribute_NewEnv
=== RUN   TestAccSchemaAttribute_String
=== PAUSE TestAccSchemaAttribute_String
=== RUN   TestAccSchemaAttribute_StringEnumeratedValues
=== PAUSE TestAccSchemaAttribute_StringEnumeratedValues
=== RUN   TestAccSchemaAttribute_StringRegexValidation
=== PAUSE TestAccSchemaAttribute_StringRegexValidation
=== RUN   TestAccSchemaAttribute_StringParameterCombinations
=== PAUSE TestAccSchemaAttribute_StringParameterCombinations
=== RUN   TestAccSchemaAttribute_JSON
=== PAUSE TestAccSchemaAttribute_JSON
=== RUN   TestAccSchemaAttribute_JSONInvalidAttrs
=== PAUSE TestAccSchemaAttribute_JSONInvalidAttrs
=== RUN   TestAccSchemaAttribute_JSONParameterCombinations
=== PAUSE TestAccSchemaAttribute_JSONParameterCombinations
=== RUN   TestAccSchemaAttribute_BadParameters
=== PAUSE TestAccSchemaAttribute_BadParameters
=== CONT  TestAccSchemaAttribute_RemovalDrift
=== CONT  TestAccSchemaAttribute_StringParameterCombinations
=== CONT  TestAccSchemaAttribute_StringEnumeratedValues
=== CONT  TestAccSchemaAttribute_JSONParameterCombinations
=== CONT  TestAccSchemaAttribute_String
=== CONT  TestAccSchemaAttribute_BadParameters
=== CONT  TestAccSchemaAttribute_JSON
=== CONT  TestAccSchemaAttribute_NewEnv
=== CONT  TestAccSchemaAttribute_JSONInvalidAttrs
=== CONT  TestAccSchemaAttribute_StringRegexValidation
--- PASS: TestAccSchemaAttribute_JSONInvalidAttrs (0.56s)
--- PASS: TestAccSchemaAttribute_BadParameters (9.36s)
--- PASS: TestAccSchemaAttribute_JSONParameterCombinations (12.17s)
--- PASS: TestAccSchemaAttribute_StringParameterCombinations (20.98s)
--- PASS: TestAccSchemaAttribute_StringEnumeratedValues (32.79s)
--- PASS: TestAccSchemaAttribute_StringRegexValidation (33.02s)
--- PASS: TestAccSchemaAttribute_JSON (33.93s)
--- PASS: TestAccSchemaAttribute_String (34.20s)
--- PASS: TestAccSchemaAttribute_NewEnv (41.44s)
--- PASS: TestAccSchemaAttribute_RemovalDrift (46.20s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 47.432s
```

</details>