### PR TITLE
Allow resources to be modified with Terraform if the `default` property is modified to `true`

### DIFF
--- a/.changelog/747.txt
+++ b/.changelog/747.txt
@@ -1,0 +1,31 @@
+```release-note:note
+`resource/pingone_sign_on_policy`: Migrated to plugin framework.
+```
+
+```release-note:note
+`resource/pingone_notification_policy`: Corrected documentation HCL examples.
+```
+
+```release-note:bug
+`resource/pingone_key`: Fixed unnecessary replacement plan when certain properties are modified.
+```
+
+```release-note:bug
+`resource/pingone_notification_policy`: The resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
+```
+
+```release-note:bug
+`resource/pingone_mfa_fido2_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
+```
+
+```release-note:bug
+`resource/pingone_risk_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
+```
+
+```release-note:bug
+`resource/pingone_sign_on_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
+```
+
+```release-note:bug
+`resource/pingone_verify_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
+```

--- a/docs/resources/notification_policy.md
+++ b/docs/resources/notification_policy.md
@@ -19,7 +19,7 @@ resource "pingone_environment" "my_environment" {
 resource "pingone_notification_policy" "unlimited" {
   environment_id = pingone_environment.my_environment.id
 
-  name = "Unlimited Quotas SMS, Voice and Email"
+  name = "Unlimited Quotas SMS Voice and Email"
 }
 ```
 
@@ -33,7 +33,7 @@ resource "pingone_environment" "my_environment" {
 resource "pingone_notification_policy" "environment" {
   environment_id = pingone_environment.my_environment.id
 
-  name = "Environment Quota SMS, Voice and Email"
+  name = "Environment Quota SMS Voice and Email"
 
   quota {
     type             = "ENVIRONMENT"
@@ -59,7 +59,7 @@ resource "pingone_environment" "my_environment" {
 resource "pingone_notification_policy" "user" {
   environment_id = pingone_environment.my_environment.id
 
-  name = "User Quota SMS, Voice and Email"
+  name = "User Quota SMS Voice and Email"
 
   quota {
     type             = "USER"

--- a/docs/resources/sign_on_policy.md
+++ b/docs/resources/sign_on_policy.md
@@ -2,12 +2,12 @@
 page_title: "pingone_sign_on_policy Resource - terraform-provider-pingone"
 subcategory: "SSO"
 description: |-
-  Resource to create and manage PingOne sign on policies
+  Resource to create and manage PingOne sign-on policies in an environment.
 ---
 
 # pingone_sign_on_policy (Resource)
 
-Resource to create and manage PingOne sign on policies
+Resource to create and manage PingOne sign-on policies in an environment.
 
 ~> A warning will be issued following `terraform apply` when attempting to remove the final sign-on policy action from an associated sign-on policy.  When removing the final sign-on policy action from a sign-on policy, it's recommended to also remove the associated sign-on policy at the same time.  Further information can be found [here](https://github.com/pingidentity/terraform-provider-pingone/issues/68).
 
@@ -76,15 +76,16 @@ resource "pingone_sign_on_policy_action" "my_policy_mfa" {
 
 ### Required
 
-- `environment_id` (String) The ID of the environment to create the sign on policy in.
-- `name` (String) A string that specifies the resource name. The name must be unique within the environment, and can consist of either a string of alphanumeric letters, underscore, hyphen, period `^[a-zA-Z0-9_.-]+$` or an absolute URI if the string contains a `:` character.
+- `environment_id` (String) The ID of the environment to manage the sign-on policy in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `name` (String) A string that specifies the sign on policy name, that is also used as the authentication context when initiating sign-on. The name must be unique within the environment, and can consist of either a string of alphanumeric letters, underscore, hyphen, period (regex `^[a-zA-Z0-9_.-]+$`) or an absolute URI if the string contains a `:` character.
 
 ### Optional
 
-- `description` (String) A string that specifies the description of the sign-on policy.
+- `description` (String) A string that specifies the description to apply to the sign-on policy.
 
 ### Read-Only
 
+- `default` (Boolean) A boolean that describes whether this policy should serve as the default sign-on policy for the environment.
 - `id` (String) The ID of this resource.
 
 ## Import

--- a/examples/resources/pingone_notification_policy/resource-environment.tf
+++ b/examples/resources/pingone_notification_policy/resource-environment.tf
@@ -5,7 +5,7 @@ resource "pingone_environment" "my_environment" {
 resource "pingone_notification_policy" "environment" {
   environment_id = pingone_environment.my_environment.id
 
-  name = "Environment Quota SMS, Voice and Email"
+  name = "Environment Quota SMS Voice and Email"
 
   quota {
     type             = "ENVIRONMENT"

--- a/examples/resources/pingone_notification_policy/resource-unlimited.tf
+++ b/examples/resources/pingone_notification_policy/resource-unlimited.tf
@@ -5,5 +5,5 @@ resource "pingone_environment" "my_environment" {
 resource "pingone_notification_policy" "unlimited" {
   environment_id = pingone_environment.my_environment.id
 
-  name = "Unlimited Quotas SMS, Voice and Email"
+  name = "Unlimited Quotas SMS Voice and Email"
 }

--- a/examples/resources/pingone_notification_policy/resource-user.tf
+++ b/examples/resources/pingone_notification_policy/resource-user.tf
@@ -5,7 +5,7 @@ resource "pingone_environment" "my_environment" {
 resource "pingone_notification_policy" "user" {
   environment_id = pingone_environment.my_environment.id
 
-  name = "User Quota SMS, Voice and Email"
+  name = "User Quota SMS Voice and Email"
 
   quota {
     type             = "USER"

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -126,7 +126,6 @@ func New(version string) func() *schema.Provider {
 				"pingone_application_sign_on_policy_assignment": sso.ResourceApplicationSignOnPolicyAssignment(),
 				"pingone_password_policy":                       sso.ResourcePasswordPolicy(),
 				"pingone_resource":                              sso.ResourceResource(),
-				"pingone_sign_on_policy":                        sso.ResourceSignOnPolicy(),
 				"pingone_sign_on_policy_action":                 sso.ResourceSignOnPolicyAction(),
 
 				"pingone_mfa_fido_policy": mfa.ResourceFIDOPolicy(),

--- a/internal/service/base/resource_key.go
+++ b/internal/service/base/resource_key.go
@@ -234,6 +234,7 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 
 				Validators: []validator.String{
@@ -286,6 +287,7 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 
 				Validators: []validator.String{

--- a/internal/service/base/resource_notification_policy.go
+++ b/internal/service/base/resource_notification_policy.go
@@ -648,7 +648,12 @@ func (p *NotificationPolicyResourceModel) expand(ctx context.Context) (*manageme
 	}
 
 	data := management.NewNotificationsPolicy(p.Name.ValueString(), quotas)
-	data.SetDefault(false)
+
+	if !p.Default.IsNull() && !p.Default.IsUnknown() {
+		data.SetDefault(p.Default.ValueBool())
+	} else {
+		data.SetDefault(false)
+	}
 
 	if !p.CountryLimit.IsNull() && !p.CountryLimit.IsUnknown() {
 		var countryLimitPlan NotificationPolicyCountryLimitResourceModel

--- a/internal/service/mfa/resource_fido2_policy.go
+++ b/internal/service/mfa/resource_fido2_policy.go
@@ -855,7 +855,11 @@ func (p *FIDO2PolicyResourceModel) expand(ctx context.Context) (*mfa.FIDO2Policy
 		data.SetDescription(p.Description.ValueString())
 	}
 
-	data.SetDefault(false)
+	if !p.Default.IsNull() && !p.Default.IsUnknown() {
+		data.SetDefault(p.Default.ValueBool())
+	} else {
+		data.SetDefault(false)
+	}
 
 	return data, diags
 }

--- a/internal/service/risk/resource_risk_policy.go
+++ b/internal/service/risk/resource_risk_policy.go
@@ -1141,7 +1141,12 @@ func (p *riskPolicyResourceModel) expand(ctx context.Context, apiClient *risk.AP
 	var diags diag.Diagnostics
 
 	data := risk.NewRiskPolicySet(p.Name.ValueString())
-	data.SetDefault(false)
+
+	if !p.Default.IsNull() && !p.Default.IsUnknown() {
+		data.SetDefault(p.Default.ValueBool())
+	} else {
+		data.SetDefault(false)
+	}
 
 	if !p.DefaultResult.IsNull() && !p.DefaultResult.IsUnknown() {
 		var plan riskPolicyResourceDefaultResultModel

--- a/internal/service/sso/resource_sign_on_policy.go
+++ b/internal/service/sso/resource_sign_on_policy.go
@@ -2,185 +2,298 @@ package sso
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
-	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
 	"github.com/pingidentity/terraform-provider-pingone/internal/verify"
 )
 
-func ResourceSignOnPolicy() *schema.Resource {
-	return &schema.Resource{
+// Types
+type SignOnPolicyResource serviceClientType
 
+type SignOnPolicyResourceModel struct {
+	Id            types.String `tfsdk:"id"`
+	EnvironmentId types.String `tfsdk:"environment_id"`
+	Name          types.String `tfsdk:"name"`
+	Description   types.String `tfsdk:"description"`
+	Default       types.Bool   `tfsdk:"default"`
+}
+
+// Framework interfaces
+var (
+	_ resource.Resource                = &SignOnPolicyResource{}
+	_ resource.ResourceWithConfigure   = &SignOnPolicyResource{}
+	_ resource.ResourceWithImportState = &SignOnPolicyResource{}
+)
+
+// New Object
+func NewSignOnPolicyResource() resource.Resource {
+	return &SignOnPolicyResource{}
+}
+
+// Metadata
+func (r *SignOnPolicyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_sign_on_policy"
+}
+
+// Schema.
+func (r *SignOnPolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+
+	const attrMinLength = 1
+
+	nameDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A string that specifies the sign on policy name, that is also used as the authentication context when initiating sign-on. The name must be unique within the environment, and can consist of either a string of alphanumeric letters, underscore, hyphen, period (regex `^[a-zA-Z0-9_.-]+$`) or an absolute URI if the string contains a `:` character.",
+	)
+
+	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		Description: "Resource to create and manage PingOne sign on policies",
+		Description: "Resource to create and manage PingOne sign-on policies in an environment.",
 
-		CreateContext: resourceSignOnPolicyCreate,
-		ReadContext:   resourceSignOnPolicyRead,
-		UpdateContext: resourceSignOnPolicyUpdate,
-		DeleteContext: resourceSignOnPolicyDelete,
+		Attributes: map[string]schema.Attribute{
+			"id": framework.Attr_ID(),
 
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceSignOnPolicyImport,
-		},
+			"environment_id": framework.Attr_LinkID(
+				framework.SchemaAttributeDescriptionFromMarkdown("The ID of the environment to manage the sign-on policy in."),
+			),
 
-		Schema: map[string]*schema.Schema{
-			"environment_id": {
-				Description:      "The ID of the environment to create the sign on policy in.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
+			"name": schema.StringAttribute{
+				Description:         nameDescription.Description,
+				MarkdownDescription: nameDescription.MarkdownDescription,
+				Required:            true,
+
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(attrMinLength),
+					stringvalidator.RegexMatches(regexp.MustCompile(`(^[a-zA-Z0-9_.-]+$)|(^(.+:\/\/)[^ :]+$)`), "Names must consist of either a string of alphanumeric letters, underscore, hyphen, period (regex `^[a-zA-Z0-9_.-]+$`) or an absolute URI if the string contains a `:` character."),
+				},
 			},
-			"name": {
-				Description:      "A string that specifies the resource name. The name must be unique within the environment, and can consist of either a string of alphanumeric letters, underscore, hyphen, period `^[a-zA-Z0-9_.-]+$` or an absolute URI if the string contains a `:` character.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(`(^[a-zA-Z0-9_.-]+$)|(^(.+:\/\/)[^ :]+$)`), "Names must consist of either a string of alphanumeric letters, underscore, hyphen, period `^[a-zA-Z0-9_.-]+$` or an absolute URI if the string contains a `:` character.")),
-			},
-			"description": {
-				Description: "A string that specifies the description of the sign-on policy.",
-				Type:        schema.TypeString,
+
+			"description": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the description to apply to the sign-on policy.").Description,
 				Optional:    true,
 			},
+
+			"default": schema.BoolAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A boolean that describes whether this policy should serve as the default sign-on policy for the environment.").Description,
+				Computed:    true,
+
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
 
-func resourceSignOnPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.ManagementAPIClient
-
-	var diags diag.Diagnostics
-
-	signOnPolicy := *management.NewSignOnPolicy(d.Get("name").(string))
-
-	if v, ok := d.GetOk("description"); ok {
-		signOnPolicy.SetDescription(v.(string))
+func (r *SignOnPolicyResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
 	}
 
-	resp, diags := sdk.ParseResponse(
+	resourceConfig, ok := req.ProviderData.(framework.ResourceType)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected the provider client, got: %T. Please report this issue to the provider maintainers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.Client = resourceConfig.Client.API
+	if r.Client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialised",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.",
+		)
+		return
+	}
+}
+
+func (r *SignOnPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan, state SignOnPolicyResourceModel
+
+	if r.Client.ManagementAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Build the model for the API
+	signOnPolicy := plan.expand()
+
+	// Run the API call
+	var response *management.SignOnPolicy
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.SignOnPoliciesApi.CreateSignOnPolicy(ctx, d.Get("environment_id").(string)).SignOnPolicy(signOnPolicy).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, apiClient, d.Get("environment_id").(string), fO, fR, fErr)
+			fO, fR, fErr := r.Client.ManagementAPIClient.SignOnPoliciesApi.CreateSignOnPolicy(ctx, plan.EnvironmentId.ValueString()).SignOnPolicy(*signOnPolicy).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, plan.EnvironmentId.ValueString(), fO, fR, fErr)
 		},
 		"CreateSignOnPolicy",
-		sdk.DefaultCustomError,
+		framework.DefaultCustomError,
 		sdk.DefaultCreateReadRetryable,
-	)
-	if diags.HasError() {
-		return diags
+		&response,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	respObject := resp.(*management.SignOnPolicy)
+	// Create the state to save
+	state = plan
 
-	d.SetId(respObject.GetId())
-
-	return resourceSignOnPolicyRead(ctx, d, meta)
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(state.toState(response)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func resourceSignOnPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.ManagementAPIClient
+func (r *SignOnPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *SignOnPolicyResourceModel
 
-	var diags diag.Diagnostics
+	if r.Client.ManagementAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
 
-	resp, diags := sdk.ParseResponse(
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	var response *management.SignOnPolicy
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.SignOnPoliciesApi.ReadOneSignOnPolicy(ctx, d.Get("environment_id").(string), d.Id()).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, apiClient, d.Get("environment_id").(string), fO, fR, fErr)
+			fO, fR, fErr := r.Client.ManagementAPIClient.SignOnPoliciesApi.ReadOneSignOnPolicy(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString()).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, data.EnvironmentId.ValueString(), fO, fR, fErr)
 		},
 		"ReadOneSignOnPolicy",
-		sdk.CustomErrorResourceNotFoundWarning,
+		framework.CustomErrorResourceNotFoundWarning,
 		sdk.DefaultCreateReadRetryable,
-	)
-	if diags.HasError() {
-		return diags
+		&response,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if resp == nil {
-		d.SetId("")
-		return nil
+	// Remove from state if resource is not found
+	if response == nil {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
-	respObject := resp.(*management.SignOnPolicy)
-
-	d.Set("name", respObject.GetName())
-
-	if v, ok := respObject.GetDescriptionOk(); ok {
-		d.Set("description", v)
-	} else {
-		d.Set("description", nil)
-	}
-
-	return diags
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(data.toState(response)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func resourceSignOnPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.ManagementAPIClient
+func (r *SignOnPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state SignOnPolicyResourceModel
 
-	var diags diag.Diagnostics
-
-	signOnPolicy := *management.NewSignOnPolicy(d.Get("name").(string))
-
-	if v, ok := d.GetOk("description"); ok {
-		signOnPolicy.SetDescription(v.(string))
+	if r.Client.ManagementAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
 	}
 
-	_, diags = sdk.ParseResponse(
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Build the model for the API
+	signOnPolicy := plan.expand()
+
+	// Run the API call
+	var response *management.SignOnPolicy
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.SignOnPoliciesApi.UpdateSignOnPolicy(ctx, d.Get("environment_id").(string), d.Id()).SignOnPolicy(signOnPolicy).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, apiClient, d.Get("environment_id").(string), fO, fR, fErr)
+			fO, fR, fErr := r.Client.ManagementAPIClient.SignOnPoliciesApi.UpdateSignOnPolicy(ctx, plan.EnvironmentId.ValueString(), plan.Id.ValueString()).SignOnPolicy(*signOnPolicy).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, plan.EnvironmentId.ValueString(), fO, fR, fErr)
 		},
 		"UpdateSignOnPolicy",
-		sdk.DefaultCustomError,
+		framework.DefaultCustomError,
 		nil,
-	)
-	if diags.HasError() {
-		return diags
+		&response,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return resourceSignOnPolicyRead(ctx, d, meta)
+	// Create the state to save
+	state = plan
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(state.toState(response)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func resourceSignOnPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.ManagementAPIClient
+func (r *SignOnPolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *SignOnPolicyResourceModel
 
-	var diags diag.Diagnostics
+	if r.Client.ManagementAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
 
-	_, diags = sdk.ParseResponse(
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fR, fErr := apiClient.SignOnPoliciesApi.DeleteSignOnPolicy(ctx, d.Get("environment_id").(string), d.Id()).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, apiClient, d.Get("environment_id").(string), nil, fR, fErr)
+			fR, fErr := r.Client.ManagementAPIClient.SignOnPoliciesApi.DeleteSignOnPolicy(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString()).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, data.EnvironmentId.ValueString(), nil, fR, fErr)
 		},
 		"DeleteSignOnPolicy",
-		sdk.CustomErrorResourceNotFoundWarning,
+		framework.CustomErrorResourceNotFoundWarning,
 		nil,
-	)
-	if diags.HasError() {
-		return diags
-	}
+		nil,
+	)...)
 
-	return diags
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
-func resourceSignOnPolicyImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func (r *SignOnPolicyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 
 	idComponents := []framework.ImportComponent{
 		{
@@ -188,20 +301,66 @@ func resourceSignOnPolicyImport(ctx context.Context, d *schema.ResourceData, met
 			Regexp: verify.P1ResourceIDRegexp,
 		},
 		{
-			Label:  "sign_on_policy_id",
-			Regexp: verify.P1ResourceIDRegexp,
+			Label:     "sign_on_policy_id",
+			Regexp:    verify.P1ResourceIDRegexp,
+			PrimaryID: true,
 		},
 	}
 
-	attributes, err := framework.ParseImportID(d.Id(), idComponents...)
+	attributes, err := framework.ParseImportID(req.ID, idComponents...)
 	if err != nil {
-		return nil, err
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			err.Error(),
+		)
+		return
 	}
 
-	d.Set("environment_id", attributes["environment_id"])
-	d.SetId(attributes["sign_on_policy_id"])
+	for _, idComponent := range idComponents {
+		pathKey := idComponent.Label
 
-	resourceSignOnPolicyRead(ctx, d, meta)
+		if idComponent.PrimaryID {
+			pathKey = "id"
+		}
 
-	return []*schema.ResourceData{d}, nil
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(pathKey), attributes[idComponent.Label])...)
+	}
+}
+
+func (p *SignOnPolicyResourceModel) expand() *management.SignOnPolicy {
+
+	data := management.NewSignOnPolicy(p.Name.ValueString())
+
+	if !p.Description.IsNull() && !p.Description.IsUnknown() {
+		data.SetDescription(p.Description.ValueString())
+	}
+
+	if !p.Default.IsNull() && !p.Default.IsUnknown() {
+		data.SetDefault(p.Default.ValueBool())
+	} else {
+		data.SetDefault(false)
+	}
+
+	return data
+}
+
+func (p *SignOnPolicyResourceModel) toState(apiObject *management.SignOnPolicy) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if apiObject == nil {
+		diags.AddError(
+			"Data object missing",
+			"Cannot convert the data object to state as the data object is nil.  Please report this to the provider maintainers.",
+		)
+
+		return diags
+	}
+
+	p.Id = framework.StringOkToTF(apiObject.GetIdOk())
+	p.EnvironmentId = framework.StringOkToTF(apiObject.Environment.GetIdOk())
+	p.Name = framework.StringOkToTF(apiObject.GetNameOk())
+	p.Description = framework.StringOkToTF(apiObject.GetDescriptionOk())
+	p.Default = framework.BoolOkToTF(apiObject.GetDefaultOk())
+
+	return diags
 }

--- a/internal/service/sso/resource_sign_on_policy_test.go
+++ b/internal/service/sso/resource_sign_on_policy_test.go
@@ -129,6 +129,7 @@ func TestAccSignOnPolicy_Full(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "description", "Test description"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 			// Test importing the resource
@@ -174,7 +175,8 @@ func TestAccSignOnPolicy_Minimal(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
-					resource.TestCheckResourceAttr(resourceFullName, "description", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 		},
@@ -204,7 +206,8 @@ func TestAccSignOnPolicy_Update(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
-					resource.TestCheckResourceAttr(resourceFullName, "description", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 			{
@@ -214,6 +217,7 @@ func TestAccSignOnPolicy_Update(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "description", "Test description"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 			{
@@ -222,7 +226,8 @@ func TestAccSignOnPolicy_Update(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
-					resource.TestCheckResourceAttr(resourceFullName, "description", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 		},
@@ -254,19 +259,19 @@ func TestAccSignOnPolicy_BadParameters(t *testing.T) {
 			{
 				ResourceName: resourceFullName,
 				ImportState:  true,
-				ExpectError:  regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/sign_on_policy_id" and must match regex: .*`),
+				ExpectError:  regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 			{
 				ResourceName:  resourceFullName,
 				ImportStateId: "/",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/sign_on_policy_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 			{
 				ResourceName:  resourceFullName,
 				ImportStateId: "badformat/badformat",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/sign_on_policy_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 		},
 	})

