### PR TITLE
`resource/pingone_password_policy`: Update minimum password length validation

### DIFF
--- a/.changelog/740.txt
+++ b/.changelog/740.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:bug
 `resource/pingone_password_policy`: Updated the validation rule to allow the user's minimum password length to be set between 8 and 32 characters (inclusive) long.
 ```

--- a/.changelog/740.txt
+++ b/.changelog/740.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_password_policy`: Updated the validation rule to allow the user's minimum password length to be set between 8 and 32 characters (inclusive) long.
+```

--- a/docs/resources/password_policy.md
+++ b/docs/resources/password_policy.md
@@ -132,8 +132,8 @@ Optional:
 
 Optional:
 
-- `max` (Number) The maximum number of characters allowed for the password. Defaults to 255. This property is not enforced when not present.
-- `min` (Number) The minimum number of characters required for the password. Defaults to 8 characters. This property is not enforced when not present.
+- `max` (Number) The maximum number of characters allowed for the password. This property is not enforced when not present. Defaults to `255`.
+- `min` (Number) The minimum number of characters required for the password. This can be from `8` to `32` (inclusive). This property is not enforced when not present. Defaults to `8`.
 
 ## Import
 

--- a/internal/service/sso/resource_password_policy.go
+++ b/internal/service/sso/resource_password_policy.go
@@ -102,16 +102,18 @@ func ResourcePasswordPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"max": {
-							Description:      "The maximum number of characters allowed for the password. Defaults to 255. This property is not enforced when not present.",
+							Description:      "The maximum number of characters allowed for the password. This property is not enforced when not present.",
 							Type:             schema.TypeInt,
 							Optional:         true,
 							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(255, 255)),
+							Default:          255,
 						},
 						"min": {
-							Description:      "The minimum number of characters required for the password. Defaults to 8 characters. This property is not enforced when not present.",
+							Description:      "The minimum number of characters required for the password. This can be from `8` to `32` (inclusive). This property is not enforced when not present.",
 							Type:             schema.TypeInt,
 							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(8, 8)),
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(8, 32)),
+							Default:          8,
 						},
 					},
 				},

--- a/internal/service/sso/resource_password_policy_test.go
+++ b/internal/service/sso/resource_password_policy_test.go
@@ -137,7 +137,7 @@ func TestAccPasswordPolicy_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "password_history.0.prior_password_count", "10"),
 					resource.TestCheckResourceAttr(resourceFullName, "password_history.0.retention_days", "150"),
 					resource.TestCheckResourceAttr(resourceFullName, "password_length.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "password_length.0.min", "8"),
+					resource.TestCheckResourceAttr(resourceFullName, "password_length.0.min", "12"),
 					resource.TestCheckResourceAttr(resourceFullName, "password_length.0.max", "255"),
 					resource.TestCheckResourceAttr(resourceFullName, "account_lockout.#", "1"),
 					resource.TestCheckResourceAttr(resourceFullName, "account_lockout.0.duration_seconds", "30"),
@@ -294,7 +294,7 @@ resource "pingone_password_policy" "%[2]s" {
   }
 
   password_length {
-    min = 8
+    min = 12
     max = 255
   }
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

As of 11 March 2022, password set by API can be between 8 and 32 characters (inclusive).  Updated the validation rule in the `pingone_password_policy` resource

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccPasswordPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccPasswordPolicy_RemovalDrift
=== PAUSE TestAccPasswordPolicy_RemovalDrift
=== RUN   TestAccPasswordPolicy_NewEnv
=== PAUSE TestAccPasswordPolicy_NewEnv
=== RUN   TestAccPasswordPolicy_Full
=== PAUSE TestAccPasswordPolicy_Full
=== RUN   TestAccPasswordPolicy_Minimal
=== PAUSE TestAccPasswordPolicy_Minimal
=== RUN   TestAccPasswordPolicy_BadParameters
=== PAUSE TestAccPasswordPolicy_BadParameters
=== CONT  TestAccPasswordPolicy_RemovalDrift
=== CONT  TestAccPasswordPolicy_Minimal
=== CONT  TestAccPasswordPolicy_BadParameters
=== CONT  TestAccPasswordPolicy_Full
=== CONT  TestAccPasswordPolicy_NewEnv
--- PASS: TestAccPasswordPolicy_Minimal (6.20s)
--- PASS: TestAccPasswordPolicy_BadParameters (8.32s)
--- PASS: TestAccPasswordPolicy_Full (9.22s)
--- PASS: TestAccPasswordPolicy_NewEnv (13.65s)
--- PASS: TestAccPasswordPolicy_RemovalDrift (17.37s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 19.397s
```

</details>