### PR TITLE
`data-source/pingone_groups`: Changed the data_filter parameter data type and renamed to data_filters (`v1`)

### DIFF
--- a/.changelog/tbc.txt
+++ b/.changelog/tbc.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`data-source/pingone_groups`: Changed the `data_filter` parameter data type and renamed to `data_filters`.
+```

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -21,10 +21,12 @@ data "pingone_groups" "by_scim_filter" {
 data "pingone_groups" "by_data_filter" {
   environment_id = var.environment_id
 
-  data_filter {
-    name   = "name"
-    values = ["My first group", "My second group"]
-  }
+  data_filters = [
+    {
+      name   = "name"
+      values = ["My first group", "My second group"]
+    }
+  ]
 }
 ```
 
@@ -37,16 +39,16 @@ data "pingone_groups" "by_data_filter" {
 
 ### Optional
 
-- `data_filter` (Block List) Individual data filters to apply to the group selection.  Allowed attributes to filter: `id`, `name`, `population.id`, `externalId` (see [below for nested schema](#nestedblock--data_filter))
-- `scim_filter` (String) A SCIM filter to apply to the group selection.  A SCIM filter offers the greatest flexibility in filtering groups.  The SCIM filter can use the following attributes: `id`, `name`, `population.id`, `externalId`.
+- `data_filters` (Attributes List) Individual data filters to apply to the group selection.  Allowed attributes to filter: `id`, `name`, `population.id`, `externalId`.  At least one of the following must be defined: `scim_filter`, `data_filters`. (see [below for nested schema](#nestedatt--data_filters))
+- `scim_filter` (String) A SCIM filter to apply to the group selection.  A SCIM filter offers the greatest flexibility in filtering groups.  The SCIM filter can use the following attributes: `id`, `name`, `population.id`, `externalId`.  At least one of the following must be defined: `scim_filter`, `data_filters`.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `ids` (List of String) The list of resulting IDs of groups that have been successfully retrieved and filtered.
 
-<a id="nestedblock--data_filter"></a>
-### Nested Schema for `data_filter`
+<a id="nestedatt--data_filters"></a>
+### Nested Schema for `data_filters`
 
 Required:
 

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -1036,6 +1036,40 @@ data "pingone_flow_policies" "example_by_data_filter" {
 }
 ```
 
+## Data Source: pingone_groups
+
+### `data_filter` optional parameter renamed and data type changed
+
+This parameter has been renamed to `data_filters` and the data type changed.  The `data_filters` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+data "pingone_groups" "example_by_data_filter" {
+  # ... other configuration parameters
+  
+  data_filter {
+    name   = "name"
+    values = ["My first group", "My second group"]
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+data "pingone_groups" "example_by_data_filter" {
+  # ... other configuration parameters
+  
+  data_filters = [
+    {
+      name   = "name"
+      values = ["My first group", "My second group"]
+    }
+  ]
+}
+```
+
 ## Data Source: pingone_organization
 
 ### `base_url_agreement_management` computed attribute removed

--- a/examples/data-sources/pingone_groups/data-source.tf
+++ b/examples/data-sources/pingone_groups/data-source.tf
@@ -7,8 +7,10 @@ data "pingone_groups" "by_scim_filter" {
 data "pingone_groups" "by_data_filter" {
   environment_id = var.environment_id
 
-  data_filter {
-    name   = "name"
-    values = ["My first group", "My second group"]
-  }
+  data_filters = [
+    {
+      name   = "name"
+      values = ["My first group", "My second group"]
+    }
+  ]
 }

--- a/internal/service/sso/data_source_groups.go
+++ b/internal/service/sso/data_source_groups.go
@@ -25,7 +25,7 @@ type GroupsDataSourceModel struct {
 	EnvironmentId types.String `tfsdk:"environment_id"`
 	Id            types.String `tfsdk:"id"`
 	ScimFilter    types.String `tfsdk:"scim_filter"`
-	DataFilter    types.List   `tfsdk:"data_filter"`
+	DataFilters   types.List   `tfsdk:"data_filters"`
 	Ids           types.List   `tfsdk:"ids"`
 }
 
@@ -68,21 +68,19 @@ func (r *GroupsDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				"A SCIM filter to apply to the group selection.  A SCIM filter offers the greatest flexibility in filtering groups.",
 			),
 				filterableAttributes,
-				[]string{"data_filter"},
+				[]string{"scim_filter", "data_filters"},
+			),
+
+			"data_filters": framework.Attr_DataFilter(framework.SchemaAttributeDescriptionFromMarkdown(
+				"Individual data filters to apply to the group selection.",
+			),
+				filterableAttributes,
+				[]string{"scim_filter", "data_filters"},
 			),
 
 			"ids": framework.Attr_DataSourceReturnIDs(framework.SchemaAttributeDescriptionFromMarkdown(
 				"The list of resulting IDs of groups that have been successfully retrieved and filtered.",
 			)),
-		},
-
-		Blocks: map[string]schema.Block{
-			"data_filter": framework.Attr_DataFilter(framework.SchemaAttributeDescriptionFromMarkdown(
-				"Individual data filters to apply to the group selection.",
-			),
-				filterableAttributes,
-				[]string{"scim_filter"},
-			),
 		},
 	}
 }
@@ -137,10 +135,10 @@ func (r *GroupsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 			return r.Client.ManagementAPIClient.GroupsApi.ReadAllGroups(ctx, data.EnvironmentId.ValueString()).Filter(data.ScimFilter.ValueString()).Execute()
 		}
 
-	} else if !data.DataFilter.IsNull() {
+	} else if !data.DataFilters.IsNull() {
 
 		var dataFilterIn []framework.DataFilterModel
-		resp.Diagnostics.Append(data.DataFilter.ElementsAs(ctx, &dataFilterIn, false)...)
+		resp.Diagnostics.Append(data.DataFilters.ElementsAs(ctx, &dataFilterIn, false)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/internal/service/sso/data_source_groups_test.go
+++ b/internal/service/sso/data_source_groups_test.go
@@ -167,10 +167,12 @@ resource "pingone_group" "%[2]s-3" {
 data "pingone_groups" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
 
-  data_filter {
-    name   = "name"
-    values = ["%[3]s-1", "%[3]s-2"]
-  }
+  data_filters = [
+    {
+      name   = "name"
+      values = ["%[3]s-1", "%[3]s-2"]
+    }
+  ]
 
   depends_on = [
     pingone_group.%[2]s-1,
@@ -202,10 +204,12 @@ resource "pingone_group" "%[2]s-3" {
 data "pingone_groups" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
 
-  data_filter {
-    name   = "name"
-    values = ["%[3]s-1", "%[3]s-2", "%[3]s-3", ]
-  }
+  data_filters = [
+    {
+      name   = "name"
+      values = ["%[3]s-1", "%[3]s-2", "%[3]s-3", ]
+    }
+  ]
 
   depends_on = [
     pingone_group.%[2]s-1,

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -1036,6 +1036,40 @@ data "pingone_flow_policies" "example_by_data_filter" {
 }
 ```
 
+## Data Source: pingone_groups
+
+### `data_filter` optional parameter renamed and data type changed
+
+This parameter has been renamed to `data_filters` and the data type changed.  The `data_filters` parameter is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+data "pingone_groups" "example_by_data_filter" {
+  # ... other configuration parameters
+  
+  data_filter {
+    name   = "name"
+    values = ["My first group", "My second group"]
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+data "pingone_groups" "example_by_data_filter" {
+  # ... other configuration parameters
+  
+  data_filters = [
+    {
+      name   = "name"
+      values = ["My first group", "My second group"]
+    }
+  ]
+}
+```
+
 ## Data Source: pingone_organization
 
 ### `base_url_agreement_management` computed attribute removed


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `data-source/pingone_groups`: Changed the `data_filter` parameter data type and renamed to `data_filters`.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccGroupsDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccGroupsDataSource_BySCIMFilter
=== PAUSE TestAccGroupsDataSource_BySCIMFilter
=== RUN   TestAccGroupsDataSource_ByDataFilter
=== PAUSE TestAccGroupsDataSource_ByDataFilter
=== RUN   TestAccGroupsDataSource_NotFound
=== PAUSE TestAccGroupsDataSource_NotFound
=== CONT  TestAccGroupsDataSource_BySCIMFilter
=== CONT  TestAccGroupsDataSource_NotFound
=== CONT  TestAccGroupsDataSource_ByDataFilter
--- PASS: TestAccGroupsDataSource_NotFound (6.45s)
--- PASS: TestAccGroupsDataSource_BySCIMFilter (11.64s)
--- PASS: TestAccGroupsDataSource_ByDataFilter (20.04s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 20.843s
```

</details>