### PR TITLE
Fix "Provider produced inconsistent result after apply" error

### DIFF
--- a/.changelog/715.txt
+++ b/.changelog/715.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_form`: Fixed "Provider produced inconsistent result after apply" error when configuring `PASSWORD` or `PASSWORD_VERIFY` type form controls with the `validation` parameter set.
+```

--- a/docs/resources/form.md
+++ b/docs/resources/form.md
@@ -223,7 +223,7 @@ Optional:
 - `size` (String) **Required** when the `type` is one of `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA size.  Options are `COMPACT`, `NORMAL`.
 - `styles` (Attributes) Optional when the `type` is one of `FLOW_BUTTON`, `FLOW_LINK`, `SUBMIT_BUTTON`.  A single object that describes style settings for the field. (see [below for nested schema](#nestedatt--components--fields--styles))
 - `theme` (String) **Required** when the `type` is one of `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA theme.  Options are `DARK`, `LIGHT`.
-- `validation` (Attributes) **Required** when the `type` is one of `TEXT`.  An object containing validation data for the field. (see [below for nested schema](#nestedatt--components--fields--validation))
+- `validation` (Attributes) **Required** when the `type` is one of `TEXT`, optional when the `type` is one of `PASSWORD`, `PASSWORD_VERIFY`.  An object containing validation data for the field. (see [below for nested schema](#nestedatt--components--fields--validation))
 
 Read-Only:
 

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -713,6 +713,7 @@ func TestAccForm_FieldPassword(t *testing.T) {
 				"other_option_enabled":            "false",
 				"other_option_attribute_disabled": "false",
 				"show_password_requirements":      "true",
+				"validation.type":                 "NONE",
 			}),
 		),
 	}
@@ -814,6 +815,7 @@ func TestAccForm_FieldPasswordVerify(t *testing.T) {
 				"other_option_enabled":            "false",
 				"other_option_attribute_disabled": "false",
 				"show_password_requirements":      "true",
+				"validation.type":                 "NONE",
 			}),
 		),
 	}
