### PR TITLE
`resource/pingone_identity_provider`: Changed block data types

### DIFF
--- a/.changelog/662.txt
+++ b/.changelog/662.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`resource/pingone_identity_provider`: Changed the `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect` and `saml` parameter data types.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -185,6 +185,160 @@ This parameter block is no longer needed and has been removed.
 
 ## Resource: pingone_identity_provider
 
+### `amazon` parameter data type change
+
+The `amazon` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  amazon {
+    client_id     = var.amazon_client_id
+    client_secret = var.amazon_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  amazon = {
+    client_id     = var.amazon_client_id
+    client_secret = var.amazon_client_secret
+  }
+}
+```
+
+### `apple` parameter data type change
+
+The `apple` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  apple {
+    client_id                 = var.apple_client_id
+    client_secret_signing_key = var.apple_client_secret_signing_key
+    key_id                    = var.apple_key_id
+    team_id                   = var.apple_team_id
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  apple = {
+    client_id                 = var.apple_client_id
+    client_secret_signing_key = var.apple_client_secret_signing_key
+    key_id                    = var.apple_key_id
+    team_id                   = var.apple_team_id
+  }
+}
+```
+
+### `facebook` parameter data type change
+
+The `facebook` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  facebook {
+    app_id     = var.facebook_app_id
+    app_secret = var.facebook_app_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  facebook = {
+    app_id     = var.facebook_app_id
+    app_secret = var.facebook_app_secret
+  }
+}
+```
+
+### `github` parameter data type change
+
+The `github` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  github {
+    client_id     = var.github_client_id
+    client_secret = var.github_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  github = {
+    client_id     = var.github_client_id
+    client_secret = var.github_client_secret
+  }
+}
+```
+
+### `google` parameter data type change
+
+The `google` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  google {
+    client_id     = var.google_client_id
+    client_secret = var.google_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  google = {
+    client_id     = var.google_client_id
+    client_secret = var.google_client_secret
+  }
+}
+```
+
 ### `icon` parameter data type change
 
 The `icon` parameter is now a nested object type and no longer a block type.
@@ -215,6 +369,36 @@ resource "pingone_identity_provider" "my_awesome_identity_provider" {
 }
 ```
 
+### `linkedin` parameter data type change
+
+The `linkedin` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  linkedin {
+    client_id     = var.linkedin_client_id
+    client_secret = var.linkedin_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  linkedin = {
+    client_id     = var.linkedin_client_id
+    client_secret = var.linkedin_client_secret
+  }
+}
+```
+
 ### `login_button_icon` parameter data type change
 
 The `login_button_icon` parameter is now a nested object type and no longer a block type.
@@ -241,6 +425,204 @@ resource "pingone_identity_provider" "my_awesome_identity_provider" {
   login_button_icon = {
     id   = pingone_image.identity_provider_login_button_icon.id
     href = pingone_image.identity_provider_login_button_icon.uploaded_image.href
+  }
+}
+```
+
+### `microsoft` parameter data type change
+
+The `microsoft` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  microsoft {
+    client_id     = var.microsoft_client_id
+    client_secret = var.microsoft_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  microsoft = {
+    client_id     = var.microsoft_client_id
+    client_secret = var.microsoft_client_secret
+  }
+}
+```
+
+### `openid_connect` parameter data type change
+
+The `openid_connect` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  openid_connect {
+    authorization_endpoint = var.openid_connect_idp_authorization_endpoint
+    client_id              = var.openid_connect_idp_client_id
+    client_secret          = var.openid_connect_idp_client_secret
+    issuer                 = var.openid_connect_idp_issuer
+    jwks_endpoint          = var.openid_connect_idp_jwks_endpoint
+    scopes                 = var.openid_connect_idp_scopes
+    token_endpoint         = var.openid_connect_idp_token_endpoint
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  openid_connect = {
+    authorization_endpoint = var.openid_connect_idp_authorization_endpoint
+    client_id              = var.openid_connect_idp_client_id
+    client_secret          = var.openid_connect_idp_client_secret
+    issuer                 = var.openid_connect_idp_issuer
+    jwks_endpoint          = var.openid_connect_idp_jwks_endpoint
+    scopes                 = var.openid_connect_idp_scopes
+    token_endpoint         = var.openid_connect_idp_token_endpoint
+  }
+}
+```
+
+### `paypal` parameter data type change
+
+The `paypal` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  paypal {
+    client_environment     = var.paypal_client_environment
+    client_id              = var.paypal_client_id
+    client_secret          = var.paypal_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  paypal = {
+    client_environment     = var.paypal_client_environment
+    client_id              = var.paypal_client_id
+    client_secret          = var.paypal_client_secret
+  }
+}
+```
+
+### `saml` parameter data type change
+
+The `saml` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml {
+    idp_entity_id                    = var.saml_idp_entity_id
+    idp_verification_certificate_ids = var.saml_idp_verification_certificate_ids 
+    sp_entity_id                     = var.saml_idp_sp_entity_id
+    sso_binding                      = var.saml_idp_sso_binding
+    sso_endpoint                     = var.saml_idp_sso_endpoint
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml = {
+    idp_entity_id                    = var.saml_idp_entity_id
+    idp_verification_certificate_ids = var.saml_idp_verification_certificate_ids 
+    sp_entity_id                     = var.saml_idp_sp_entity_id
+    sso_binding                      = var.saml_idp_sso_binding
+    sso_endpoint                     = var.saml_idp_sso_endpoint
+  }
+}
+```
+
+### `twitter` parameter data type change
+
+The `twitter` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  twitter {
+    client_id     = var.twitter_client_id
+    client_secret = var.twitter_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  twitter = {
+    client_id     = var.twitter_client_id
+    client_secret = var.twitter_client_secret
+  }
+}
+```
+
+### `yahoo` parameter data type change
+
+The `yahoo` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  yahoo {
+    client_id     = var.yahoo_client_id
+    client_secret = var.yahoo_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  yahoo = {
+    client_id     = var.yahoo_client_id
+    client_secret = var.yahoo_client_secret
   }
 }
 ```

--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -22,7 +22,7 @@ resource "pingone_identity_provider" "facebook" {
   name    = "Facebook"
   enabled = true
 
-  facebook {
+  facebook = {
     app_id     = var.facebook_app_id
     app_secret = var.facebook_app_secret
   }
@@ -34,7 +34,7 @@ resource "pingone_identity_provider" "google" {
   name    = "Google"
   enabled = true
 
-  google {
+  google = {
     client_id     = var.google_client_id
     client_secret = var.google_client_secret
   }
@@ -46,7 +46,7 @@ resource "pingone_identity_provider" "apple" {
   name    = "Apple"
   enabled = true
 
-  apple {
+  apple = {
     client_id                 = var.apple_client_id
     client_secret_signing_key = var.apple_client_secret_signing_key
     key_id                    = var.apple_key_id
@@ -65,29 +65,29 @@ resource "pingone_identity_provider" "apple" {
 
 ### Optional
 
-- `amazon` (Block List) A single block that specifies options for connectivity to the Amazon social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--amazon))
-- `apple` (Block List) A single block that specifies options for connectivity to the Apple social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--apple))
+- `amazon` (Attributes) A single block that specifies options for connectivity to the Amazon social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--amazon))
+- `apple` (Attributes) A single block that specifies options for connectivity to the Apple social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--apple))
 - `description` (String) A string that specifies the description of the identity provider.
 - `enabled` (Boolean) A boolean that specifies whether the identity provider is enabled in the environment.  Defaults to `false`.
-- `facebook` (Block List) A single block that specifies options for connectivity to the Facebook social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--facebook))
-- `github` (Block List) A single block that specifies options for connectivity to the Github social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--github))
-- `google` (Block List) A single block that specifies options for connectivity to the Google social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--google))
+- `facebook` (Attributes) A single block that specifies options for connectivity to the Facebook social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--facebook))
+- `github` (Attributes) A single block that specifies options for connectivity to the Github social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--github))
+- `google` (Attributes) A single block that specifies options for connectivity to the Google social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--google))
 - `icon` (Attributes) A single object that specifies the HREF and ID for the identity provider icon. (see [below for nested schema](#nestedatt--icon))
-- `linkedin` (Block List) A single block that specifies options for connectivity to the LinkedIn social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--linkedin))
+- `linkedin` (Attributes) A single block that specifies options for connectivity to the LinkedIn social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--linkedin))
 - `login_button_icon` (Attributes) A single object that specifies the HREF and ID for the identity provider icon to use in the login button. (see [below for nested schema](#nestedatt--login_button_icon))
-- `microsoft` (Block List) A single block that specifies options for connectivity to the Microsoft social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--microsoft))
-- `openid_connect` (Block List) A single block that specifies options for connectivity to an OpenID Connect compliant identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--openid_connect))
-- `paypal` (Block List) A single block that specifies options for connectivity to the Paypal social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--paypal))
+- `microsoft` (Attributes) A single block that specifies options for connectivity to the Microsoft social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--microsoft))
+- `openid_connect` (Attributes) A single block that specifies options for connectivity to an OpenID Connect compliant identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--openid_connect))
+- `paypal` (Attributes) A single block that specifies options for connectivity to the Paypal social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--paypal))
 - `registration_population_id` (String) A string that specifies the population ID to create users in, when using just-in-time provisioning. Setting this attribute gives management of linked users to the IdP and also triggers just-in-time provisioning of new users to the population ID provided.  Must be a valid PingOne resource ID.
