### PR TITLE
`data-source/pingone_licenses`: Migrate to plugin framework

### DIFF
--- a/.changelog/728.txt
+++ b/.changelog/728.txt
@@ -1,0 +1,7 @@
+```release-note:note
+`data-source/pingone_licenses`: Migrated to plugin framework.
+```
+
+```release-note:bug
+`data-source/pingone_licenses`: Fixed `data_filter.name` defined as an optional parameter.  The `data_filter.name` parameter is now required when defining the `data_filter` block.
+```

--- a/docs/data-sources/licenses.md
+++ b/docs/data-sources/licenses.md
@@ -41,8 +41,8 @@ data "pingone_licenses" "my_licenses_by_data_filter" {
 
 ### Optional
 
-- `data_filter` (Block List) Individual data filters to apply to the license selection.  Allowed attributes to filter: `name`, `package`, `status` (see [below for nested schema](#nestedblock--data_filter))
-- `scim_filter` (String) A SCIM filter to apply to the license selection.  A SCIM filter offers the greatest flexibility in filtering licenses.  The SCIM filter can use the following attributes: `name`, `package`, `status`.
+- `data_filter` (Block List) Individual data filters to apply to the license selection.  If the attribute filter is `status`, available values are `ACTIVE`, `EXPIRED`, `FUTURE` and `TERMINATED`.  Allowed attributes to filter: `name`, `package`, `status` (see [below for nested schema](#nestedblock--data_filter))
+- `scim_filter` (String) A SCIM filter to apply to the license selection.  A SCIM filter offers the greatest flexibility in filtering licenses.  If the attribute filter is `status`, available values are `ACTIVE`, `EXPIRED`, `FUTURE` and `TERMINATED`.  The SCIM filter can use the following attributes: `name`, `package`, `status`.
 
 ### Read-Only
 

--- a/docs/data-sources/licenses.md
+++ b/docs/data-sources/licenses.md
@@ -37,12 +37,12 @@ data "pingone_licenses" "my_licenses_by_data_filter" {
 
 ### Required
 
-- `organization_id` (String) The ID of the organization.
+- `organization_id` (String) The ID of the organization to retreive licenses for.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 
 ### Optional
 
-- `data_filter` (Block Set) Individual data filters to apply to the license selection. (see [below for nested schema](#nestedblock--data_filter))
-- `scim_filter` (String) A SCIM filter to apply to the license selection.  A SCIM filter offers the greatest flexibility in filtering licenses.
+- `data_filter` (Block List) Individual data filters to apply to the license selection.  Allowed attributes to filter: `name`, `package`, `status` (see [below for nested schema](#nestedblock--data_filter))
+- `scim_filter` (String) A SCIM filter to apply to the license selection.  A SCIM filter offers the greatest flexibility in filtering licenses.  The SCIM filter can use the following attributes: `name`, `package`, `status`.
 
 ### Read-Only
 
@@ -54,8 +54,5 @@ data "pingone_licenses" "my_licenses_by_data_filter" {
 
 Required:
 
-- `values` (Set of String) The possible values (case sensitive) of the attribute defined in the `name` parameter to filter.  If the attribute filter is `package`, the value is a free text, case-sensitive field.  Package names are not fixed and can change over time. If the attribute filter is `status`, available values are `ACTIVE`, `EXPIRED`, `FUTURE` and `TERMINATED`.  If the attribute filter is `name`, the exact name of the license should be provided.
-
-Optional:
-
-- `name` (String) The attribute name to filter on.  Options are `name`, `package` or `status`.
+- `name` (String) The attribute name to filter on.  Must be one of the following values: `name`, `package`, `status`.
+- `values` (List of String) The possible values (case sensitive) of the attribute defined in the `name` parameter to filter.

--- a/docs/data-sources/licenses.md
+++ b/docs/data-sources/licenses.md
@@ -37,7 +37,7 @@ data "pingone_licenses" "my_licenses_by_data_filter" {
 
 ### Required
 
-- `organization_id` (String) The ID of the organization to retreive licenses for.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `organization_id` (String) The ID of the organization to retrieve licenses for.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 
 ### Optional
 

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -102,7 +102,6 @@ func New(version string) func() *schema.Provider {
 				"pingone_certificate_signing_request":    base.DatasourceCertificateSigningRequest(),
 				"pingone_language":                       base.DatasourceLanguage(),
 				"pingone_license":                        base.DatasourceLicense(),
-				"pingone_licenses":                       base.DatasourceLicenses(),
 				"pingone_trusted_email_domain_dkim":      base.DatasourceTrustedEmailDomainDKIM(),
 				"pingone_trusted_email_domain_ownership": base.DatasourceTrustedEmailDomainOwnership(),
 				"pingone_trusted_email_domain_spf":       base.DatasourceTrustedEmailDomainSPF(),

--- a/internal/service/base/data_source_licenses.go
+++ b/internal/service/base/data_source_licenses.go
@@ -54,7 +54,7 @@ func (r *LicensesDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 			"id": framework.Attr_ID(),
 
 			"organization_id": framework.Attr_LinkID(framework.SchemaAttributeDescriptionFromMarkdown(
-				"The ID of the organization to retreive licenses for.",
+				"The ID of the organization to retrieve licenses for.",
 			)),
 
 			"scim_filter": framework.Attr_SCIMFilter(framework.SchemaAttributeDescriptionFromMarkdown(

--- a/internal/service/base/data_source_licenses.go
+++ b/internal/service/base/data_source_licenses.go
@@ -2,163 +2,218 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
-	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
+	"github.com/pingidentity/terraform-provider-pingone/internal/filter"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
-	"github.com/pingidentity/terraform-provider-pingone/internal/verify"
 )
 
-func DatasourceLicenses() *schema.Resource {
-	return &schema.Resource{
+// Types
+type LicensesDataSource serviceClientType
 
+type LicensesDataSourceModel struct {
+	OrganizationId types.String `tfsdk:"organization_id"`
+	Id             types.String `tfsdk:"id"`
+	ScimFilter     types.String `tfsdk:"scim_filter"`
+	DataFilter     types.List   `tfsdk:"data_filter"`
+	Ids            types.List   `tfsdk:"ids"`
+}
+
+// Framework interfaces
+var (
+	_ datasource.DataSource = &LicensesDataSource{}
+)
+
+// New Object
+func NewLicensesDataSource() datasource.DataSource {
+	return &LicensesDataSource{}
+}
+
+// Metadata
+func (r *LicensesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_licenses"
+}
+
+// Schema
+func (r *LicensesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+
+	filterableAttributes := []string{"name", "package", "status"}
+
+	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
 		Description: "Datasource to retrieve multiple PingOne license IDs selected by a SCIM filter or a name/value list combination.",
 
-		ReadContext: datasourcePingOneLicensesRead,
+		Attributes: map[string]schema.Attribute{
+			"id": framework.Attr_ID(),
 
-		Schema: map[string]*schema.Schema{
-			"organization_id": {
-				Description:      "The ID of the organization.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
-			},
-			"scim_filter": {
-				Description:  "A SCIM filter to apply to the license selection.  A SCIM filter offers the greatest flexibility in filtering licenses.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ExactlyOneOf: []string{"scim_filter", "data_filter"},
-			},
-			"data_filter": {
-				Description:  "Individual data filters to apply to the license selection.",
-				Type:         schema.TypeSet,
-				Optional:     true,
-				ExactlyOneOf: []string{"scim_filter", "data_filter"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Description:      "The attribute name to filter on.  Options are `name`, `package` or `status`.",
-							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"name", "package", "status"}, false)),
-						},
-						"values": {
-							Description: "The possible values (case sensitive) of the attribute defined in the `name` parameter to filter.  If the attribute filter is `package`, the value is a free text, case-sensitive field.  Package names are not fixed and can change over time. If the attribute filter is `status`, available values are `ACTIVE`, `EXPIRED`, `FUTURE` and `TERMINATED`.  If the attribute filter is `name`, the exact name of the license should be provided.",
-							Type:        schema.TypeSet,
-							Required:    true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-			"ids": {
-				Description: "The list of resulting IDs of licenses that have been successfully retrieved and filtered.",
-				Type:        schema.TypeList,
-				Computed:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
+			"organization_id": framework.Attr_LinkID(framework.SchemaAttributeDescriptionFromMarkdown(
+				"The ID of the organization to retreive licenses for.",
+			)),
+
+			"scim_filter": framework.Attr_SCIMFilter(framework.SchemaAttributeDescriptionFromMarkdown(
+				"A SCIM filter to apply to the license selection.  A SCIM filter offers the greatest flexibility in filtering licenses.",
+			),
+				filterableAttributes,
+				[]string{"data_filter"},
+			),
+
+			"ids": framework.Attr_DataSourceReturnIDs(framework.SchemaAttributeDescriptionFromMarkdown(
+				"The list of resulting IDs of licenses that have been successfully retrieved and filtered.",
+			)),
+		},
+
+		Blocks: map[string]schema.Block{
+			"data_filter": framework.Attr_DataFilter(framework.SchemaAttributeDescriptionFromMarkdown(
+				"Individual data filters to apply to the license selection.",
+			),
+				filterableAttributes,
+				[]string{"scim_filter"},
+			),
 		},
 	}
 }
 
-func datasourcePingOneLicensesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.ManagementAPIClient
+func (r *LicensesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
 
-	var diags diag.Diagnostics
+	resourceConfig, ok := req.ProviderData.(framework.ResourceType)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected the provider client, got: %T. Please report this issue to the provider maintainers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.Client = resourceConfig.Client.API
+	if r.Client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialised",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.",
+		)
+		return
+	}
+}
+
+func (r *LicensesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *LicensesDataSourceModel
+
+	if r.Client.ManagementAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	var filterFunction sdk.SDKInterfaceFunc
 
-	if v, ok := d.GetOk("scim_filter"); ok {
+	if !data.ScimFilter.IsNull() {
 
 		filterFunction = func() (any, *http.Response, error) {
-			return apiClient.LicensesApi.ReadAllLicenses(ctx, d.Get("organization_id").(string)).Filter(v.(string)).Execute()
+			return r.Client.ManagementAPIClient.LicensesApi.ReadAllLicenses(ctx, data.OrganizationId.ValueString()).Filter(data.ScimFilter.ValueString()).Execute()
 		}
 
-	}
+	} else if !data.DataFilter.IsNull() {
 
-	if _, ok := d.GetOk("data_filter"); ok {
+		var dataFilterIn []framework.DataFilterModel
+		resp.Diagnostics.Append(data.DataFilter.ElementsAs(ctx, &dataFilterIn, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		filterSet := make([]interface{}, 0)
+
+		for _, v := range dataFilterIn {
+
+			values := framework.TFListToStringSlice(ctx, v.Values)
+			tflog.Debug(ctx, "Filter set loop", map[string]interface{}{
+				"name":          v.Name.ValueString(),
+				"len(elements)": fmt.Sprintf("%d", len(v.Values.Elements())),
+				"len(values)":   fmt.Sprintf("%d", len(values)),
+			})
+			filterSet = append(filterSet, map[string]interface{}{
+				"name":   v.Name.ValueString(),
+				"values": values,
+			})
+		}
+
+		scimFilter := filter.BuildScimFilter(filterSet, map[string]string{})
+
+		tflog.Debug(ctx, "SCIM Filter", map[string]interface{}{
+			"scimFilter": scimFilter,
+		})
 
 		filterFunction = func() (any, *http.Response, error) {
-			return apiClient.LicensesApi.ReadAllLicenses(ctx, d.Get("organization_id").(string)).Execute()
+			return r.Client.ManagementAPIClient.LicensesApi.ReadAllLicenses(ctx, data.OrganizationId.ValueString()).Filter(scimFilter).Execute()
 		}
 
+	} else {
+		resp.Diagnostics.AddError(
+			"Missing parameter",
+			"Cannot find the requested DaVinci flow policies. scim_filter or data_filter must be set.",
+		)
+		return
 	}
 
-	resp, diags := sdk.ParseResponse(
+	var entityArray *management.EntityArray
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
+
 		filterFunction,
 		"ReadAllLicenses",
-		sdk.DefaultCustomError,
+		framework.DefaultCustomError,
 		nil,
-	)
-	if diags.HasError() {
+		&entityArray,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(data.toState(data.OrganizationId.ValueString(), entityArray.Embedded.GetLicenses())...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (p *LicensesDataSourceModel) toState(environmentID string, licenses []management.License) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if licenses == nil || environmentID == "" {
+		diags.AddError(
+			"Data object missing",
+			"Cannot convert the data object to state as the data object is nil.  Please report this to the provider maintainers.",
+		)
+
 		return diags
 	}
 
-	respObject := resp.(*management.EntityArray)
-
-	d.SetId(d.Get("organization_id").(string))
-
-	var licensesList []management.License
-
-	if v, ok := d.GetOk("data_filter"); ok {
-		licensesList = filterResults(v.(*schema.Set), respObject.GetEmbedded().Licenses)
-	} else {
-		licensesList = respObject.GetEmbedded().Licenses
+	list := make([]string, 0)
+	for _, item := range licenses {
+		list = append(list, item.GetId())
 	}
 
-	idList := make([]string, 0)
-	for _, v := range licensesList {
-		idList = append(idList, v.GetId())
-	}
+	var d diag.Diagnostics
 
-	d.Set("ids", idList)
+	p.Id = framework.StringToTF(environmentID)
+	p.Ids, d = framework.StringSliceToTF(list)
+	diags.Append(d...)
 
 	return diags
-}
-
-func filterResults(filterSet *schema.Set, licenses []management.License) []management.License {
-	items := make([]management.License, 0)
-
-	for _, license := range licenses {
-
-		filterMap := map[string]interface{}{
-			"name":    license.GetName(),
-			"package": license.GetPackage(),
-			"status":  string(license.GetStatus()),
-		}
-
-		include := true
-
-		for _, c := range filterSet.List() {
-
-			obj := c.(map[string]interface{})
-
-			for k, v := range filterMap {
-				if obj["name"].(string) == k {
-					if !obj["values"].(*schema.Set).Contains(v) {
-						include = false
-					}
-				}
-			}
-
-		}
-
-		if include {
-			items = append(items, license)
-		}
-
-	}
-
-	return items
 }

--- a/internal/service/base/service.go
+++ b/internal/service/base/service.go
@@ -49,6 +49,7 @@ func DataSources() []func() datasource.DataSource {
 		NewEnvironmentDataSource,
 		NewEnvironmentsDataSource,
 		NewGatewayDataSource,
+		NewLicensesDataSource,
 		NewOrganizationDataSource,
 		NewPhoneDeliverySettingsListDataSource,
 		NewRoleDataSource,


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `data-source/pingone_licenses`: Migrate to plugin framework

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 500s -run ^TestAccLicensesDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccLicensesDataSource_BySCIMFilter
=== PAUSE TestAccLicensesDataSource_BySCIMFilter
=== RUN   TestAccLicensesDataSource_ByDataFilter
=== PAUSE TestAccLicensesDataSource_ByDataFilter
=== RUN   TestAccLicensesDataSource_NotFound
=== PAUSE TestAccLicensesDataSource_NotFound
=== CONT  TestAccLicensesDataSource_BySCIMFilter
=== CONT  TestAccLicensesDataSource_NotFound
=== CONT  TestAccLicensesDataSource_ByDataFilter
--- PASS: TestAccLicensesDataSource_BySCIMFilter (3.67s)
--- PASS: TestAccLicensesDataSource_NotFound (3.76s)
--- PASS: TestAccLicensesDataSource_ByDataFilter (7.89s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        9.602s
```

</details>