### PR TITLE
Correct Login SOP action error when mapping LDAP gateways for PingOne user lookup

### DIFF
--- a/.changelog/721.txt
+++ b/.changelog/721.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_sign_on_policy_action`: Corrected the "login" sign on policy action error messages when configuring a gateway with missing configuration.
+```


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Corrected the "login" sign on policy action error messages when configuring a gateway with missing configuration

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a
<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccSignOnPolicyAction_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccSignOnPolicyAction_RemovalDrift
=== PAUSE TestAccSignOnPolicyAction_RemovalDrift
=== RUN   TestAccSignOnPolicyAction_LoginAction
=== PAUSE TestAccSignOnPolicyAction_LoginAction
=== RUN   TestAccSignOnPolicyAction_LoginAction_Gateway
=== PAUSE TestAccSignOnPolicyAction_LoginAction_Gateway
=== RUN   TestAccSignOnPolicyAction_IDFirstAction
=== PAUSE TestAccSignOnPolicyAction_IDFirstAction
=== RUN   TestAccSignOnPolicyAction_MFAAction
=== PAUSE TestAccSignOnPolicyAction_MFAAction
=== RUN   TestAccSignOnPolicyAction_IDPAction
=== PAUSE TestAccSignOnPolicyAction_IDPAction
=== RUN   TestAccSignOnPolicyAction_AgreementAction
=== PAUSE TestAccSignOnPolicyAction_AgreementAction
=== RUN   TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== PAUSE TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== RUN   TestAccSignOnPolicyAction_PingIDAction
=== PAUSE TestAccSignOnPolicyAction_PingIDAction
=== RUN   TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
=== PAUSE TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
=== RUN   TestAccSignOnPolicyAction_MultipleActionChange
=== PAUSE TestAccSignOnPolicyAction_MultipleActionChange
=== RUN   TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== PAUSE TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
=== RUN   TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== PAUSE TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== RUN   TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== PAUSE TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== RUN   TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== PAUSE TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== RUN   TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== PAUSE TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== RUN   TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== RUN   TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== RUN   TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== PAUSE TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== RUN   TestAccSignOnPolicyAction_ConditionsGeovelocity
=== PAUSE TestAccSignOnPolicyAction_ConditionsGeovelocity
=== RUN   TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== PAUSE TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== RUN   TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== PAUSE TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== RUN   TestAccSignOnPolicyAction_ConditionsCompound
=== PAUSE TestAccSignOnPolicyAction_ConditionsCompound
=== RUN   TestAccSignOnPolicyAction_BadParameters
=== PAUSE TestAccSignOnPolicyAction_BadParameters
=== CONT  TestAccSignOnPolicyAction_RemovalDrift
=== CONT  TestAccSignOnPolicyAction_ConditionsMemberOfPopulations
=== CONT  TestAccSignOnPolicyAction_ConditionsIPHighRisk
=== CONT  TestAccSignOnPolicyAction_ConditionsInvalidPriority1
=== CONT  TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
=== CONT  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
=== CONT  TestAccSignOnPolicyAction_AgreementAction
=== CONT  TestAccSignOnPolicyAction_ConditionsGeovelocity
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool
=== CONT  TestAccSignOnPolicyAction_IDPAction
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString
=== CONT  TestAccSignOnPolicyAction_ConditionsMemberOfPopulation
=== CONT  TestAccSignOnPolicyAction_MFAAction
=== CONT  TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
=== NAME  TestAccSignOnPolicyAction_ConditionsGeovelocity
    resource_sign_on_policy_action_test.go:1436: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsGeovelocity (0.00s)
=== NAME  TestAccSignOnPolicyAction_ConditionsIPHighRisk
    resource_sign_on_policy_action_test.go:1378: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPHighRisk (0.00s)
=== CONT  TestAccSignOnPolicyAction_LoginAction_Gateway
=== CONT  TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple
=== NAME  TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed
    resource_sign_on_policy_action_test.go:1554: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsAnonymousNetworkWithAllowed (0.00s)
=== CONT  TestAccSignOnPolicyAction_LoginAction
=== NAME  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple
    resource_sign_on_policy_action_test.go:1316: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPOutOfRangeMultiple (0.00s)
=== CONT  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
=== CONT  TestAccSignOnPolicyAction_IDFirstAction
=== CONT  TestAccSignOnPolicyAction_ProgressiveProfilingAction
=== NAME  TestAccSignOnPolicyAction_ConditionsAnonymousNetwork
    resource_sign_on_policy_action_test.go:1494: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsAnonymousNetwork (0.00s)
=== CONT  TestAccSignOnPolicyAction_BadParameters
=== NAME  TestAccSignOnPolicyAction_MFAAction
    resource_sign_on_policy_action_test.go:378: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_MFAAction (0.00s)
=== NAME  TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle
    resource_sign_on_policy_action_test.go:1256: Test to be re-defined
--- SKIP: TestAccSignOnPolicyAction_ConditionsIPOutOfRangeSingle (0.00s)
=== CONT  TestAccSignOnPolicyAction_ConditionsCompound
=== CONT  TestAccSignOnPolicyAction_MultipleActionChange
--- PASS: TestAccSignOnPolicyAction_ConditionsInvalidPriority1 (7.41s)
=== CONT  TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle
--- PASS: TestAccSignOnPolicyAction_ConditionsCompound (13.04s)
=== CONT  TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction
--- PASS: TestAccSignOnPolicyAction_BadParameters (17.02s)
=== CONT  TestAccSignOnPolicyAction_PingIDAction
--- PASS: TestAccSignOnPolicyAction_MultipleActionChange (24.92s)
--- PASS: TestAccSignOnPolicyAction_ConditionsMemberOfPopulations (25.20s)
--- PASS: TestAccSignOnPolicyAction_ConditionsMemberOfPopulation (26.35s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleString (26.36s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsSingleBool (26.95s)
--- PASS: TestAccSignOnPolicyAction_PingIDWinLoginPasswordlessAction (13.95s)
--- PASS: TestAccSignOnPolicyAction_ConditionsUserAttributeEqualsMultiple (27.01s)
--- PASS: TestAccSignOnPolicyAction_IDPAction (28.24s)
--- PASS: TestAccSignOnPolicyAction_ProgressiveProfilingAction (28.28s)
--- PASS: TestAccSignOnPolicyAction_PingIDAction (12.84s)
--- PASS: TestAccSignOnPolicyAction_ConditionsSignOnOlderThanSingle (23.09s)
--- PASS: TestAccSignOnPolicyAction_IDFirstAction (30.99s)
--- PASS: TestAccSignOnPolicyAction_LoginAction (31.03s)
--- PASS: TestAccSignOnPolicyAction_LoginAction_Gateway (33.61s)
--- PASS: TestAccSignOnPolicyAction_RemovalDrift (36.96s)
--- PASS: TestAccSignOnPolicyAction_AgreementAction (49.11s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 50.199s
```

</details>