### PR TITLE
`resource/pingone_webhook`: Changed block data types

### DIFF
--- a/.changelog/663.txt
+++ b/.changelog/663.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`resource/pingone_webhook`: Changed the `filter_options` parameter data type.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -837,6 +837,36 @@ This parameter was previously deprecated and has now been made read only.  Use t
 
 This parameter was previously deprecated and has been removed.  Use the `enabled` parameter going forward.
 
+## Resource: pingone_webhook
+
+### `filter_options` parameter data type change
+
+The `filter_options` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_webhook" "my_webhook" {
+  # ... other configuration parameters
+  
+  filter_options {
+    included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_webhook" "my_webhook" {
+  # ... other configuration parameters
+  
+  filter_options = {
+    included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
+  }
+}
+```
+
 ## Data Source: pingone_organization
 
 ### `base_url_agreement_management` computed attribute removed

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -29,7 +29,7 @@ resource "pingone_webhook" "my_webhook" {
 
   format = "ACTIVITY"
 
-  filter_options {
+  filter_options = {
     included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
   }
 }
@@ -41,6 +41,7 @@ resource "pingone_webhook" "my_webhook" {
 ### Required
 
 - `environment_id` (String) The ID of the environment to create the webhook in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `filter_options` (Attributes) A single object that specifies the PingOne platform event filters to be included to trigger this webhook. (see [below for nested schema](#nestedatt--filter_options))
 - `format` (String) A string that specifies one of the supported webhook formats.  Options are `ACTIVITY`, `NEWRELIC`, `SPLUNK`.
 - `http_endpoint_url` (String) A string that specifies a valid HTTPS URL to which event messages are sent.
 - `name` (String) A string that specifies the webhook name.
@@ -48,7 +49,6 @@ resource "pingone_webhook" "my_webhook" {
 ### Optional
 
 - `enabled` (Boolean) A boolean that specifies whether a created or updated webhook should be active or suspended. A suspended state (`"enabled":false`) accumulates all matched events, but these events are not delivered until the webhook becomes active again (`"enabled":true`). For suspended webhooks, events accumulate for a maximum of two weeks. Events older than two weeks are deleted. Restarted webhooks receive the saved events (up to two weeks from the restart date).  Defaults to `false`.
-- `filter_options` (Block List) A block that specifies the PingOne platform event filters to be included to trigger this webhook. (see [below for nested schema](#nestedblock--filter_options))
 - `http_endpoint_headers` (Map of String) A map that specifies the headers applied to the outbound request (for example, `Authorization` `Basic usernamepassword`. The purpose of these headers is for the HTTPS endpoint to authenticate the PingOne service, ensuring that the information from PingOne is from a trusted source.
 - `verify_tls_certificates` (Boolean) A boolean that specifies whether a certificates should be verified. If this property's value is set to `false`, then all certificates are trusted. (Setting this property's value to false introduces a security risk.).  Defaults to `true`.
 
@@ -56,7 +56,7 @@ resource "pingone_webhook" "my_webhook" {
 
 - `id` (String) The ID of this resource.
 
-<a id="nestedblock--filter_options"></a>
+<a id="nestedatt--filter_options"></a>
 ### Nested Schema for `filter_options`
 
 Required:

--- a/examples/resources/pingone_webhook/resource.tf
+++ b/examples/resources/pingone_webhook/resource.tf
@@ -15,7 +15,7 @@ resource "pingone_webhook" "my_webhook" {
 
   format = "ACTIVITY"
 
-  filter_options {
+  filter_options = {
     included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
   }
 }

--- a/internal/service/base/resource_webhook.go
+++ b/internal/service/base/resource_webhook.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -37,10 +36,10 @@ type WebhookResourceModel struct {
 	HttpEndpointHeaders   types.Map    `tfsdk:"http_endpoint_headers"`
 	VerifyTLSCertificates types.Bool   `tfsdk:"verify_tls_certificates"`
 	Format                types.String `tfsdk:"format"`
-	FilterOptions         types.List   `tfsdk:"filter_options"`
+	FilterOptions         types.Object `tfsdk:"filter_options"`
 }
 
-type WebookFilterOptionsModel struct {
+type WebhookFilterOptionsResourceModel struct {
 	IncludedActionTypes    types.Set  `tfsdk:"included_action_types"`
 	IncludedApplicationIds types.Set  `tfsdk:"included_application_ids"`
 	IncludedPopulationIds  types.Set  `tfsdk:"included_population_ids"`
@@ -124,7 +123,6 @@ func (r *WebhookResource) Schema(ctx context.Context, req resource.SchemaRequest
 
 	const attrMinLength = 1
 	const attrFilterOptionsIncludedIDsMaxLength = 10
-	const attrFilterOptionsLimit = 1
 
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
@@ -190,99 +188,88 @@ func (r *WebhookResource) Schema(ctx context.Context, req resource.SchemaRequest
 					stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumSubscriptionFormatEnumValues)...),
 				},
 			},
-		},
 
-		Blocks: map[string]schema.Block{
+			"filter_options": schema.SingleNestedAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that specifies the PingOne platform event filters to be included to trigger this webhook.").Description,
+				Required:    true,
 
-			"filter_options": schema.ListNestedBlock{
-				Description: framework.SchemaAttributeDescriptionFromMarkdown("A block that specifies the PingOne platform event filters to be included to trigger this webhook.").Description,
+				Attributes: map[string]schema.Attribute{
+					"included_action_types": schema.SetAttribute{
+						Description:         filterOptionsIncludedActionTypesDescription.Description,
+						MarkdownDescription: filterOptionsIncludedActionTypesDescription.MarkdownDescription,
+						Required:            true,
 
-				NestedObject: schema.NestedBlockObject{
+						ElementType: types.StringType,
 
-					Attributes: map[string]schema.Attribute{
-						"included_action_types": schema.SetAttribute{
-							Description:         filterOptionsIncludedActionTypesDescription.Description,
-							MarkdownDescription: filterOptionsIncludedActionTypesDescription.MarkdownDescription,
-							Required:            true,
-
-							ElementType: types.StringType,
-
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(attrMinLength),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthAtLeast(attrMinLength),
-								),
-							},
-						},
-
-						"included_application_ids": schema.SetAttribute{
-							Description:         filterOptionsIncludedApplicationIDsDescription.Description,
-							MarkdownDescription: filterOptionsIncludedApplicationIDsDescription.MarkdownDescription,
-							Optional:            true,
-
-							ElementType: types.StringType,
-
-							Validators: []validator.Set{
-								setvalidator.SizeAtMost(attrFilterOptionsIncludedIDsMaxLength),
-								setvalidator.ValueStringsAre(
-									verify.P1ResourceIDValidator(),
-								),
-							},
-						},
-
-						"included_population_ids": schema.SetAttribute{
-							Description:         filterOptionsIncludedPopulationIDsDescription.Description,
-							MarkdownDescription: filterOptionsIncludedPopulationIDsDescription.MarkdownDescription,
-							Optional:            true,
-
-							ElementType: types.StringType,
-
-							Validators: []validator.Set{
-								setvalidator.SizeAtMost(attrFilterOptionsIncludedIDsMaxLength),
-								setvalidator.ValueStringsAre(
-									verify.P1ResourceIDValidator(),
-								),
-							},
-						},
-
-						"included_tags": schema.SetAttribute{
-							Description:         filterOptionsIncludedTagsDescription.Description,
-							MarkdownDescription: filterOptionsIncludedTagsDescription.MarkdownDescription,
-							Optional:            true,
-
-							ElementType: types.StringType,
-
-							Validators: []validator.Set{
-								setvalidator.ValueStringsAre(
-									stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumSubscriptionFilterIncludedTagsEnumValues)...),
-								),
-							},
-						},
-
-						"ip_address_exposed": schema.BoolAttribute{
-							Description:         filterOptionsIPAddressExposedDescription.Description,
-							MarkdownDescription: filterOptionsIPAddressExposedDescription.MarkdownDescription,
-							Optional:            true,
-							Computed:            true,
-
-							Default: booldefault.StaticBool(false),
-						},
-
-						"useragent_exposed": schema.BoolAttribute{
-							Description:         filterOptionsUseragentExposedDescription.Description,
-							MarkdownDescription: filterOptionsUseragentExposedDescription.MarkdownDescription,
-							Optional:            true,
-							Computed:            true,
-
-							Default: booldefault.StaticBool(false),
+						Validators: []validator.Set{
+							setvalidator.SizeAtLeast(attrMinLength),
+							setvalidator.ValueStringsAre(
+								stringvalidator.LengthAtLeast(attrMinLength),
+							),
 						},
 					},
-				},
 
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(attrFilterOptionsLimit),
-					listvalidator.SizeAtMost(attrFilterOptionsLimit),
-					listvalidator.IsRequired(),
+					"included_application_ids": schema.SetAttribute{
+						Description:         filterOptionsIncludedApplicationIDsDescription.Description,
+						MarkdownDescription: filterOptionsIncludedApplicationIDsDescription.MarkdownDescription,
+						Optional:            true,
+
+						ElementType: types.StringType,
+
+						Validators: []validator.Set{
+							setvalidator.SizeAtMost(attrFilterOptionsIncludedIDsMaxLength),
+							setvalidator.ValueStringsAre(
+								verify.P1ResourceIDValidator(),
+							),
+						},
+					},
+
+					"included_population_ids": schema.SetAttribute{
+						Description:         filterOptionsIncludedPopulationIDsDescription.Description,
+						MarkdownDescription: filterOptionsIncludedPopulationIDsDescription.MarkdownDescription,
+						Optional:            true,
+
+						ElementType: types.StringType,
+
+						Validators: []validator.Set{
+							setvalidator.SizeAtMost(attrFilterOptionsIncludedIDsMaxLength),
+							setvalidator.ValueStringsAre(
+								verify.P1ResourceIDValidator(),
+							),
+						},
+					},
+
+					"included_tags": schema.SetAttribute{
+						Description:         filterOptionsIncludedTagsDescription.Description,
+						MarkdownDescription: filterOptionsIncludedTagsDescription.MarkdownDescription,
+						Optional:            true,
+
+						ElementType: types.StringType,
+
+						Validators: []validator.Set{
+							setvalidator.ValueStringsAre(
+								stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumSubscriptionFilterIncludedTagsEnumValues)...),
+							),
+						},
+					},
+
+					"ip_address_exposed": schema.BoolAttribute{
+						Description:         filterOptionsIPAddressExposedDescription.Description,
+						MarkdownDescription: filterOptionsIPAddressExposedDescription.MarkdownDescription,
+						Optional:            true,
+						Computed:            true,
+
+						Default: booldefault.StaticBool(false),
+					},
+
+					"useragent_exposed": schema.BoolAttribute{
+						Description:         filterOptionsUseragentExposedDescription.Description,
+						MarkdownDescription: filterOptionsUseragentExposedDescription.MarkdownDescription,
+						Optional:            true,
+						Computed:            true,
+
+						Default: booldefault.StaticBool(false),
+					},
 				},
 			},
 		},
@@ -541,20 +528,20 @@ func (p *WebhookResourceModel) expand(ctx context.Context) (*management.Subscrip
 		httpEndpoint.SetHeaders(headersPlan)
 	}
 
-	var filterOptionsPlan []WebookFilterOptionsModel
-	diags.Append(p.FilterOptions.ElementsAs(ctx, &filterOptionsPlan, false)...)
+	var filterOptionsPlan WebhookFilterOptionsResourceModel
+	diags.Append(p.FilterOptions.As(ctx, &filterOptionsPlan, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    true,
+		UnhandledUnknownAsEmpty: true,
+	})...)
 	if diags.HasError() {
 		return nil, diags
 	}
 
 	var filterOptions *management.SubscriptionFilterOptions
 	var d diag.Diagnostics
-	if len(filterOptionsPlan) == 1 {
-		filterOptions, d = filterOptionsPlan[0].expand(ctx)
-		diags.Append(d...)
-	} else {
-		d.AddError("Invalid webhook filter options", "Exactly one filter options block must be specified")
-	}
+
+	filterOptions, d = filterOptionsPlan.expand(ctx)
+	diags.Append(d...)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -571,7 +558,7 @@ func (p *WebhookResourceModel) expand(ctx context.Context) (*management.Subscrip
 	return data, diags
 }
 
-func (p *WebookFilterOptionsModel) expand(ctx context.Context) (*management.SubscriptionFilterOptions, diag.Diagnostics) {
+func (p *WebhookFilterOptionsResourceModel) expand(ctx context.Context) (*management.SubscriptionFilterOptions, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var includedActionTypes []string
@@ -673,12 +660,11 @@ func (p *WebhookResourceModel) toState(apiObject *management.Subscription) diag.
 	return diags
 }
 
-func toStateWebhookFilterOptions(v *management.SubscriptionFilterOptions, ok bool) (types.List, diag.Diagnostics) {
+func toStateWebhookFilterOptions(v *management.SubscriptionFilterOptions, ok bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	tfObjType := types.ObjectType{AttrTypes: webhookFilterOptionsTFObjectTypes}
 
 	if !ok || v == nil {
-		return types.ListNull(types.ObjectType{AttrTypes: webhookFilterOptionsTFObjectTypes}), diags
+		return types.ObjectNull(webhookFilterOptionsTFObjectTypes), diags
 	}
 
 	var applicationIDSet, populationIDSet basetypes.SetValue
@@ -714,10 +700,7 @@ func toStateWebhookFilterOptions(v *management.SubscriptionFilterOptions, ok boo
 		"useragent_exposed":        framework.BoolOkToTF(v.GetUserAgentExposedOk()),
 	}
 
-	flattenedObj, d := types.ObjectValue(webhookFilterOptionsTFObjectTypes, objMap)
-	diags.Append(d...)
-
-	returnVar, d := types.ListValue(tfObjType, append([]attr.Value{}, flattenedObj))
+	returnVar, d := types.ObjectValue(webhookFilterOptionsTFObjectTypes, objMap)
 	diags.Append(d...)
 
 	return returnVar, diags

--- a/internal/service/base/resource_webhook_test.go
+++ b/internal/service/base/resource_webhook_test.go
@@ -135,22 +135,21 @@ func TestAccWebhook_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "http_endpoint_headers.Content-Type", "application/json"),
 					resource.TestCheckResourceAttr(resourceFullName, "verify_tls_certificates", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "format", "ACTIVITY"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_action_types.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.LINKED"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.UNLINKED"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_tags.*", "adminIdentityEvent"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_action_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.LINKED"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.UNLINKED"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_application_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_population_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_tags.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_tags.*", "adminIdentityEvent"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.ip_address_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.useragent_exposed", "true"),
 				),
 			},
 			{
@@ -200,15 +199,14 @@ func TestAccWebhook_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "http_endpoint_headers.%", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "verify_tls_certificates", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "format", "SPLUNK"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_action_types.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.LINKED"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.UNLINKED"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_action_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.LINKED"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.UNLINKED"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_application_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_population_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.ip_address_exposed", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.useragent_exposed", "false"),
 				),
 			},
 		},
@@ -245,22 +243,21 @@ func TestAccWebhook_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "http_endpoint_headers.Content-Type", "application/json"),
 					resource.TestCheckResourceAttr(resourceFullName, "verify_tls_certificates", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "format", "ACTIVITY"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_action_types.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.LINKED"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.UNLINKED"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_tags.*", "adminIdentityEvent"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_action_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.LINKED"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.UNLINKED"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_application_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_population_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_tags.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_tags.*", "adminIdentityEvent"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.ip_address_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.useragent_exposed", "true"),
 				),
 			},
 			{
@@ -274,15 +271,14 @@ func TestAccWebhook_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "http_endpoint_headers.%", "0"),
 					resource.TestCheckResourceAttr(resourceFullName, "verify_tls_certificates", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "format", "SPLUNK"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_action_types.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.LINKED"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.UNLINKED"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_action_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.LINKED"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.UNLINKED"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_application_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_population_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.ip_address_exposed", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.useragent_exposed", "false"),
 				),
 			},
 			{
@@ -298,22 +294,21 @@ func TestAccWebhook_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "http_endpoint_headers.Content-Type", "application/json"),
 					resource.TestCheckResourceAttr(resourceFullName, "verify_tls_certificates", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "format", "ACTIVITY"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_action_types.#", "2"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.LINKED"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_action_types.*", "ACCOUNT.UNLINKED"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_tags.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.0.included_tags.*", "adminIdentityEvent"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.ip_address_exposed", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.useragent_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_action_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.LINKED"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_action_types.*", "ACCOUNT.UNLINKED"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_application_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_population_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_tags.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "filter_options.included_tags.*", "adminIdentityEvent"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.ip_address_exposed", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.useragent_exposed", "true"),
 				),
 			},
 		},
@@ -340,18 +335,18 @@ func TestAccWebhook_Webhooks(t *testing.T) {
 			{
 				Config: testAccWebhookConfig_Profile1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_application_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.2", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 			{
 				Config: testAccWebhookConfig_Profile2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_application_ids.#", "2"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_application_ids.#", "2"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_application_ids.1", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 		},
@@ -378,18 +373,18 @@ func TestAccWebhook_Populations(t *testing.T) {
 			{
 				Config: testAccWebhookConfig_Profile1(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "3"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_population_ids.#", "3"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.2", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 			{
 				Config: testAccWebhookConfig_Profile2(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "filter_options.0.included_population_ids.#", "2"),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
-					resource.TestMatchResourceAttr(resourceFullName, "filter_options.0.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "filter_options.included_population_ids.#", "2"),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.0", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "filter_options.included_population_ids.1", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 		},
@@ -452,7 +447,7 @@ resource "pingone_webhook" "%[3]s" {
 
   format = "ACTIVITY"
 
-  filter_options {
+  filter_options = {
     included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name)
@@ -541,7 +536,7 @@ resource "pingone_webhook" "%[2]s" {
 
   format = "ACTIVITY"
 
-  filter_options {
+  filter_options = {
     included_action_types    = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
     included_application_ids = [pingone_application.%[3]s-2.id, pingone_application.%[3]s-3.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-2.id, pingone_population.%[3]s-3.id, pingone_population.%[3]s-1.id]
@@ -564,7 +559,7 @@ resource "pingone_webhook" "%[2]s" {
 
   format = "SPLUNK"
 
-  filter_options {
+  filter_options = {
     included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
@@ -646,7 +641,7 @@ resource "pingone_webhook" "%[2]s" {
 
   format = "ACTIVITY"
 
-  filter_options {
+  filter_options = {
     included_action_types    = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
     included_application_ids = [pingone_application.%[3]s-2.id, pingone_application.%[3]s-3.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-2.id, pingone_population.%[3]s-3.id, pingone_population.%[3]s-1.id]
@@ -711,7 +706,7 @@ resource "pingone_webhook" "%[2]s" {
 
   format = "ACTIVITY"
 
-  filter_options {
+  filter_options = {
     included_action_types    = ["ACCOUNT.LINKED"]
     included_application_ids = [pingone_application.%[3]s-new.id, pingone_application.%[3]s-1.id]
     included_population_ids  = [pingone_population.%[3]s-new.id, pingone_population.%[3]s-1.id]

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -837,6 +837,36 @@ This parameter was previously deprecated and has now been made read only.  Use t
 
 This parameter was previously deprecated and has been removed.  Use the `enabled` parameter going forward.
 
+## Resource: pingone_webhook
+
+### `filter_options` parameter data type change
+
+The `filter_options` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_webhook" "my_webhook" {
+  # ... other configuration parameters
+  
+  filter_options {
+    included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_webhook" "my_webhook" {
+  # ... other configuration parameters
+  
+  filter_options = {
+    included_action_types = ["ACCOUNT.LINKED", "ACCOUNT.UNLINKED"]
+  }
+}
+```
+
 ## Data Source: pingone_organization
 
 ### `base_url_agreement_management` computed attribute removed


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_webhook`: Changed the `filter_options` parameter data type.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccWebhook_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccWebhook_RemovalDrift
=== PAUSE TestAccWebhook_RemovalDrift
=== RUN   TestAccWebhook_NewEnv
=== PAUSE TestAccWebhook_NewEnv
=== RUN   TestAccWebhook_Full
=== PAUSE TestAccWebhook_Full
=== RUN   TestAccWebhook_Minimal
=== PAUSE TestAccWebhook_Minimal
=== RUN   TestAccWebhook_Change
=== PAUSE TestAccWebhook_Change
=== RUN   TestAccWebhook_Webhooks
=== PAUSE TestAccWebhook_Webhooks
=== RUN   TestAccWebhook_Populations
=== PAUSE TestAccWebhook_Populations
=== RUN   TestAccWebhook_BadParameters
=== PAUSE TestAccWebhook_BadParameters
=== CONT  TestAccWebhook_BadParameters
=== CONT  TestAccWebhook_RemovalDrift
=== CONT  TestAccWebhook_Populations
=== CONT  TestAccWebhook_Webhooks
=== CONT  TestAccWebhook_Change
=== CONT  TestAccWebhook_Minimal
=== CONT  TestAccWebhook_Full
=== CONT  TestAccWebhook_NewEnv
--- PASS: TestAccWebhook_Minimal (7.21s)
--- PASS: TestAccWebhook_BadParameters (9.01s)
--- PASS: TestAccWebhook_Full (9.52s)
--- PASS: TestAccWebhook_Populations (13.68s)
--- PASS: TestAccWebhook_Webhooks (13.83s)
--- PASS: TestAccWebhook_Change (20.65s)
--- PASS: TestAccWebhook_NewEnv (40.95s)
--- PASS: TestAccWebhook_RemovalDrift (45.64s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        (cached)
```

</details>