-- `saml` (Block List) A single block that specifies options for connectivity to a SAML 2.0 compliant identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--saml))
-- `twitter` (Block List) A single block that specifies options for connectivity to the Twitter social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--twitter))
-- `yahoo` (Block List) A single block that specifies options for connectivity to the Yahoo social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules. (see [below for nested schema](#nestedblock--yahoo))
+- `saml` (Attributes) A single block that specifies options for connectivity to a SAML 2.0 compliant identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--saml))
+- `twitter` (Attributes) A single block that specifies options for connectivity to the Twitter social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--twitter))
+- `yahoo` (Attributes) A single block that specifies options for connectivity to the Yahoo social identity provider.  At least one of the following must be defined: `facebook`, `google`, `linkedin`, `yahoo`, `amazon`, `twitter`, `apple`, `paypal`, `microsoft`, `github`, `openid_connect`, `saml`.  This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules. (see [below for nested schema](#nestedatt--yahoo))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 
-<a id="nestedblock--amazon"></a>
+<a id="nestedatt--amazon"></a>
 ### Nested Schema for `amazon`
 
 Required:
@@ -96,7 +96,7 @@ Required:
 - `client_secret` (String, Sensitive) A string that specifies the application client secret from Amazon.
 
 
-<a id="nestedblock--apple"></a>
+<a id="nestedatt--apple"></a>
 ### Nested Schema for `apple`
 
 Required:
@@ -107,7 +107,7 @@ Required:
 - `team_id` (String) A 10-character string that Apple uses to identify teams.
 
 
-<a id="nestedblock--facebook"></a>
+<a id="nestedatt--facebook"></a>
 ### Nested Schema for `facebook`
 
 Required:
@@ -116,7 +116,7 @@ Required:
 - `app_secret` (String, Sensitive) A string that specifies the application secret from Facebook.
 
 
-<a id="nestedblock--github"></a>
+<a id="nestedatt--github"></a>
 ### Nested Schema for `github`
 
 Required:
@@ -125,7 +125,7 @@ Required:
 - `client_secret` (String, Sensitive) A string that specifies the application client secret from Github.
 
 
-<a id="nestedblock--google"></a>
+<a id="nestedatt--google"></a>
 ### Nested Schema for `google`
 
 Required:
@@ -143,7 +143,7 @@ Required:
 - `id` (String) The ID for the identity provider icon to use as the login button.  This can be retrieved from the `id` parameter of the `pingone_image` resource.  Must be a valid PingOne resource ID.
 
 
-<a id="nestedblock--linkedin"></a>
+<a id="nestedatt--linkedin"></a>
 ### Nested Schema for `linkedin`
 
 Required:
@@ -161,7 +161,7 @@ Required:
 - `id` (String) The ID for the identity provider icon to use as the login button.  This can be retrieved from the `id` parameter of the `pingone_image` resource.  Must be a valid PingOne resource ID.
 
 
-<a id="nestedblock--microsoft"></a>
+<a id="nestedatt--microsoft"></a>
 ### Nested Schema for `microsoft`
 
 Required:
@@ -170,7 +170,7 @@ Required:
 - `client_secret` (String, Sensitive) A string that specifies the application client secret from Microsoft.
 
 
-<a id="nestedblock--openid_connect"></a>
+<a id="nestedatt--openid_connect"></a>
 ### Nested Schema for `openid_connect`
 
 Required:
@@ -190,7 +190,7 @@ Optional:
 - `userinfo_endpoint` (String) A string that specifies the OIDC identity provider's userInfo endpoint. This value must be a URL that uses https.
 
 
-<a id="nestedblock--paypal"></a>
+<a id="nestedatt--paypal"></a>
 ### Nested Schema for `paypal`
 
 Required:
@@ -200,7 +200,7 @@ Required:
 - `client_secret` (String, Sensitive) A string that specifies the application secret from PayPal.
 
 
-<a id="nestedblock--saml"></a>
+<a id="nestedatt--saml"></a>
 ### Nested Schema for `saml`
 
 Required:
@@ -221,7 +221,7 @@ Optional:
 - `sp_signing_key_id` (String) A string that specifies the service provider's signing key ID.  Must be a valid PingOne resource ID.
 
 
-<a id="nestedblock--twitter"></a>
+<a id="nestedatt--twitter"></a>
 ### Nested Schema for `twitter`
 
 Required:
@@ -230,7 +230,7 @@ Required:
 - `client_secret` (String, Sensitive) A string that specifies the application client secret from Twitter.
 
 
-<a id="nestedblock--yahoo"></a>
+<a id="nestedatt--yahoo"></a>
 ### Nested Schema for `yahoo`
 
 Required:

--- a/docs/resources/identity_provider_attribute.md
+++ b/docs/resources/identity_provider_attribute.md
@@ -25,7 +25,7 @@ resource "pingone_identity_provider" "apple" {
   name    = "Apple"
   enabled = true
 
-  apple {
+  apple = {
     client_id                 = var.apple_client_id
     client_secret_signing_key = var.apple_client_secret_signing_key
     key_id                    = var.apple_key_id

--- a/examples/resources/pingone_identity_provider/resource.tf
+++ b/examples/resources/pingone_identity_provider/resource.tf
@@ -8,7 +8,7 @@ resource "pingone_identity_provider" "facebook" {
   name    = "Facebook"
   enabled = true
 
-  facebook {
+  facebook = {
     app_id     = var.facebook_app_id
     app_secret = var.facebook_app_secret
   }
@@ -20,7 +20,7 @@ resource "pingone_identity_provider" "google" {
   name    = "Google"
   enabled = true
 
-  google {
+  google = {
     client_id     = var.google_client_id
     client_secret = var.google_client_secret
   }
@@ -32,7 +32,7 @@ resource "pingone_identity_provider" "apple" {
   name    = "Apple"
   enabled = true
 
-  apple {
+  apple = {
     client_id                 = var.apple_client_id
     client_secret_signing_key = var.apple_client_secret_signing_key
     key_id                    = var.apple_key_id

--- a/examples/resources/pingone_identity_provider_attribute/resource.tf
+++ b/examples/resources/pingone_identity_provider_attribute/resource.tf
@@ -8,7 +8,7 @@ resource "pingone_identity_provider" "apple" {
   name    = "Apple"
   enabled = true
 
-  apple {
+  apple = {
     client_id                 = var.apple_client_id
     client_secret_signing_key = var.apple_client_secret_signing_key
     key_id                    = var.apple_key_id

--- a/internal/framework/schema_attribute_description.go
+++ b/internal/framework/schema_attribute_description.go
@@ -111,8 +111,8 @@ func (r SchemaAttributeDescription) RequiresReplace() SchemaAttributeDescription
 	return r.AppendMarkdownString("This field is immutable and will trigger a replace plan if changed.")
 }
 
-func (r SchemaAttributeDescription) RequiresReplaceBlock() SchemaAttributeDescription {
-	return r.AppendMarkdownString("This block is immutable.  If this block is added or removed, a replacement plan is triggered.  Parameters within the block are subject to their own immutability rules.")
+func (r SchemaAttributeDescription) RequiresReplaceNestedAttributes() SchemaAttributeDescription {
+	return r.AppendMarkdownString("This object is immutable.  If this object is added or removed, a replacement plan is triggered.  Parameters within the object are subject to their own immutability rules.")
 }
 
 func (r SchemaAttributeDescription) AppendSliceValues(pretext string, values []string) SchemaAttributeDescription {

--- a/internal/service/sso/resource_identity_provider.go
+++ b/internal/service/sso/resource_identity_provider.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -42,18 +42,18 @@ type IdentityProviderResourceModel struct {
 	RegistrationPopulationId types.String `tfsdk:"registration_population_id"`
 	LoginButtonIcon          types.Object `tfsdk:"login_button_icon"`
 	Icon                     types.Object `tfsdk:"icon"`
-	Facebook                 types.List   `tfsdk:"facebook"`
-	Google                   types.List   `tfsdk:"google"`
-	LinkedIn                 types.List   `tfsdk:"linkedin"`
-	Yahoo                    types.List   `tfsdk:"yahoo"`
-	Amazon                   types.List   `tfsdk:"amazon"`
-	Twitter                  types.List   `tfsdk:"twitter"`
-	Apple                    types.List   `tfsdk:"apple"`
-	Paypal                   types.List   `tfsdk:"paypal"`
-	Microsoft                types.List   `tfsdk:"microsoft"`
-	Github                   types.List   `tfsdk:"github"`
-	OpenIDConnect            types.List   `tfsdk:"openid_connect"`
-	Saml                     types.List   `tfsdk:"saml"`
+	Facebook                 types.Object `tfsdk:"facebook"`
+	Google                   types.Object `tfsdk:"google"`
+	LinkedIn                 types.Object `tfsdk:"linkedin"`
+	Yahoo                    types.Object `tfsdk:"yahoo"`
+	Amazon                   types.Object `tfsdk:"amazon"`
+	Twitter                  types.Object `tfsdk:"twitter"`
+	Apple                    types.Object `tfsdk:"apple"`
+	Paypal                   types.Object `tfsdk:"paypal"`
+	Microsoft                types.Object `tfsdk:"microsoft"`
+	Github                   types.Object `tfsdk:"github"`
+	OpenIDConnect            types.Object `tfsdk:"openid_connect"`
+	Saml                     types.Object `tfsdk:"saml"`
 }
 
 type IdentityProviderClientIdClientSecretResourceModel struct {
@@ -357,12 +357,9 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 					},
 				},
 			},
-		},
-
-		Blocks: map[string]schema.Block{
 
 			// The providers
-			"facebook": identityProviderSchemaBlock(
+			"facebook": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Facebook social identity provider."),
 
 				map[string]schema.Attribute{
@@ -389,7 +386,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"google": identityProviderSchemaBlock(
+			"google": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Google social identity provider."),
 
 				identityProviderClientIdClientSecretAttributes("Google"),
@@ -397,7 +394,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"linkedin": identityProviderSchemaBlock(
+			"linkedin": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the LinkedIn social identity provider."),
 
 				identityProviderClientIdClientSecretAttributes("LinkedIn"),
@@ -405,7 +402,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"yahoo": identityProviderSchemaBlock(
+			"yahoo": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Yahoo social identity provider."),
 
 				identityProviderClientIdClientSecretAttributes("Yahoo"),
@@ -413,7 +410,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"amazon": identityProviderSchemaBlock(
+			"amazon": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Amazon social identity provider."),
 
 				identityProviderClientIdClientSecretAttributes("Amazon"),
@@ -421,7 +418,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"twitter": identityProviderSchemaBlock(
+			"twitter": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Twitter social identity provider."),
 
 				identityProviderClientIdClientSecretAttributes("Twitter"),
@@ -429,7 +426,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"apple": identityProviderSchemaBlock(
+			"apple": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Apple social identity provider."),
 
 				map[string]schema.Attribute{
@@ -474,7 +471,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"paypal": identityProviderSchemaBlock(
+			"paypal": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Paypal social identity provider."),
 
 				map[string]schema.Attribute{
@@ -511,7 +508,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"microsoft": identityProviderSchemaBlock(
+			"microsoft": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Microsoft social identity provider."),
 
 				identityProviderClientIdClientSecretAttributes("Microsoft"),
@@ -519,7 +516,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"github": identityProviderSchemaBlock(
+			"github": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to the Github social identity provider."),
 
 				identityProviderClientIdClientSecretAttributes("Github"),
@@ -527,7 +524,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"openid_connect": identityProviderSchemaBlock(
+			"openid_connect": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to an OpenID Connect compliant identity provider."),
 
 				map[string]schema.Attribute{
@@ -635,7 +632,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 				providerAttributeList,
 			),
 
-			"saml": identityProviderSchemaBlock(
+			"saml": identityProviderSchemaAttribute(
 				framework.SchemaAttributeDescriptionFromMarkdown("A single block that specifies options for connectivity to a SAML 2.0 compliant identity provider."),
 
 				map[string]schema.Attribute{
@@ -758,31 +755,29 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 	}
 }
 
-func identityProviderSchemaBlock(description framework.SchemaAttributeDescription, attributes map[string]schema.Attribute, exactlyOneOfBlockNames []string) schema.ListNestedBlock {
-	description = description.ExactlyOneOf(exactlyOneOfBlockNames).RequiresReplaceBlock()
+func identityProviderSchemaAttribute(description framework.SchemaAttributeDescription, attributes map[string]schema.Attribute, exactlyOneOfBlockNames []string) schema.SingleNestedAttribute {
+	description = description.ExactlyOneOf(exactlyOneOfBlockNames).RequiresReplaceNestedAttributes()
 
 	exactlyOneOfPaths := make([]path.Expression, len(exactlyOneOfBlockNames))
 	for i, blockName := range exactlyOneOfBlockNames {
 		exactlyOneOfPaths[i] = path.MatchRelative().AtParent().AtName(blockName)
 	}
 
-	return schema.ListNestedBlock{
+	return schema.SingleNestedAttribute{
 		Description:         description.Description,
 		MarkdownDescription: description.MarkdownDescription,
+		Optional:            true,
 
-		NestedObject: schema.NestedBlockObject{
-			Attributes: attributes,
-		},
+		Attributes: attributes,
 
-		Validators: []validator.List{
-			listvalidator.SizeAtMost(1),
-			listvalidator.ExactlyOneOf(
+		Validators: []validator.Object{
+			objectvalidator.ExactlyOneOf(
 				exactlyOneOfPaths...,
 			),
 		},
 
-		PlanModifiers: []planmodifier.List{
-			listplanmodifier.RequiresReplace(),
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.RequiresReplace(),
 		},
 	}
 }
@@ -1107,21 +1102,15 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 	processedCount := 0
 
 	if !p.Facebook.IsNull() && !p.Facebook.IsUnknown() {
-		var plan []IdentityProviderFacebookResourceModel
-		d := p.Facebook.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderFacebookResourceModel
+		d := p.Facebook.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `facebook` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderFacebook{
 			Enabled:         common.Enabled,
@@ -1133,29 +1122,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetAppId(planItem.AppId.ValueString())
-		idpData.SetAppSecret(planItem.AppSecret.ValueString())
+		idpData.SetAppId(plan.AppId.ValueString())
+		idpData.SetAppSecret(plan.AppSecret.ValueString())
 
 		data.IdentityProviderFacebook = &idpData
 		processedCount += 1
 	}
 
 	if !p.Google.IsNull() && !p.Google.IsUnknown() {
-		var plan []IdentityProviderGoogleResourceModel
-		d := p.Google.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderGoogleResourceModel
+		d := p.Google.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `google` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderClientIDClientSecret{
 			Enabled:         common.Enabled,
@@ -1167,29 +1150,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
 
 		data.IdentityProviderClientIDClientSecret = &idpData
 		processedCount += 1
 	}
 
 	if !p.LinkedIn.IsNull() && !p.LinkedIn.IsUnknown() {
-		var plan []IdentityProviderLinkedInResourceModel
-		d := p.LinkedIn.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderLinkedInResourceModel
+		d := p.LinkedIn.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `linkedin` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderClientIDClientSecret{
 			Enabled:         common.Enabled,
@@ -1201,29 +1178,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
 
 		data.IdentityProviderClientIDClientSecret = &idpData
 		processedCount += 1
 	}
 
 	if !p.Yahoo.IsNull() && !p.Yahoo.IsUnknown() {
-		var plan []IdentityProviderYahooResourceModel
-		d := p.Yahoo.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderYahooResourceModel
+		d := p.Yahoo.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `yahoo` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderClientIDClientSecret{
 			Enabled:         common.Enabled,
@@ -1235,29 +1206,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
 
 		data.IdentityProviderClientIDClientSecret = &idpData
 		processedCount += 1
 	}
 
 	if !p.Amazon.IsNull() && !p.Amazon.IsUnknown() {
-		var plan []IdentityProviderAmazonResourceModel
-		d := p.Amazon.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderAmazonResourceModel
+		d := p.Amazon.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `amazon` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderClientIDClientSecret{
 			Enabled:         common.Enabled,
@@ -1269,29 +1234,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
 
 		data.IdentityProviderClientIDClientSecret = &idpData
 		processedCount += 1
 	}
 
 	if !p.Twitter.IsNull() && !p.Twitter.IsUnknown() {
-		var plan []IdentityProviderTwitterResourceModel
-		d := p.Twitter.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderTwitterResourceModel
+		d := p.Twitter.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `twitter` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderClientIDClientSecret{
 			Enabled:         common.Enabled,
@@ -1303,29 +1262,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
 
 		data.IdentityProviderClientIDClientSecret = &idpData
 		processedCount += 1
 	}
 
 	if !p.Apple.IsNull() && !p.Apple.IsUnknown() {
-		var plan []IdentityProviderAppleResourceModel
-		d := p.Apple.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderAppleResourceModel
+		d := p.Apple.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `apple` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderApple{
 			Enabled:         common.Enabled,
@@ -1337,31 +1290,25 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecretSigningKey(planItem.ClientSecretSigningKey.ValueString())
-		idpData.SetKeyId(planItem.KeyId.ValueString())
-		idpData.SetTeamId(planItem.TeamId.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecretSigningKey(plan.ClientSecretSigningKey.ValueString())
+		idpData.SetKeyId(plan.KeyId.ValueString())
+		idpData.SetTeamId(plan.TeamId.ValueString())
 
 		data.IdentityProviderApple = &idpData
 		processedCount += 1
 	}
 
 	if !p.Paypal.IsNull() && !p.Paypal.IsUnknown() {
-		var plan []IdentityProviderPaypalResourceModel
-		d := p.Paypal.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderPaypalResourceModel
+		d := p.Paypal.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `paypal` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderPaypal{
 			Enabled:         common.Enabled,
@@ -1373,30 +1320,24 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
-		idpData.SetClientEnvironment(planItem.ClientEnvironment.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
+		idpData.SetClientEnvironment(plan.ClientEnvironment.ValueString())
 
 		data.IdentityProviderPaypal = &idpData
 		processedCount += 1
 	}
 
 	if !p.Microsoft.IsNull() && !p.Microsoft.IsUnknown() {
-		var plan []IdentityProviderMicrosoftResourceModel
-		d := p.Microsoft.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderMicrosoftResourceModel
+		d := p.Microsoft.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `microsoft` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderClientIDClientSecret{
 			Enabled:         common.Enabled,
@@ -1408,29 +1349,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
 
 		data.IdentityProviderClientIDClientSecret = &idpData
 		processedCount += 1
 	}
 
 	if !p.Github.IsNull() && !p.Github.IsUnknown() {
-		var plan []IdentityProviderGithubResourceModel
-		d := p.Github.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderGithubResourceModel
+		d := p.Github.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `github` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderClientIDClientSecret{
 			Enabled:         common.Enabled,
@@ -1442,29 +1377,23 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		idpData.SetClientId(planItem.ClientId.ValueString())
-		idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		idpData.SetClientId(plan.ClientId.ValueString())
+		idpData.SetClientSecret(plan.ClientSecret.ValueString())
 
 		data.IdentityProviderClientIDClientSecret = &idpData
 		processedCount += 1
 	}
 
 	if !p.OpenIDConnect.IsNull() && !p.OpenIDConnect.IsUnknown() {
-		var plan []IdentityProviderOIDCResourceModel
-		d := p.OpenIDConnect.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderOIDCResourceModel
+		d := p.OpenIDConnect.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `openid_connect` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderOIDC{
 			Enabled:         common.Enabled,
@@ -1476,33 +1405,33 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		if !planItem.AuthorizationEndpoint.IsNull() && !planItem.AuthorizationEndpoint.IsUnknown() {
-			idpData.SetAuthorizationEndpoint(planItem.AuthorizationEndpoint.ValueString())
+		if !plan.AuthorizationEndpoint.IsNull() && !plan.AuthorizationEndpoint.IsUnknown() {
+			idpData.SetAuthorizationEndpoint(plan.AuthorizationEndpoint.ValueString())
 		}
 
-		if !planItem.ClientId.IsNull() && !planItem.ClientId.IsUnknown() {
-			idpData.SetClientId(planItem.ClientId.ValueString())
+		if !plan.ClientId.IsNull() && !plan.ClientId.IsUnknown() {
+			idpData.SetClientId(plan.ClientId.ValueString())
 		}
 
-		if !planItem.ClientSecret.IsNull() && !planItem.ClientSecret.IsUnknown() {
-			idpData.SetClientSecret(planItem.ClientSecret.ValueString())
+		if !plan.ClientSecret.IsNull() && !plan.ClientSecret.IsUnknown() {
+			idpData.SetClientSecret(plan.ClientSecret.ValueString())
 		}
 
-		if !planItem.DiscoveryEndpoint.IsNull() && !planItem.DiscoveryEndpoint.IsUnknown() {
-			idpData.SetDiscoveryEndpoint(planItem.DiscoveryEndpoint.ValueString())
+		if !plan.DiscoveryEndpoint.IsNull() && !plan.DiscoveryEndpoint.IsUnknown() {
+			idpData.SetDiscoveryEndpoint(plan.DiscoveryEndpoint.ValueString())
 		}
 
-		if !planItem.Issuer.IsNull() && !planItem.Issuer.IsUnknown() {
-			idpData.SetIssuer(planItem.Issuer.ValueString())
+		if !plan.Issuer.IsNull() && !plan.Issuer.IsUnknown() {
+			idpData.SetIssuer(plan.Issuer.ValueString())
 		}
 
-		if !planItem.JwksEndpoint.IsNull() && !planItem.JwksEndpoint.IsUnknown() {
-			idpData.SetJwksEndpoint(planItem.JwksEndpoint.ValueString())
+		if !plan.JwksEndpoint.IsNull() && !plan.JwksEndpoint.IsUnknown() {
+			idpData.SetJwksEndpoint(plan.JwksEndpoint.ValueString())
 		}
 
-		if !planItem.Scopes.IsNull() && !planItem.Scopes.IsUnknown() {
+		if !plan.Scopes.IsNull() && !plan.Scopes.IsUnknown() {
 			var scopesPlan []string
-			diags.Append(planItem.Scopes.ElementsAs(ctx, &scopesPlan, false)...)
+			diags.Append(plan.Scopes.ElementsAs(ctx, &scopesPlan, false)...)
 			if diags.HasError() {
 				return nil, diags
 			}
@@ -1510,16 +1439,16 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			idpData.SetScopes(scopesPlan)
 		}
 
-		if !planItem.TokenEndpoint.IsNull() && !planItem.TokenEndpoint.IsUnknown() {
-			idpData.SetTokenEndpoint(planItem.TokenEndpoint.ValueString())
+		if !plan.TokenEndpoint.IsNull() && !plan.TokenEndpoint.IsUnknown() {
+			idpData.SetTokenEndpoint(plan.TokenEndpoint.ValueString())
 		}
 
-		if !planItem.TokenEndpointAuthMethod.IsNull() && !planItem.TokenEndpointAuthMethod.IsUnknown() {
-			idpData.SetTokenEndpointAuthMethod(management.EnumIdentityProviderOIDCTokenAuthMethod(planItem.TokenEndpointAuthMethod.ValueString()))
+		if !plan.TokenEndpointAuthMethod.IsNull() && !plan.TokenEndpointAuthMethod.IsUnknown() {
+			idpData.SetTokenEndpointAuthMethod(management.EnumIdentityProviderOIDCTokenAuthMethod(plan.TokenEndpointAuthMethod.ValueString()))
 		}
 
-		if !planItem.UserinfoEndpoint.IsNull() && !planItem.UserinfoEndpoint.IsUnknown() {
-			idpData.SetUserInfoEndpoint(planItem.UserinfoEndpoint.ValueString())
+		if !plan.UserinfoEndpoint.IsNull() && !plan.UserinfoEndpoint.IsUnknown() {
+			idpData.SetUserInfoEndpoint(plan.UserinfoEndpoint.ValueString())
 		}
 
 		data.IdentityProviderOIDC = &idpData
@@ -1527,21 +1456,15 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 	}
 
 	if !p.Saml.IsNull() && !p.Saml.IsUnknown() {
-		var plan []IdentityProviderSAMLResourceModel
-		d := p.Saml.ElementsAs(ctx, &plan, false)
+		var plan IdentityProviderSAMLResourceModel
+		d := p.Saml.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})
 		diags.Append(d...)
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		if len(plan) == 0 {
-			diags.AddError(
-				"Invalid configuration",
-				"The `saml` block is declared but has no configuration.  Please report this to the provider maintainers.",
-			)
-		}
-
-		planItem := plan[0]
 
 		idpData := management.IdentityProviderSAML{
 			Enabled:         common.Enabled,
@@ -1553,21 +1476,21 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			Icon:            common.Icon,
 		}
 
-		if !planItem.AuthenticationRequestSigned.IsNull() && !planItem.AuthenticationRequestSigned.IsUnknown() {
-			idpData.SetAuthnRequestSigned(planItem.AuthenticationRequestSigned.ValueBool())
+		if !plan.AuthenticationRequestSigned.IsNull() && !plan.AuthenticationRequestSigned.IsUnknown() {
+			idpData.SetAuthnRequestSigned(plan.AuthenticationRequestSigned.ValueBool())
 		}
 
-		if !planItem.IdpEntityId.IsNull() && !planItem.IdpEntityId.IsUnknown() {
-			idpData.SetIdpEntityId(planItem.IdpEntityId.ValueString())
+		if !plan.IdpEntityId.IsNull() && !plan.IdpEntityId.IsUnknown() {
+			idpData.SetIdpEntityId(plan.IdpEntityId.ValueString())
 		}
 
-		if !planItem.SpEntityId.IsNull() && !planItem.SpEntityId.IsUnknown() {
-			idpData.SetSpEntityId(planItem.SpEntityId.ValueString())
+		if !plan.SpEntityId.IsNull() && !plan.SpEntityId.IsUnknown() {
+			idpData.SetSpEntityId(plan.SpEntityId.ValueString())
 		}
 
-		if !planItem.IdpVerificationCertificateIds.IsNull() && !planItem.IdpVerificationCertificateIds.IsUnknown() {
+		if !plan.IdpVerificationCertificateIds.IsNull() && !plan.IdpVerificationCertificateIds.IsUnknown() {
 			var certificateIdsPlan []string
-			diags.Append(planItem.IdpVerificationCertificateIds.ElementsAs(ctx, &certificateIdsPlan, false)...)
+			diags.Append(plan.IdpVerificationCertificateIds.ElementsAs(ctx, &certificateIdsPlan, false)...)
 			if diags.HasError() {
 				return nil, diags
 			}
@@ -1581,34 +1504,34 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			idpData.SetIdpVerification(*idpVerifcation)
 		}
 
-		if !planItem.SpSigningKeyId.IsNull() && !planItem.SpSigningKeyId.IsUnknown() {
-			spSigningKey := management.NewIdentityProviderSAMLAllOfSpSigningKey(planItem.SpSigningKeyId.ValueString())
+		if !plan.SpSigningKeyId.IsNull() && !plan.SpSigningKeyId.IsUnknown() {
+			spSigningKey := management.NewIdentityProviderSAMLAllOfSpSigningKey(plan.SpSigningKeyId.ValueString())
 			spSigning := management.NewIdentityProviderSAMLAllOfSpSigning(*spSigningKey)
 			idpData.SetSpSigning(*spSigning)
 		}
 
-		if !planItem.SsoBinding.IsNull() && !planItem.SsoBinding.IsUnknown() {
-			idpData.SetSsoBinding(management.EnumIdentityProviderSAMLSSOBinding(planItem.SsoBinding.ValueString()))
+		if !plan.SsoBinding.IsNull() && !plan.SsoBinding.IsUnknown() {
+			idpData.SetSsoBinding(management.EnumIdentityProviderSAMLSSOBinding(plan.SsoBinding.ValueString()))
 		}
 
-		if !planItem.SsoEndpoint.IsNull() && !planItem.SsoEndpoint.IsUnknown() {
-			idpData.SetSsoEndpoint(planItem.SsoEndpoint.ValueString())
+		if !plan.SsoEndpoint.IsNull() && !plan.SsoEndpoint.IsUnknown() {
+			idpData.SetSsoEndpoint(plan.SsoEndpoint.ValueString())
 		}
 
-		if !planItem.SloBinding.IsNull() && !planItem.SloBinding.IsUnknown() {
-			idpData.SetSloBinding(management.EnumIdentityProviderSAMLSLOBinding(planItem.SloBinding.ValueString()))
+		if !plan.SloBinding.IsNull() && !plan.SloBinding.IsUnknown() {
+			idpData.SetSloBinding(management.EnumIdentityProviderSAMLSLOBinding(plan.SloBinding.ValueString()))
 		}
 
-		if !planItem.SloEndpoint.IsNull() && !planItem.SloEndpoint.IsUnknown() {
-			idpData.SetSloEndpoint(planItem.SloEndpoint.ValueString())
+		if !plan.SloEndpoint.IsNull() && !plan.SloEndpoint.IsUnknown() {
+			idpData.SetSloEndpoint(plan.SloEndpoint.ValueString())
 		}
 
-		if !planItem.SloResponseEndpoint.IsNull() && !planItem.SloResponseEndpoint.IsUnknown() {
-			idpData.SetSloResponseEndpoint(planItem.SloResponseEndpoint.ValueString())
+		if !plan.SloResponseEndpoint.IsNull() && !plan.SloResponseEndpoint.IsUnknown() {
+			idpData.SetSloResponseEndpoint(plan.SloResponseEndpoint.ValueString())
 		}
 
-		if !planItem.SloWindow.IsNull() && !planItem.SloWindow.IsUnknown() {
-			idpData.SetSloWindow(int32(planItem.SloWindow.ValueInt64()))
+		if !plan.SloWindow.IsNull() && !plan.SloWindow.IsUnknown() {
+			idpData.SetSloWindow(int32(plan.SloWindow.ValueInt64()))
 		}
 
 		data.IdentityProviderSAML = &idpData
@@ -1726,13 +1649,11 @@ func (p *IdentityProviderResourceModel) toState(apiObject *management.IdentityPr
 	return diags
 }
 
-func identityProviderFacebookToTF(idpApiObject *management.IdentityProviderFacebook) (types.List, diag.Diagnostics) {
+func identityProviderFacebookToTF(idpApiObject *management.IdentityProviderFacebook) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	tfObjType := types.ObjectType{AttrTypes: identityProviderFacebookTFObjectTypes}
-
 	if idpApiObject == nil || idpApiObject.GetType() != management.ENUMIDENTITYPROVIDEREXT_FACEBOOK {
-		return types.ListNull(tfObjType), diags
+		return types.ObjectNull(identityProviderFacebookTFObjectTypes), diags
 	}
 
 	attributesMap := map[string]attr.Value{
@@ -1740,22 +1661,17 @@ func identityProviderFacebookToTF(idpApiObject *management.IdentityProviderFaceb
 		"app_secret": framework.StringOkToTF(idpApiObject.GetAppSecretOk()),
 	}
 
-	flattenedObj, d := types.ObjectValue(identityProviderFacebookTFObjectTypes, attributesMap)
-	diags.Append(d...)
-
-	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	returnVar, d := types.ObjectValue(identityProviderFacebookTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags
 }
 
-func identityProviderClientIDClientSecretToTF(idpApiObject *management.IdentityProviderClientIDClientSecret, idpType management.EnumIdentityProviderExt) (types.List, diag.Diagnostics) {
+func identityProviderClientIDClientSecretToTF(idpApiObject *management.IdentityProviderClientIDClientSecret, idpType management.EnumIdentityProviderExt) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	tfObjType := types.ObjectType{AttrTypes: identityProviderClientIDClientSecretTFObjectTypes}
-
 	if idpApiObject == nil || idpApiObject.GetType() != idpType {
-		return types.ListNull(tfObjType), diags
+		return types.ObjectNull(identityProviderClientIDClientSecretTFObjectTypes), diags
 	}
 
 	attributesMap := map[string]attr.Value{
@@ -1763,22 +1679,17 @@ func identityProviderClientIDClientSecretToTF(idpApiObject *management.IdentityP
 		"client_secret": framework.StringOkToTF(idpApiObject.GetClientSecretOk()),
 	}
 
-	flattenedObj, d := types.ObjectValue(identityProviderClientIDClientSecretTFObjectTypes, attributesMap)
-	diags.Append(d...)
-
-	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	returnVar, d := types.ObjectValue(identityProviderClientIDClientSecretTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags
 }
 
-func identityProviderAppleToTF(idpApiObject *management.IdentityProviderApple) (types.List, diag.Diagnostics) {
+func identityProviderAppleToTF(idpApiObject *management.IdentityProviderApple) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	tfObjType := types.ObjectType{AttrTypes: identityProviderAppleTFObjectTypes}
-
 	if idpApiObject == nil || idpApiObject.GetType() != management.ENUMIDENTITYPROVIDEREXT_APPLE {
-		return types.ListNull(tfObjType), diags
+		return types.ObjectNull(identityProviderAppleTFObjectTypes), diags
 	}
 
 	attributesMap := map[string]attr.Value{
@@ -1788,22 +1699,17 @@ func identityProviderAppleToTF(idpApiObject *management.IdentityProviderApple) (
 		"client_secret_signing_key": framework.StringOkToTF(idpApiObject.GetClientSecretSigningKeyOk()),
 	}
 
-	flattenedObj, d := types.ObjectValue(identityProviderAppleTFObjectTypes, attributesMap)
-	diags.Append(d...)
-
-	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	returnVar, d := types.ObjectValue(identityProviderAppleTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags
 }
 
-func identityProviderPaypalToTF(idpApiObject *management.IdentityProviderPaypal) (types.List, diag.Diagnostics) {
+func identityProviderPaypalToTF(idpApiObject *management.IdentityProviderPaypal) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	tfObjType := types.ObjectType{AttrTypes: identityProviderPaypalTFObjectTypes}
-
 	if idpApiObject == nil || idpApiObject.GetType() != management.ENUMIDENTITYPROVIDEREXT_PAYPAL {
-		return types.ListNull(tfObjType), diags
+		return types.ObjectNull(identityProviderPaypalTFObjectTypes), diags
 	}
 
 	attributesMap := map[string]attr.Value{
@@ -1812,22 +1718,17 @@ func identityProviderPaypalToTF(idpApiObject *management.IdentityProviderPaypal)
 		"client_environment": framework.StringOkToTF(idpApiObject.GetClientEnvironmentOk()),
 	}
 
-	flattenedObj, d := types.ObjectValue(identityProviderPaypalTFObjectTypes, attributesMap)
-	diags.Append(d...)
-
-	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	returnVar, d := types.ObjectValue(identityProviderPaypalTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags
 }
 
-func identityProviderOIDCToTF(idpApiObject *management.IdentityProviderOIDC) (types.List, diag.Diagnostics) {
+func identityProviderOIDCToTF(idpApiObject *management.IdentityProviderOIDC) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	tfObjType := types.ObjectType{AttrTypes: identityProviderOIDCTFObjectTypes}
-
 	if idpApiObject == nil || idpApiObject.GetType() != management.ENUMIDENTITYPROVIDEREXT_OPENID_CONNECT {
-		return types.ListNull(tfObjType), diags
+		return types.ObjectNull(identityProviderOIDCTFObjectTypes), diags
 	}
 
 	attributesMap := map[string]attr.Value{
@@ -1843,22 +1744,17 @@ func identityProviderOIDCToTF(idpApiObject *management.IdentityProviderOIDC) (ty
 		"userinfo_endpoint":          framework.StringOkToTF(idpApiObject.GetUserInfoEndpointOk()),
 	}
 
-	flattenedObj, d := types.ObjectValue(identityProviderOIDCTFObjectTypes, attributesMap)
-	diags.Append(d...)
-
-	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	returnVar, d := types.ObjectValue(identityProviderOIDCTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags
 }
 
-func identityProviderSAMLToTF(idpApiObject *management.IdentityProviderSAML) (types.List, diag.Diagnostics) {
+func identityProviderSAMLToTF(idpApiObject *management.IdentityProviderSAML) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	tfObjType := types.ObjectType{AttrTypes: identityProviderSAMLTFObjectTypes}
-
 	if idpApiObject == nil || idpApiObject.GetType() != management.ENUMIDENTITYPROVIDEREXT_SAML {
-		return types.ListNull(tfObjType), diags
+		return types.ObjectNull(identityProviderSAMLTFObjectTypes), diags
 	}
 
 	attributesMap := map[string]attr.Value{
@@ -1892,10 +1788,7 @@ func identityProviderSAMLToTF(idpApiObject *management.IdentityProviderSAML) (ty
 		}
 	}
 
-	flattenedObj, d := types.ObjectValue(identityProviderSAMLTFObjectTypes, attributesMap)
-	diags.Append(d...)
-
-	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	returnVar, d := types.ObjectValue(identityProviderSAMLTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags

--- a/internal/service/sso/resource_identity_provider_attribute_test.go
+++ b/internal/service/sso/resource_identity_provider_attribute_test.go
@@ -368,7 +368,7 @@ resource "pingone_identity_provider" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
   name           = "%[4]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -392,7 +392,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -416,7 +416,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -439,7 +439,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -463,7 +463,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -487,7 +487,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -510,7 +510,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -533,7 +533,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -556,7 +556,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }

--- a/internal/service/sso/resource_identity_provider_test.go
+++ b/internal/service/sso/resource_identity_provider_test.go
@@ -142,8 +142,8 @@ func TestAccIdentityProvider_Change(t *testing.T) {
 			resource.TestCheckNoResourceAttr(resourceFullName, "description"),
 			resource.TestCheckResourceAttr(resourceFullName, "enabled", "false"),
 			resource.TestCheckNoResourceAttr(resourceFullName, "registration_population_id"),
-			resource.TestCheckResourceAttr(resourceFullName, "login_button_icon.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "icon.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "login_button_icon.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "icon.%", "0"),
 		),
 	}
 
@@ -196,41 +196,39 @@ func TestAccIdentityProvider_Facebook(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Facebook1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.0.app_id", "dummyappid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.0.app_secret", "dummyappsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "facebook.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/facebook$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.app_id", "dummyappid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.app_secret", "dummyappsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "facebook.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/facebook$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Facebook2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.0.app_id", "dummyappid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.0.app_secret", "dummyappsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "facebook.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/facebook$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.app_id", "dummyappid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.app_secret", "dummyappsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "facebook.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/facebook$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -273,41 +271,39 @@ func TestAccIdentityProvider_Google(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Google1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.0.client_secret", "dummyclientsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "google.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/google$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.client_secret", "dummyclientsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "google.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/google$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Google2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "google.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/google$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "google.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/google$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -350,41 +346,39 @@ func TestAccIdentityProvider_LinkedIn(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_LinkedIn1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.0.client_secret", "dummyclientsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "linkedin.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/linkedin$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.client_secret", "dummyclientsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "linkedin.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/linkedin$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_LinkedIn2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "linkedin.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/linkedin$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "linkedin.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/linkedin$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -427,41 +421,39 @@ func TestAccIdentityProvider_Yahoo(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Yahoo1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.0.client_secret", "dummyclientsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "yahoo.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/yahoo$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.client_secret", "dummyclientsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "yahoo.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/yahoo$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Yahoo2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "yahoo.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/yahoo$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "yahoo.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/yahoo$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -504,41 +496,39 @@ func TestAccIdentityProvider_Amazon(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Amazon1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.0.client_secret", "dummyclientsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "amazon.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/amazon$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.client_secret", "dummyclientsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "amazon.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/amazon$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Amazon2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "amazon.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/amazon$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "amazon.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/amazon$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -581,41 +571,39 @@ func TestAccIdentityProvider_Twitter(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Twitter1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.0.client_secret", "dummyclientsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "twitter.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/twitter$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.client_secret", "dummyclientsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "twitter.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/twitter$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Twitter2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "twitter.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/twitter$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "twitter.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/twitter$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -658,45 +646,43 @@ func TestAccIdentityProvider_Apple(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Apple1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.client_secret_signing_key", "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey1-----END PRIVATE KEY-----"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.key_id", "dummykeyi1"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.team_id", "dummyteam1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "apple.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/apple$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.client_secret_signing_key", "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey1-----END PRIVATE KEY-----"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.key_id", "dummykeyi1"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.team_id", "dummyteam1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "apple.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/apple$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Apple2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.client_secret_signing_key", "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey2-----END PRIVATE KEY-----"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.key_id", "dummykeyi2"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.team_id", "dummyteam2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "apple.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/apple$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.client_secret_signing_key", "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey2-----END PRIVATE KEY-----"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.key_id", "dummykeyi2"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.team_id", "dummyteam2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "apple.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/apple$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -739,43 +725,41 @@ func TestAccIdentityProvider_Paypal(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Paypal1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.0.client_secret", "dummyclientsecret1"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.0.client_environment", "sandbox"),
-					// resource.TestMatchResourceAttr(resourceFullName, "paypal.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/paypal$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.client_secret", "dummyclientsecret1"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.client_environment", "sandbox"),
+					// resource.TestMatchResourceAttr(resourceFullName, "paypal.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/paypal$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Paypal2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.0.client_secret", "dummyclientsecret2"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.0.client_environment", "live"),
-					// resource.TestMatchResourceAttr(resourceFullName, "paypal.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/paypal$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.client_secret", "dummyclientsecret2"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.client_environment", "live"),
+					// resource.TestMatchResourceAttr(resourceFullName, "paypal.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/paypal$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -818,41 +802,39 @@ func TestAccIdentityProvider_Microsoft(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Microsoft1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.0.client_secret", "dummyclientsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "microsoft.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/microsoft$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.client_secret", "dummyclientsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "microsoft.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/microsoft$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Microsoft2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "microsoft.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/microsoft$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "microsoft.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/microsoft$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -895,41 +877,39 @@ func TestAccIdentityProvider_Github(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Github1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.0.client_secret", "dummyclientsecret1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "github.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/github$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.client_secret", "dummyclientsecret1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "github.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/github$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Github2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "github.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/github$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "github.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/github$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			// Test importing the resource
@@ -970,62 +950,60 @@ func TestAccIdentityProvider_OIDC(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "login_button_icon.href", regexp.MustCompile(`^https:\/\/uploads\.pingone\.((eu)|(com)|(asia)|(ca))\/environments\/[a-zA-Z0-9-]*\/images\/[a-zA-Z0-9-]*_[a-zA-Z0-9-]*_original\.png$`)),
 			resource.TestMatchResourceAttr(resourceFullName, "icon.id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "icon.href", regexp.MustCompile(`^https:\/\/uploads\.pingone\.((eu)|(com)|(asia)|(ca))\/environments\/[a-zA-Z0-9-]*\/images\/[a-zA-Z0-9-]*_[a-zA-Z0-9-]*_original\.png$`)),
-			resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.authorization_endpoint", "https://www.pingidentity.com/authz"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.client_id", "dummyclientid1"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.client_secret", "dummyclientsecret1"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.discovery_endpoint", "https://www.pingidentity.com/discovery"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.issuer", "https://www.pingidentity.com/issuer"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.jwks_endpoint", "https://www.pingidentity.com/jwks"),
-			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.0.scopes.*", "openid"),
-			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.0.scopes.*", "scope1"),
-			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.0.scopes.*", "scope2"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.token_endpoint", "https://www.pingidentity.com/token"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.token_endpoint_auth_method", "CLIENT_SECRET_POST"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.userinfo_endpoint", "https://www.pingidentity.com/userinfo"),
-			// resource.TestMatchResourceAttr(resourceFullName, "openid_connect.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/openid_connect$`)),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.authorization_endpoint", "https://www.pingidentity.com/authz"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.client_id", "dummyclientid1"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.client_secret", "dummyclientsecret1"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.discovery_endpoint", "https://www.pingidentity.com/discovery"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.issuer", "https://www.pingidentity.com/issuer"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.jwks_endpoint", "https://www.pingidentity.com/jwks"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "openid"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "scope1"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "scope2"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.token_endpoint", "https://www.pingidentity.com/token"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.token_endpoint_auth_method", "CLIENT_SECRET_POST"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.userinfo_endpoint", "https://www.pingidentity.com/userinfo"),
+			// resource.TestMatchResourceAttr(resourceFullName, "openid_connect.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/openid_connect$`)),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 		),
 	}
 
 	minimalStep := resource.TestStep{
 		Config: testAccIdentityProviderConfig_OIDCMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.authorization_endpoint", "https://www.pingidentity.com/authz2"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.client_id", "dummyclientid2"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.client_secret", "dummyclientsecret2"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "openid_connect.0.discovery_endpoint"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.issuer", "https://www.pingidentity.com/issuer2"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.jwks_endpoint", "https://www.pingidentity.com/jwks2"),
-			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.0.scopes.*", "openid"),
-			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.0.scopes.*", "scope3"),
-			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.0.scopes.*", "scope4"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.token_endpoint", "https://www.pingidentity.com/token2"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.0.token_endpoint_auth_method", "CLIENT_SECRET_BASIC"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "openid_connect.0.userinfo_endpoint"),
-			// resource.TestMatchResourceAttr(resourceFullName, "openid_connect.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/openid_connect$`)),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.authorization_endpoint", "https://www.pingidentity.com/authz2"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.client_id", "dummyclientid2"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.client_secret", "dummyclientsecret2"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "openid_connect.discovery_endpoint"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.issuer", "https://www.pingidentity.com/issuer2"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.jwks_endpoint", "https://www.pingidentity.com/jwks2"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "openid"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "scope3"),
+			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "scope4"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.token_endpoint", "https://www.pingidentity.com/token2"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.token_endpoint_auth_method", "CLIENT_SECRET_BASIC"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "openid_connect.userinfo_endpoint"),
+			// resource.TestMatchResourceAttr(resourceFullName, "openid_connect.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/openid_connect$`)),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 		),
 	}
 
@@ -1087,59 +1065,57 @@ func TestAccIdentityProvider_SAML(t *testing.T) {
 	fullStep := resource.TestStep{
 		Config: testAccIdentityProviderConfig_SAMLFull(resourceName, name, pem_cert),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.authentication_request_signed", "true"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.idp_entity_id", fmt.Sprintf("idp:%s", name)),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.sp_entity_id", fmt.Sprintf("sp:%s", name)),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.idp_verification_certificate_ids.#", "1"),
-			resource.TestMatchResourceAttr(resourceFullName, "saml.0.idp_verification_certificate_ids.0", verify.P1ResourceIDRegexpFullString),
-			resource.TestMatchResourceAttr(resourceFullName, "saml.0.sp_signing_key_id", verify.P1ResourceIDRegexpFullString),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.sso_binding", "HTTP_POST"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.sso_endpoint", "https://www.pingidentity.com/sso"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_binding", "HTTP_REDIRECT"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_endpoint", "https://dummy-slo-endpoint.pingidentity.com"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_response_endpoint", "https://dummy-slo-response-endpoint.pingidentity.com"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_window", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.authentication_request_signed", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_entity_id", fmt.Sprintf("idp:%s", name)),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sp_entity_id", fmt.Sprintf("sp:%s", name)),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_verification_certificate_ids.#", "1"),
+			resource.TestMatchResourceAttr(resourceFullName, "saml.idp_verification_certificate_ids.0", verify.P1ResourceIDRegexpFullString),
+			resource.TestMatchResourceAttr(resourceFullName, "saml.sp_signing_key_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_binding", "HTTP_POST"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_endpoint", "https://www.pingidentity.com/sso"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_binding", "HTTP_REDIRECT"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_endpoint", "https://dummy-slo-endpoint.pingidentity.com"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_response_endpoint", "https://dummy-slo-response-endpoint.pingidentity.com"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_window", "1"),
 		),
 	}
 
 	minimalStep := resource.TestStep{
 		Config: testAccIdentityProviderConfig_SAMLMinimal(resourceName, name, pem_cert),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.authentication_request_signed", "false"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.idp_entity_id", fmt.Sprintf("idp:%s-1", name)),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.sp_entity_id", fmt.Sprintf("sp:%s-1", name)),
-			resource.TestMatchResourceAttr(resourceFullName, "saml.0.idp_verification_certificate_ids.0", verify.P1ResourceIDRegexpFullString),
-			resource.TestCheckNoResourceAttr(resourceFullName, "saml.0.sp_signing_key_id"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.sso_binding", "HTTP_REDIRECT"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.sso_endpoint", "https://www.pingidentity.com/sso1"),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.0.slo_binding", "HTTP_POST"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "saml.0.slo_endpoint"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "saml.0.slo_response_endpoint"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "saml.0.slo_window"),
+			resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.authentication_request_signed", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_entity_id", fmt.Sprintf("idp:%s-1", name)),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sp_entity_id", fmt.Sprintf("sp:%s-1", name)),
+			resource.TestMatchResourceAttr(resourceFullName, "saml.idp_verification_certificate_ids.0", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckNoResourceAttr(resourceFullName, "saml.sp_signing_key_id"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_binding", "HTTP_REDIRECT"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_endpoint", "https://www.pingidentity.com/sso1"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_binding", "HTTP_POST"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "saml.slo_endpoint"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "saml.slo_response_endpoint"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "saml.slo_window"),
 		),
 	}
 
@@ -1209,43 +1185,41 @@ func TestAccIdentityProvider_ChangeProvider(t *testing.T) {
 			{
 				Config: testAccIdentityProviderConfig_Apple1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.client_id", "dummyclientid1"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.client_secret_signing_key", "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey1-----END PRIVATE KEY-----"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.key_id", "dummykeyi1"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.0.team_id", "dummyteam1"),
-					// resource.TestMatchResourceAttr(resourceFullName, "apple.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/apple$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.client_id", "dummyclientid1"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.client_secret_signing_key", "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey1-----END PRIVATE KEY-----"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.key_id", "dummykeyi1"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.team_id", "dummyteam1"),
+					// resource.TestMatchResourceAttr(resourceFullName, "apple.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/apple$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityProviderConfig_Github2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "facebook.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "google.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "linkedin.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "yahoo.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "amazon.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "twitter.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "apple.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "paypal.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "microsoft.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.0.client_id", "dummyclientid2"),
-					resource.TestCheckResourceAttr(resourceFullName, "github.0.client_secret", "dummyclientsecret2"),
-					// resource.TestMatchResourceAttr(resourceFullName, "github.0.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/github$`)),
-					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "saml.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "facebook.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "google.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "linkedin.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "yahoo.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "amazon.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "twitter.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "apple.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "paypal.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "microsoft.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.client_id", "dummyclientid2"),
+					resource.TestCheckResourceAttr(resourceFullName, "github.client_secret", "dummyclientsecret2"),
+					// resource.TestMatchResourceAttr(resourceFullName, "github.callback_url", regexp.MustCompile(`^https:\/\/auth\.pingone\.(?:eu|com|asia|ca)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/rp\/callback\/github$`)),
+					resource.TestCheckResourceAttr(resourceFullName, "openid_connect.%", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "saml.%", "0"),
 				),
 			},
 		},
@@ -1302,7 +1276,7 @@ resource "pingone_identity_provider" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
   name           = "%[4]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -1343,7 +1317,7 @@ resource "pingone_identity_provider" "%[2]s" {
     href = pingone_image.%[2]s.uploaded_image.href
   }
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -1358,7 +1332,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -1373,7 +1347,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  facebook {
+  facebook = {
     app_id     = "dummyappid1"
     app_secret = "dummyappsecret1"
   }
@@ -1388,7 +1362,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  facebook {
+  facebook = {
     app_id     = "dummyappid2"
     app_secret = "dummyappsecret2"
   }
@@ -1403,7 +1377,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -1418,7 +1392,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  google {
+  google = {
     client_id     = "dummyclientid2"
     client_secret = "dummyclientsecret2"
   }
@@ -1433,7 +1407,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  linkedin {
+  linkedin = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -1448,7 +1422,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  linkedin {
+  linkedin = {
     client_id     = "dummyclientid2"
     client_secret = "dummyclientsecret2"
   }
@@ -1463,7 +1437,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  yahoo {
+  yahoo = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -1478,7 +1452,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  yahoo {
+  yahoo = {
     client_id     = "dummyclientid2"
     client_secret = "dummyclientsecret2"
   }
@@ -1493,7 +1467,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  amazon {
+  amazon = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -1508,7 +1482,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  amazon {
+  amazon = {
     client_id     = "dummyclientid2"
     client_secret = "dummyclientsecret2"
   }
@@ -1523,7 +1497,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  twitter {
+  twitter = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -1538,7 +1512,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  twitter {
+  twitter = {
     client_id     = "dummyclientid2"
     client_secret = "dummyclientsecret2"
   }
@@ -1553,7 +1527,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  apple {
+  apple = {
     client_id                 = "dummyclientid1"
     client_secret_signing_key = "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey1-----END PRIVATE KEY-----"
     key_id                    = "dummykeyi1"
@@ -1570,7 +1544,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  apple {
+  apple = {
     client_id                 = "dummyclientid2"
     client_secret_signing_key = "-----BEGIN PRIVATE KEY-----dummyclientsecretsigningkey2-----END PRIVATE KEY-----"
     key_id                    = "dummykeyi2"
@@ -1587,7 +1561,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  paypal {
+  paypal = {
     client_id          = "dummyclientid1"
     client_secret      = "dummyclientsecret1"
     client_environment = "sandbox"
@@ -1603,7 +1577,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  paypal {
+  paypal = {
     client_id          = "dummyclientid2"
     client_secret      = "dummyclientsecret2"
     client_environment = "live"
@@ -1619,7 +1593,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  microsoft {
+  microsoft = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -1634,7 +1608,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  microsoft {
+  microsoft = {
     client_id     = "dummyclientid2"
     client_secret = "dummyclientsecret2"
   }
@@ -1649,7 +1623,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  github {
+  github = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -1664,7 +1638,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  github {
+  github = {
     client_id     = "dummyclientid2"
     client_secret = "dummyclientsecret2"
   }
@@ -1696,7 +1670,7 @@ resource "pingone_identity_provider" "%[2]s" {
     href = pingone_image.%[2]s.uploaded_image.href
   }
 
-  openid_connect {
+  openid_connect = {
     authorization_endpoint     = "https://www.pingidentity.com/authz"
     client_id                  = "dummyclientid1"
     client_secret              = "dummyclientsecret1"
@@ -1719,7 +1693,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  openid_connect {
+  openid_connect = {
     authorization_endpoint = "https://www.pingidentity.com/authz2"
     client_id              = "dummyclientid2"
     client_secret          = "dummyclientsecret2"
@@ -1762,7 +1736,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  saml {
+  saml = {
     authentication_request_signed    = true
     idp_entity_id                    = "idp:%[3]s"
     sp_entity_id                     = "sp:%[3]s"
@@ -1797,7 +1771,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s1"
 
-  saml {
+  saml = {
     idp_entity_id                    = "idp:%[3]s-1"
     sp_entity_id                     = "sp:%[3]s-1"
     idp_verification_certificate_ids = [pingone_certificate.%[2]s.id]

--- a/internal/service/sso/resource_sign_on_policy_action_test.go
+++ b/internal/service/sso/resource_sign_on_policy_action_test.go
@@ -1741,7 +1741,7 @@ resource "pingone_identity_provider" "%[2]s-1" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-1"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -1751,7 +1751,7 @@ resource "pingone_identity_provider" "%[2]s-2" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-2"
 
-  facebook {
+  facebook = {
     app_id     = "testclientid"
     app_secret = "testclientsecret"
   }
@@ -1794,7 +1794,7 @@ resource "pingone_identity_provider" "%[2]s-1" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-1"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -1804,7 +1804,7 @@ resource "pingone_identity_provider" "%[2]s-2" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-2"
 
-  facebook {
+  facebook = {
     app_id     = "testclientid"
     app_secret = "testclientsecret"
   }
@@ -2087,7 +2087,7 @@ resource "pingone_identity_provider" "%[2]s-1" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-1"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -2097,7 +2097,7 @@ resource "pingone_identity_provider" "%[2]s-2" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-2"
 
-  facebook {
+  facebook = {
     app_id     = "testclientid"
     app_secret = "testclientsecret"
   }
@@ -2147,7 +2147,7 @@ resource "pingone_identity_provider" "%[2]s-1" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-1"
 
-  google {
+  google = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
   }
@@ -2157,7 +2157,7 @@ resource "pingone_identity_provider" "%[2]s-2" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s-2"
 
-  facebook {
+  facebook = {
     app_id     = "testclientid"
     app_secret = "testclientsecret"
   }
@@ -2238,7 +2238,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  openid_connect {
+  openid_connect = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
 
@@ -2284,7 +2284,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  openid_connect {
+  openid_connect = {
     client_id     = "testclientid"
     client_secret = "testclientsecret"
 

--- a/internal/service/sso/resource_user_test.go
+++ b/internal/service/sso/resource_user_test.go
@@ -569,7 +569,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  linkedin {
+  linkedin = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -656,7 +656,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  linkedin {
+  linkedin = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -732,7 +732,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  linkedin {
+  linkedin = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }
@@ -761,7 +761,7 @@ resource "pingone_identity_provider" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
-  linkedin {
+  linkedin = {
     client_id     = "dummyclientid1"
     client_secret = "dummyclientsecret1"
   }

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -185,6 +185,160 @@ This parameter block is no longer needed and has been removed.
 
 ## Resource: pingone_identity_provider
 
+### `amazon` parameter data type change
+
+The `amazon` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  amazon {
+    client_id     = var.amazon_client_id
+    client_secret = var.amazon_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  amazon = {
+    client_id     = var.amazon_client_id
+    client_secret = var.amazon_client_secret
+  }
+}
+```
+
+### `apple` parameter data type change
+
+The `apple` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  apple {
+    client_id                 = var.apple_client_id
+    client_secret_signing_key = var.apple_client_secret_signing_key
+    key_id                    = var.apple_key_id
+    team_id                   = var.apple_team_id
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  apple = {
+    client_id                 = var.apple_client_id
+    client_secret_signing_key = var.apple_client_secret_signing_key
+    key_id                    = var.apple_key_id
+    team_id                   = var.apple_team_id
+  }
+}
+```
+
+### `facebook` parameter data type change
+
+The `facebook` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  facebook {
+    app_id     = var.facebook_app_id
+    app_secret = var.facebook_app_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  facebook = {
+    app_id     = var.facebook_app_id
+    app_secret = var.facebook_app_secret
+  }
+}
+```
+
+### `github` parameter data type change
+
+The `github` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  github {
+    client_id     = var.github_client_id
+    client_secret = var.github_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  github = {
+    client_id     = var.github_client_id
+    client_secret = var.github_client_secret
+  }
+}
+```
+
+### `google` parameter data type change
+
+The `google` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  google {
+    client_id     = var.google_client_id
+    client_secret = var.google_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  google = {
+    client_id     = var.google_client_id
+    client_secret = var.google_client_secret
+  }
+}
+```
+
 ### `icon` parameter data type change
 
 The `icon` parameter is now a nested object type and no longer a block type.
@@ -215,6 +369,36 @@ resource "pingone_identity_provider" "my_awesome_identity_provider" {
 }
 ```
 
+### `linkedin` parameter data type change
+
+The `linkedin` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  linkedin {
+    client_id     = var.linkedin_client_id
+    client_secret = var.linkedin_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  linkedin = {
+    client_id     = var.linkedin_client_id
+    client_secret = var.linkedin_client_secret
+  }
+}
+```
+
 ### `login_button_icon` parameter data type change
 
 The `login_button_icon` parameter is now a nested object type and no longer a block type.
@@ -241,6 +425,204 @@ resource "pingone_identity_provider" "my_awesome_identity_provider" {
   login_button_icon = {
     id   = pingone_image.identity_provider_login_button_icon.id
     href = pingone_image.identity_provider_login_button_icon.uploaded_image.href
+  }
+}
+```
+
+### `microsoft` parameter data type change
+
+The `microsoft` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  microsoft {
+    client_id     = var.microsoft_client_id
+    client_secret = var.microsoft_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  microsoft = {
+    client_id     = var.microsoft_client_id
+    client_secret = var.microsoft_client_secret
+  }
+}
+```
+
+### `openid_connect` parameter data type change
+
+The `openid_connect` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  openid_connect {
+    authorization_endpoint = var.openid_connect_idp_authorization_endpoint
+    client_id              = var.openid_connect_idp_client_id
+    client_secret          = var.openid_connect_idp_client_secret
+    issuer                 = var.openid_connect_idp_issuer
+    jwks_endpoint          = var.openid_connect_idp_jwks_endpoint
+    scopes                 = var.openid_connect_idp_scopes
+    token_endpoint         = var.openid_connect_idp_token_endpoint
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  openid_connect = {
+    authorization_endpoint = var.openid_connect_idp_authorization_endpoint
+    client_id              = var.openid_connect_idp_client_id
+    client_secret          = var.openid_connect_idp_client_secret
+    issuer                 = var.openid_connect_idp_issuer
+    jwks_endpoint          = var.openid_connect_idp_jwks_endpoint
+    scopes                 = var.openid_connect_idp_scopes
+    token_endpoint         = var.openid_connect_idp_token_endpoint
+  }
+}
+```
+
+### `paypal` parameter data type change
+
+The `paypal` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  paypal {
+    client_environment     = var.paypal_client_environment
+    client_id              = var.paypal_client_id
+    client_secret          = var.paypal_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  paypal = {
+    client_environment     = var.paypal_client_environment
+    client_id              = var.paypal_client_id
+    client_secret          = var.paypal_client_secret
+  }
+}
+```
+
+### `saml` parameter data type change
+
+The `saml` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml {
+    idp_entity_id                    = var.saml_idp_entity_id
+    idp_verification_certificate_ids = var.saml_idp_verification_certificate_ids 
+    sp_entity_id                     = var.saml_idp_sp_entity_id
+    sso_binding                      = var.saml_idp_sso_binding
+    sso_endpoint                     = var.saml_idp_sso_endpoint
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml = {
+    idp_entity_id                    = var.saml_idp_entity_id
+    idp_verification_certificate_ids = var.saml_idp_verification_certificate_ids 
+    sp_entity_id                     = var.saml_idp_sp_entity_id
+    sso_binding                      = var.saml_idp_sso_binding
+    sso_endpoint                     = var.saml_idp_sso_endpoint
+  }
+}
+```
+
+### `twitter` parameter data type change
+
+The `twitter` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  twitter {
+    client_id     = var.twitter_client_id
+    client_secret = var.twitter_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  twitter = {
+    client_id     = var.twitter_client_id
+    client_secret = var.twitter_client_secret
+  }
+}
+```
+
+### `yahoo` parameter data type change
+
+The `yahoo` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  yahoo {
+    client_id     = var.yahoo_client_id
+    client_secret = var.yahoo_client_secret
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  yahoo = {
+    client_id     = var.yahoo_client_id
+    client_secret = var.yahoo_client_secret
   }
 }
 ```


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_identity_provider`: Changed block data types

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccIdentityProvider_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccIdentityProvider_RemovalDrift
=== PAUSE TestAccIdentityProvider_RemovalDrift
=== RUN   TestAccIdentityProvider_NewEnv
=== PAUSE TestAccIdentityProvider_NewEnv
=== RUN   TestAccIdentityProvider_Change
=== PAUSE TestAccIdentityProvider_Change
=== RUN   TestAccIdentityProvider_Facebook
=== PAUSE TestAccIdentityProvider_Facebook
=== RUN   TestAccIdentityProvider_Google
=== PAUSE TestAccIdentityProvider_Google
=== RUN   TestAccIdentityProvider_LinkedIn
=== PAUSE TestAccIdentityProvider_LinkedIn
=== RUN   TestAccIdentityProvider_Yahoo
=== PAUSE TestAccIdentityProvider_Yahoo
=== RUN   TestAccIdentityProvider_Amazon
=== PAUSE TestAccIdentityProvider_Amazon
=== RUN   TestAccIdentityProvider_Twitter
=== PAUSE TestAccIdentityProvider_Twitter
=== RUN   TestAccIdentityProvider_Apple
=== PAUSE TestAccIdentityProvider_Apple
=== RUN   TestAccIdentityProvider_Paypal
=== PAUSE TestAccIdentityProvider_Paypal
=== RUN   TestAccIdentityProvider_Microsoft
=== PAUSE TestAccIdentityProvider_Microsoft
=== RUN   TestAccIdentityProvider_Github
=== PAUSE TestAccIdentityProvider_Github
=== RUN   TestAccIdentityProvider_OIDC
=== PAUSE TestAccIdentityProvider_OIDC
=== RUN   TestAccIdentityProvider_SAML
=== PAUSE TestAccIdentityProvider_SAML
=== RUN   TestAccIdentityProvider_ChangeProvider
=== PAUSE TestAccIdentityProvider_ChangeProvider
=== RUN   TestAccIdentityProvider_BadParameters
=== PAUSE TestAccIdentityProvider_BadParameters
=== CONT  TestAccIdentityProvider_RemovalDrift
=== CONT  TestAccIdentityProvider_Apple
=== CONT  TestAccIdentityProvider_OIDC
=== CONT  TestAccIdentityProvider_ChangeProvider
=== CONT  TestAccIdentityProvider_LinkedIn
=== CONT  TestAccIdentityProvider_Twitter
=== CONT  TestAccIdentityProvider_Amazon
=== CONT  TestAccIdentityProvider_Yahoo
=== CONT  TestAccIdentityProvider_Facebook
=== CONT  TestAccIdentityProvider_Google
=== CONT  TestAccIdentityProvider_NewEnv
=== CONT  TestAccIdentityProvider_SAML
=== CONT  TestAccIdentityProvider_Paypal
=== CONT  TestAccIdentityProvider_Github
=== CONT  TestAccIdentityProvider_BadParameters
=== CONT  TestAccIdentityProvider_Change
--- PASS: TestAccIdentityProvider_BadParameters (12.01s)
=== CONT  TestAccIdentityProvider_Microsoft
--- PASS: TestAccIdentityProvider_ChangeProvider (14.60s)
--- PASS: TestAccIdentityProvider_Paypal (14.78s)
--- PASS: TestAccIdentityProvider_Github (16.23s)
--- PASS: TestAccIdentityProvider_Facebook (16.23s)
--- PASS: TestAccIdentityProvider_Twitter (16.27s)
--- PASS: TestAccIdentityProvider_LinkedIn (16.27s)
--- PASS: TestAccIdentityProvider_Amazon (16.60s)
--- PASS: TestAccIdentityProvider_Yahoo (16.84s)
--- PASS: TestAccIdentityProvider_Google (16.85s)
--- PASS: TestAccIdentityProvider_Apple (17.02s)
--- PASS: TestAccIdentityProvider_Microsoft (11.27s)
--- PASS: TestAccIdentityProvider_Change (37.68s)
--- PASS: TestAccIdentityProvider_SAML (37.73s)
--- PASS: TestAccIdentityProvider_OIDC (38.10s)
--- PASS: TestAccIdentityProvider_NewEnv (41.79s)
--- PASS: TestAccIdentityProvider_RemovalDrift (48.39s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso (cached)
```

</details>