--- a/internal/service/sso/service.go
+++ b/internal/service/sso/service.go
@@ -29,6 +29,7 @@ func Resources() []func() resource.Resource {
 		NewResourceScopePingOneAPIResource,
 		NewResourceScopeResource,
 		NewSchemaAttributeResource,
+		NewSignOnPolicyResource,
 		NewUserGroupAssignmentResource,
 		NewUserResource,
 	}

--- a/internal/service/verify/resource_verify_policy.go
+++ b/internal/service/verify/resource_verify_policy.go
@@ -433,8 +433,6 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 				Description:         defaultDescription.Description,
 				MarkdownDescription: defaultDescription.MarkdownDescription,
 				Computed:            true,
-
-				Default: booldefault.StaticBool(false),
 			},
 
 			"description": schema.StringAttribute{
@@ -1665,9 +1663,12 @@ func (p *verifyPolicyResourceModel) expand(ctx context.Context) (*verify.VerifyP
 		data.SetDescription(p.Description.ValueString())
 	}
 
-	// Verify policies managed via TF currently cannot be set to the default policy due to a potential lock situation or state management problem.
 	// The verify policy will also have default set to false.
-	data.SetDefault(false)
+	if !p.Default.IsNull() && !p.Default.IsUnknown() {
+		data.SetDefault(p.Default.ValueBool())
+	} else {
+		data.SetDefault(false)
+	}
 
 	return data, diags
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_sign_on_policy`: Migrated to plugin framework.
- `resource/pingone_notification_policy`: Corrected documentation HCL examples.
- `resource/pingone_key`: Fixed unnecessary replacement plan when certain properties are modified.
- `resource/pingone_notification_policy`: The resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
- `resource/pingone_mfa_fido2_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
- `resource/pingone_risk_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
- `resource/pingone_sign_on_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
- `resource/pingone_verify_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.


### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccSignOnPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso && \
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccKey_ github.com/pingidentity/terraform-provider-pingone/internal/service/base && \
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccNotificationPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/base && \
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccFIDO2Policy_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa && \
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccVerifyPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/verify
```

(Risk policy testing deferred due to conflicting issues)

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccSignOnPolicy_RemovalDrift
=== PAUSE TestAccSignOnPolicy_RemovalDrift
=== RUN   TestAccSignOnPolicy_NewEnv
=== PAUSE TestAccSignOnPolicy_NewEnv
=== RUN   TestAccSignOnPolicy_Full
=== PAUSE TestAccSignOnPolicy_Full
=== RUN   TestAccSignOnPolicy_Minimal
=== PAUSE TestAccSignOnPolicy_Minimal
=== RUN   TestAccSignOnPolicy_Update
=== PAUSE TestAccSignOnPolicy_Update
=== RUN   TestAccSignOnPolicy_BadParameters
=== PAUSE TestAccSignOnPolicy_BadParameters
=== CONT  TestAccSignOnPolicy_RemovalDrift
=== CONT  TestAccSignOnPolicy_Minimal
=== CONT  TestAccSignOnPolicy_BadParameters
=== CONT  TestAccSignOnPolicy_Update
=== CONT  TestAccSignOnPolicy_NewEnv
=== CONT  TestAccSignOnPolicy_Full
--- PASS: TestAccSignOnPolicy_Minimal (6.30s)
--- PASS: TestAccSignOnPolicy_Full (8.63s)
--- PASS: TestAccSignOnPolicy_BadParameters (8.63s)
--- PASS: TestAccSignOnPolicy_Update (10.87s)
--- PASS: TestAccSignOnPolicy_NewEnv (13.51s)
--- PASS: TestAccSignOnPolicy_RemovalDrift (17.20s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso (cached)
=== RUN   TestAccKey_RemovalDrift
=== PAUSE TestAccKey_RemovalDrift
=== RUN   TestAccKey_Full
=== PAUSE TestAccKey_Full
=== RUN   TestAccKey_Minimal
=== PAUSE TestAccKey_Minimal
=== RUN   TestAccKey_PKCS12
=== PAUSE TestAccKey_PKCS12
=== RUN   TestAccKey_Change
=== PAUSE TestAccKey_Change
=== RUN   TestAccKey_CustomCRL
=== PAUSE TestAccKey_CustomCRL
=== RUN   TestAccKey_BadParameters
=== PAUSE TestAccKey_BadParameters
=== CONT  TestAccKey_RemovalDrift
=== CONT  TestAccKey_BadParameters
=== CONT  TestAccKey_Minimal
=== CONT  TestAccKey_CustomCRL
=== CONT  TestAccKey_Full
=== CONT  TestAccKey_Change
=== CONT  TestAccKey_PKCS12
--- PASS: TestAccKey_Minimal (14.26s)
--- PASS: TestAccKey_CustomCRL (17.54s)
--- PASS: TestAccKey_BadParameters (17.70s)
--- PASS: TestAccKey_PKCS12 (21.51s)
--- PASS: TestAccKey_RemovalDrift (26.40s)
--- PASS: TestAccKey_Full (38.68s)
--- PASS: TestAccKey_Change (45.06s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        (cached)
=== RUN   TestAccNotificationPolicy_RemovalDrift
=== PAUSE TestAccNotificationPolicy_RemovalDrift
=== RUN   TestAccNotificationPolicy_NewEnv
=== PAUSE TestAccNotificationPolicy_NewEnv
=== RUN   TestAccNotificationPolicy_Full
=== PAUSE TestAccNotificationPolicy_Full
=== RUN   TestAccNotificationPolicy_Quotas
=== PAUSE TestAccNotificationPolicy_Quotas
=== RUN   TestAccNotificationPolicy_CountryLimit
=== PAUSE TestAccNotificationPolicy_CountryLimit
=== RUN   TestAccNotificationPolicy_BadParameters
=== PAUSE TestAccNotificationPolicy_BadParameters
=== CONT  TestAccNotificationPolicy_RemovalDrift
=== CONT  TestAccNotificationPolicy_Quotas
=== CONT  TestAccNotificationPolicy_Full
=== CONT  TestAccNotificationPolicy_NewEnv
=== CONT  TestAccNotificationPolicy_CountryLimit
=== CONT  TestAccNotificationPolicy_BadParameters
--- PASS: TestAccNotificationPolicy_BadParameters (7.90s)
--- PASS: TestAccNotificationPolicy_NewEnv (12.97s)
--- PASS: TestAccNotificationPolicy_RemovalDrift (16.21s)
--- PASS: TestAccNotificationPolicy_Full (22.28s)
--- PASS: TestAccNotificationPolicy_Quotas (31.06s)
--- PASS: TestAccNotificationPolicy_CountryLimit (32.53s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        (cached)
=== RUN   TestAccFIDO2Policy_RemovalDrift
=== PAUSE TestAccFIDO2Policy_RemovalDrift
=== RUN   TestAccFIDO2Policy_NewEnv
=== PAUSE TestAccFIDO2Policy_NewEnv
=== RUN   TestAccFIDO2Policy_Full
=== PAUSE TestAccFIDO2Policy_Full
=== RUN   TestAccFIDO2Policy_Errors
=== PAUSE TestAccFIDO2Policy_Errors
=== RUN   TestAccFIDO2Policy_BadParameters
=== PAUSE TestAccFIDO2Policy_BadParameters
=== CONT  TestAccFIDO2Policy_RemovalDrift
=== CONT  TestAccFIDO2Policy_Errors
=== CONT  TestAccFIDO2Policy_Full
=== CONT  TestAccFIDO2Policy_BadParameters
=== CONT  TestAccFIDO2Policy_NewEnv
--- PASS: TestAccFIDO2Policy_Errors (1.20s)
--- PASS: TestAccFIDO2Policy_BadParameters (7.67s)
--- PASS: TestAccFIDO2Policy_NewEnv (12.99s)
--- PASS: TestAccFIDO2Policy_RemovalDrift (16.82s)
--- PASS: TestAccFIDO2Policy_Full (23.59s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/mfa (cached)
=== RUN   TestAccVerifyPolicy_RemovalDrift
=== PAUSE TestAccVerifyPolicy_RemovalDrift
=== RUN   TestAccVerifyPolicy_NewEnv
=== PAUSE TestAccVerifyPolicy_NewEnv
=== RUN   TestAccVerifyPolicy_Full
=== PAUSE TestAccVerifyPolicy_Full
=== RUN   TestAccVerifyPolicy_ValidationChecks
=== PAUSE TestAccVerifyPolicy_ValidationChecks
=== RUN   TestAccVerifyPolicy_BadParameters
=== PAUSE TestAccVerifyPolicy_BadParameters
=== CONT  TestAccVerifyPolicy_RemovalDrift
=== CONT  TestAccVerifyPolicy_ValidationChecks
=== CONT  TestAccVerifyPolicy_Full
=== CONT  TestAccVerifyPolicy_NewEnv
=== CONT  TestAccVerifyPolicy_BadParameters
--- PASS: TestAccVerifyPolicy_ValidationChecks (1.36s)
--- PASS: TestAccVerifyPolicy_BadParameters (7.69s)
--- PASS: TestAccVerifyPolicy_NewEnv (14.69s)
--- PASS: TestAccVerifyPolicy_RemovalDrift (20.22s)
--- PASS: TestAccVerifyPolicy_Full (27.47s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/verify      28.791s
```

</details>