@@ -3108,6 +3110,10 @@ resource "pingone_form" "%[2]s" {
         required                   = true
         attribute_disabled         = false
         show_password_requirements = true
+
+        validation = {
+          type = "NONE"
+        }
       },
       {
         type = "SUBMIT_BUTTON"
@@ -3239,6 +3245,10 @@ resource "pingone_form" "%[2]s" {
         required                   = true
         attribute_disabled         = false
         show_password_requirements = true
+
+        validation = {
+          type = "NONE"
+        }
       },
       {
         type = "SUBMIT_BUTTON"

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -752,6 +752,10 @@ func TestAccForm_FieldPassword(t *testing.T) {
 				Config:      testAccFormConfig_FieldPasswordMissingRequiredParams(resourceName, name),
 				ExpectError: regexp.MustCompile(`Invalid DaVinci form configuration`),
 			},
+			{
+				Config:      testAccFormConfig_FieldPasswordInvalidValidation(resourceName, name),
+				ExpectError: regexp.MustCompile(`Invalid DaVinci form configuration`),
+			},
 			// Full step
 			fullStep,
 			{
@@ -852,6 +856,10 @@ func TestAccForm_FieldPasswordVerify(t *testing.T) {
 			// Validate
 			{
 				Config:      testAccFormConfig_FieldPasswordVerifyMissingRequiredParams(resourceName, name),
+				ExpectError: regexp.MustCompile(`Invalid DaVinci form configuration`),
+			},
+			{
+				Config:      testAccFormConfig_FieldPasswordVerifyInvalidValidation(resourceName, name),
 				ExpectError: regexp.MustCompile(`Invalid DaVinci form configuration`),
 			},
 			// Full step
@@ -3212,6 +3220,51 @@ resource "pingone_form" "%[2]s" {
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
+func testAccFormConfig_FieldPasswordInvalidValidation(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "PASSWORD"
+
+        position = {
+          row = 0
+          col = 0
+        }
+
+		validation = {
+			type          = "CUSTOM"
+			regex         = "[a-zA-Z0-9]+"
+			error_message = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]"
+		  }
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
 func testAccFormConfig_FieldPasswordVerifyFull(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
@@ -3331,6 +3384,51 @@ resource "pingone_form" "%[2]s" {
           row = 0
           col = 0
         }
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccFormConfig_FieldPasswordVerifyInvalidValidation(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "PASSWORD_VERIFY"
+
+        position = {
+          row = 0
+          col = 0
+        }
+
+		validation = {
+			type          = "CUSTOM"
+			regex         = "[a-zA-Z0-9]+"
+			error_message = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]"
+		  }
       },
       {
         type = "SUBMIT_BUTTON"

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -3244,11 +3244,11 @@ resource "pingone_form" "%[2]s" {
           col = 0
         }
 
-		validation = {
-			type          = "CUSTOM"
-			regex         = "[a-zA-Z0-9]+"
-			error_message = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]"
-		  }
+        validation = {
+          type          = "CUSTOM"
+          regex         = "[a-zA-Z0-9]+"
+          error_message = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]"
+        }
       },
       {
         type = "SUBMIT_BUTTON"
@@ -3424,11 +3424,11 @@ resource "pingone_form" "%[2]s" {
           col = 0
         }
 
-		validation = {
-			type          = "CUSTOM"
-			regex         = "[a-zA-Z0-9]+"
-			error_message = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]"
-		  }
+        validation = {
+          type          = "CUSTOM"
+          regex         = "[a-zA-Z0-9]+"
+          error_message = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]"
+        }
       },
       {
         type = "SUBMIT_BUTTON"


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_form`: Fixed "Provider produced inconsistent result after apply" error when configuring `PASSWORD` or `PASSWORD_VERIFY` type form controls with the `validation` parameter set.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccForm_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccForm_RemovalDrift
=== PAUSE TestAccForm_RemovalDrift
=== RUN   TestAccForm_NewEnv
=== PAUSE TestAccForm_NewEnv
=== RUN   TestAccForm_Full
=== PAUSE TestAccForm_Full
=== RUN   TestAccForm_Multiple
=== PAUSE TestAccForm_Multiple
=== RUN   TestAccForm_FieldCheckbox
=== PAUSE TestAccForm_FieldCheckbox
=== RUN   TestAccForm_FieldCombobox
=== PAUSE TestAccForm_FieldCombobox
=== RUN   TestAccForm_FieldDropdown
=== PAUSE TestAccForm_FieldDropdown
=== RUN   TestAccForm_FieldPassword
=== PAUSE TestAccForm_FieldPassword
=== RUN   TestAccForm_FieldPasswordVerify
=== PAUSE TestAccForm_FieldPasswordVerify
=== RUN   TestAccForm_FieldRadio
=== PAUSE TestAccForm_FieldRadio
=== RUN   TestAccForm_FieldSubmitButton
=== PAUSE TestAccForm_FieldSubmitButton
=== RUN   TestAccForm_FieldText
=== PAUSE TestAccForm_FieldText
=== RUN   TestAccForm_ItemDivider
=== PAUSE TestAccForm_ItemDivider
=== RUN   TestAccForm_ItemEmptyField
=== PAUSE TestAccForm_ItemEmptyField
=== RUN   TestAccForm_ItemErrorDisplay
=== PAUSE TestAccForm_ItemErrorDisplay
=== RUN   TestAccForm_ItemFlowButton
=== PAUSE TestAccForm_ItemFlowButton
=== RUN   TestAccForm_ItemFlowLink
=== PAUSE TestAccForm_ItemFlowLink
=== RUN   TestAccForm_ItemQRCode
=== PAUSE TestAccForm_ItemQRCode
=== RUN   TestAccForm_ItemRecaptchaV2
=== PAUSE TestAccForm_ItemRecaptchaV2
=== RUN   TestAccForm_ItemSlateTextblob
=== PAUSE TestAccForm_ItemSlateTextblob
=== RUN   TestAccForm_ItemTextblob
=== PAUSE TestAccForm_ItemTextblob
=== RUN   TestAccForm_BadParameters
=== PAUSE TestAccForm_BadParameters
=== CONT  TestAccForm_RemovalDrift
=== CONT  TestAccForm_FieldDropdown
=== CONT  TestAccForm_FieldText
=== CONT  TestAccForm_BadParameters
=== CONT  TestAccForm_ItemTextblob
=== CONT  TestAccForm_ItemSlateTextblob
=== CONT  TestAccForm_ItemRecaptchaV2
=== CONT  TestAccForm_ItemQRCode
=== CONT  TestAccForm_ItemFlowLink
=== CONT  TestAccForm_ItemFlowButton
=== CONT  TestAccForm_ItemErrorDisplay
=== CONT  TestAccForm_ItemEmptyField
=== CONT  TestAccForm_ItemDivider
=== CONT  TestAccForm_FieldRadio
=== CONT  TestAccForm_FieldSubmitButton
=== CONT  TestAccForm_Multiple
--- PASS: TestAccForm_BadParameters (45.39s)
=== CONT  TestAccForm_FieldCombobox
--- PASS: TestAccForm_ItemSlateTextblob (61.53s)
=== CONT  TestAccForm_FieldCheckbox
--- PASS: TestAccForm_RemovalDrift (76.04s)
=== CONT  TestAccForm_FieldPasswordVerify
--- PASS: TestAccForm_Multiple (85.73s)
=== CONT  TestAccForm_Full
--- PASS: TestAccForm_ItemQRCode (125.51s)
=== CONT  TestAccForm_FieldPassword
--- PASS: TestAccForm_ItemErrorDisplay (126.57s)
=== CONT  TestAccForm_NewEnv
--- PASS: TestAccForm_ItemRecaptchaV2 (127.88s)
--- PASS: TestAccForm_ItemFlowButton (128.22s)
--- PASS: TestAccForm_FieldText (130.55s)
--- PASS: TestAccForm_FieldSubmitButton (130.90s)
--- PASS: TestAccForm_ItemTextblob (132.51s)
--- PASS: TestAccForm_ItemDivider (132.79s)
--- PASS: TestAccForm_ItemEmptyField (133.53s)
--- PASS: TestAccForm_ItemFlowLink (133.68s)
--- PASS: TestAccForm_FieldDropdown (133.87s)
--- PASS: TestAccForm_FieldRadio (135.39s)
--- PASS: TestAccForm_NewEnv (22.86s)
--- PASS: TestAccForm_FieldCombobox (109.58s)
--- PASS: TestAccForm_FieldCheckbox (99.77s)
--- PASS: TestAccForm_FieldPasswordVerify (88.19s)
--- PASS: TestAccForm_Full (80.47s)
--- PASS: TestAccForm_FieldPassword (53.96s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        180.586s
```

</details>