### PR TITLE
Address Terraform minimum version compatibility issues

### DIFF
--- a/.changelog/704.txt
+++ b/.changelog/704.txt
@@ -1,0 +1,7 @@
+```release-note:note
+To avoid plan inconsistency issues in earlier versions of Terraform, the provider now requires Terraform `v1.3` or later.
+```
+
+```release-note:bug
+`resource/pingone_user`: Resolve plan inconsistency issues when using Teraform version `v1.3`.
+```

--- a/.github/workflows/acceptance-test-ff-multi-version.yml
+++ b/.github/workflows/acceptance-test-ff-multi-version.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform: # We test the earliest supported (v1.1), and the latest supported (v1.6)
-          - '1.1.*'
+          - '1.3.*'
           - '1.6.*'
       max-parallel: 1
     steps:

--- a/.github/workflows/acceptance-test-multi-version.yml
+++ b/.github/workflows/acceptance-test-multi-version.yml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform: # We test the earliest supported (v1.1), and the latest supported (v1.6)
-          - '1.1.*'
+          - '1.3.*'
           - '1.6.*'
       max-parallel: 1
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The PingOne Terraform provider is a plugin for [Terraform](https://www.terraform
 * [Ping Identity Home](https://www.pingidentity.com/en.html)
 
 ## Requirements
-* Terraform 1.1+
+* Terraform 1.3+
 * Go 1.20+ (for local development builds)
 
 ## Quickstarts

--- a/docs/resources/form.md
+++ b/docs/resources/form.md
@@ -189,7 +189,6 @@ resource "pingone_form" "my_awesome_form" {
 
 - `field_types` (Set of String) A set of strings that specifies the field types in the form.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`, `TEXTBLOB`.
 - `id` (String) The ID of this resource.
-- `language_bundle` (Map of String) An map of strings that provides i18n keys to their translations. This object includes both the keys and their default translations.
 
 <a id="nestedatt--components"></a>
 ### Nested Schema for `components`

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -123,8 +123,6 @@ func TestAccForm_Full(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "mark_required", "true"),
 			resource.TestCheckResourceAttr(resourceFullName, "mark_optional", "true"),
 			resource.TestCheckResourceAttr(resourceFullName, "cols", "4"),
-			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.button.text", "Submit"),
 			resource.TestCheckResourceAttr(resourceFullName, "translation_method", "DEFAULT_VALUE"),
 		),
 	}
@@ -140,8 +138,6 @@ func TestAccForm_Full(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "mark_required", "false"),
 			resource.TestCheckResourceAttr(resourceFullName, "mark_optional", "false"),
 			resource.TestCheckResourceAttr(resourceFullName, "cols", "4"),
-			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.button.text", "Submit"),
 			resource.TestCheckNoResourceAttr(resourceFullName, "translation_method"),
 		),
 	}

--- a/internal/service/sso/resource_user.go
+++ b/internal/service/sso/resource_user.go
@@ -449,6 +449,10 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 							"The time the specified user account was locked. This property might be absent if the account is unlocked or if the account was locked out automatically by failed password attempts.",
 						).Description,
 						Computed: true,
+
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 
 					"status": schema.StringAttribute{
@@ -973,6 +977,13 @@ func (r *UserResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 		resp.Diagnostics.Append(d...)
 
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("account"), objValue)...)
+	} else {
+		var accountPlan *UserAccountResourceModel
+		resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root("account"), &accountPlan)...)
+
+		if !accountPlan.Status.Equal(types.StringValue("LOCKED")) {
+			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("account").AtName("locked_at"), types.StringNull())...)
+		}
 	}
 }
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Address `pingone_form` plan inconsistency issues on Terraform versions `< 1.6` (no changelog needed)
- Address `pingone_user` plan inconsistency issues on Terraform versions `< 1.4`
- Raise minimum terraform version from `v1.1` to `v1.3` to avoid plan inconsistency issues in earlier versions of Terraform

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccForm_ github.com/pingidentity/terraform-provider-pingone/internal/service/base && \
TF_ACC=1 go test -v -timeout 500s -run ^TestAccUser github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccForm_RemovalDrift
=== PAUSE TestAccForm_RemovalDrift
=== RUN   TestAccForm_NewEnv
=== PAUSE TestAccForm_NewEnv
=== RUN   TestAccForm_Full
=== PAUSE TestAccForm_Full
=== RUN   TestAccForm_Multiple
=== PAUSE TestAccForm_Multiple
=== RUN   TestAccForm_FieldCheckbox
=== PAUSE TestAccForm_FieldCheckbox
=== RUN   TestAccForm_FieldCombobox
=== PAUSE TestAccForm_FieldCombobox
=== RUN   TestAccForm_FieldDropdown
=== PAUSE TestAccForm_FieldDropdown
=== RUN   TestAccForm_FieldPassword
=== PAUSE TestAccForm_FieldPassword
=== RUN   TestAccForm_FieldPasswordVerify
=== PAUSE TestAccForm_FieldPasswordVerify
=== RUN   TestAccForm_FieldRadio
=== PAUSE TestAccForm_FieldRadio
=== RUN   TestAccForm_FieldSubmitButton
=== PAUSE TestAccForm_FieldSubmitButton
=== RUN   TestAccForm_FieldText
=== PAUSE TestAccForm_FieldText
=== RUN   TestAccForm_ItemDivider
=== PAUSE TestAccForm_ItemDivider
=== RUN   TestAccForm_ItemEmptyField
=== PAUSE TestAccForm_ItemEmptyField
=== RUN   TestAccForm_ItemErrorDisplay
=== PAUSE TestAccForm_ItemErrorDisplay
=== RUN   TestAccForm_ItemFlowButton
=== PAUSE TestAccForm_ItemFlowButton
=== RUN   TestAccForm_ItemFlowLink
=== PAUSE TestAccForm_ItemFlowLink
=== RUN   TestAccForm_ItemQRCode
=== PAUSE TestAccForm_ItemQRCode
=== RUN   TestAccForm_ItemRecaptchaV2
=== PAUSE TestAccForm_ItemRecaptchaV2
=== RUN   TestAccForm_ItemSlateTextblob
=== PAUSE TestAccForm_ItemSlateTextblob
=== RUN   TestAccForm_ItemTextblob
=== PAUSE TestAccForm_ItemTextblob
=== RUN   TestAccForm_BadParameters
=== PAUSE TestAccForm_BadParameters
=== CONT  TestAccForm_RemovalDrift
=== CONT  TestAccForm_FieldText
=== CONT  TestAccForm_FieldDropdown
=== CONT  TestAccForm_FieldRadio
=== CONT  TestAccForm_FieldPasswordVerify
=== CONT  TestAccForm_FieldSubmitButton
=== CONT  TestAccForm_ItemRecaptchaV2
=== CONT  TestAccForm_ItemFlowLink
=== CONT  TestAccForm_Multiple
=== CONT  TestAccForm_ItemFlowButton
=== CONT  TestAccForm_FieldCombobox
=== CONT  TestAccForm_ItemQRCode
=== CONT  TestAccForm_ItemTextblob
=== CONT  TestAccForm_ItemSlateTextblob
=== CONT  TestAccForm_BadParameters
=== CONT  TestAccForm_FieldPassword
--- PASS: TestAccForm_BadParameters (20.18s)
=== CONT  TestAccForm_ItemEmptyField
--- PASS: TestAccForm_ItemSlateTextblob (26.63s)
=== CONT  TestAccForm_ItemErrorDisplay
--- PASS: TestAccForm_Multiple (32.06s)
=== CONT  TestAccForm_ItemDivider
--- PASS: TestAccForm_RemovalDrift (41.29s)
=== CONT  TestAccForm_FieldCheckbox
--- PASS: TestAccForm_FieldPassword (55.31s)
=== CONT  TestAccForm_Full
--- PASS: TestAccForm_FieldText (55.58s)
=== CONT  TestAccForm_NewEnv
--- PASS: TestAccForm_ItemRecaptchaV2 (55.94s)
--- PASS: TestAccForm_FieldSubmitButton (56.48s)
--- PASS: TestAccForm_ItemQRCode (56.48s)
--- PASS: TestAccForm_FieldRadio (57.62s)
--- PASS: TestAccForm_FieldDropdown (57.73s)
--- PASS: TestAccForm_ItemFlowButton (57.91s)
--- PASS: TestAccForm_ItemTextblob (58.38s)
--- PASS: TestAccForm_FieldCombobox (58.82s)
--- PASS: TestAccForm_FieldPasswordVerify (58.97s)
--- PASS: TestAccForm_ItemFlowLink (62.77s)
--- PASS: TestAccForm_NewEnv (17.33s)
--- PASS: TestAccForm_ItemEmptyField (53.52s)
--- PASS: TestAccForm_ItemErrorDisplay (48.33s)
--- PASS: TestAccForm_ItemDivider (46.91s)
--- PASS: TestAccForm_FieldCheckbox (49.59s)
--- PASS: TestAccForm_Full (39.46s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        95.739s
=== RUN   TestAccUserDataSource_ByNameFull
=== PAUSE TestAccUserDataSource_ByNameFull
=== RUN   TestAccUserDataSource_ByEmailFull
=== PAUSE TestAccUserDataSource_ByEmailFull
=== RUN   TestAccUserDataSource_ByIDFull
=== PAUSE TestAccUserDataSource_ByIDFull
=== RUN   TestAccUserDataSource_NotFound
=== PAUSE TestAccUserDataSource_NotFound
=== RUN   TestAccUsersDataSource_BySCIMFilter
=== PAUSE TestAccUsersDataSource_BySCIMFilter
=== RUN   TestAccUsersDataSource_ByDataFilter
=== PAUSE TestAccUsersDataSource_ByDataFilter
=== RUN   TestAccUsersDataSource_NotFound
=== PAUSE TestAccUsersDataSource_NotFound
=== RUN   TestAccUserGroupAssignment_RemovalDrift
=== PAUSE TestAccUserGroupAssignment_RemovalDrift
=== RUN   TestAccUserGroupAssignment_Full
=== PAUSE TestAccUserGroupAssignment_Full
=== RUN   TestAccUserGroupAssignment_BadParameters
=== PAUSE TestAccUserGroupAssignment_BadParameters
=== RUN   TestAccUser_RemovalDrift
=== PAUSE TestAccUser_RemovalDrift
=== RUN   TestAccUser_NewEnv
=== PAUSE TestAccUser_NewEnv
=== RUN   TestAccUser_All
=== PAUSE TestAccUser_All
=== RUN   TestAccUser_AllWithoutReplacement
=== PAUSE TestAccUser_AllWithoutReplacement
=== RUN   TestAccUser_AccountLocked
=== PAUSE TestAccUser_AccountLocked
=== RUN   TestAccUser_ChangePopulation
=== PAUSE TestAccUser_ChangePopulation
=== RUN   TestAccUser_ChangeMFA
=== PAUSE TestAccUser_ChangeMFA
=== RUN   TestAccUser_ChangeUsernameAndEmail
=== PAUSE TestAccUser_ChangeUsernameAndEmail
=== RUN   TestAccUser_BadParameters
=== PAUSE TestAccUser_BadParameters
=== CONT  TestAccUserDataSource_ByNameFull
=== CONT  TestAccUser_RemovalDrift
=== CONT  TestAccUsersDataSource_ByDataFilter
=== CONT  TestAccUsersDataSource_BySCIMFilter
=== CONT  TestAccUser_ChangePopulation
=== CONT  TestAccUser_AllWithoutReplacement
=== CONT  TestAccUser_BadParameters
=== CONT  TestAccUserGroupAssignment_BadParameters
=== CONT  TestAccUser_ChangeUsernameAndEmail
=== CONT  TestAccUsersDataSource_NotFound
=== CONT  TestAccUserGroupAssignment_Full
=== CONT  TestAccUserGroupAssignment_RemovalDrift
=== CONT  TestAccUser_NewEnv
=== CONT  TestAccUser_ChangeMFA
=== CONT  TestAccUser_AccountLocked
=== CONT  TestAccUser_All
--- PASS: TestAccUsersDataSource_NotFound (9.63s)
=== CONT  TestAccUserDataSource_NotFound
--- PASS: TestAccUserDataSource_NotFound (4.92s)
=== CONT  TestAccUserDataSource_ByEmailFull
--- PASS: TestAccUsersDataSource_BySCIMFilter (14.93s)
=== CONT  TestAccUserDataSource_ByIDFull
--- PASS: TestAccUserDataSource_ByNameFull (15.09s)
--- PASS: TestAccUserGroupAssignment_Full (18.59s)
--- PASS: TestAccUser_BadParameters (18.87s)
--- PASS: TestAccUser_ChangePopulation (19.62s)
--- PASS: TestAccUserGroupAssignment_BadParameters (19.68s)
--- PASS: TestAccUser_NewEnv (19.73s)
--- PASS: TestAccUsersDataSource_ByDataFilter (21.56s)
--- PASS: TestAccUserDataSource_ByEmailFull (10.35s)
--- PASS: TestAccUserDataSource_ByIDFull (10.61s)
--- PASS: TestAccUser_ChangeMFA (27.62s)
--- PASS: TestAccUser_RemovalDrift (28.16s)
--- PASS: TestAccUser_AccountLocked (28.68s)
--- PASS: TestAccUser_ChangeUsernameAndEmail (32.58s)
--- PASS: TestAccUser_AllWithoutReplacement (46.55s)
--- PASS: TestAccUserGroupAssignment_RemovalDrift (49.40s)
--- PASS: TestAccUser_All (53.01s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 53.668s
```

</details>