### PR TITLE
Fix "Cannot find risk predictor from compact name" error

### DIFF
--- a/.changelog/748.txt
+++ b/.changelog/748.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/pingone_risk_policy`: Fixed "Cannot find risk predictor from compact name" error when applying a policy containing "bot detection", "new device" or "adversary in the middle" predictors.
+```
+
+```release-note:bug
+`resource/pingone_risk_policy`: Provider now waits for confirmation that, on destroy, the risk policy has been successfully removed in the environment.
+```

--- a/internal/service/risk/resource_risk_policy.go
+++ b/internal/service/risk/resource_risk_policy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -1045,6 +1046,8 @@ func (r *RiskPolicyResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Create the state to save
 	state = plan
+
+	time.Sleep(60 * time.Second)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(state.toState(response)...)

--- a/internal/service/risk/resource_risk_policy.go
+++ b/internal/service/risk/resource_risk_policy.go
@@ -1049,8 +1049,6 @@ func (r *RiskPolicyResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Create the state to save
 	state = plan
 
-	time.Sleep(60 * time.Second)
-
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(state.toState(response)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_risk_policy`: Fixed "Cannot find risk predictor from compact name" error when applying a policy containing "bot detection", "new device" or "adversary in the middle" predictors.
- `resource/pingone_risk_policy`: Provider now waits for confirmation that, on destroy, the risk policy has been successfully removed in the environment.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccRiskPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/risk
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

**Note** Testing includes workaround for state inconsistency issue raised in STAGING-22374

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccRiskPolicy_RemovalDrift
=== PAUSE TestAccRiskPolicy_RemovalDrift
=== RUN   TestAccRiskPolicy_NewEnv
=== PAUSE TestAccRiskPolicy_NewEnv
=== RUN   TestAccRiskPolicy_Full
=== PAUSE TestAccRiskPolicy_Full
=== RUN   TestAccRiskPolicy_Scores
=== PAUSE TestAccRiskPolicy_Scores
=== RUN   TestAccRiskPolicy_Weights
=== PAUSE TestAccRiskPolicy_Weights
=== RUN   TestAccRiskPolicy_ChangeType
=== PAUSE TestAccRiskPolicy_ChangeType
=== RUN   TestAccRiskPolicy_PolicyOverrides
=== PAUSE TestAccRiskPolicy_PolicyOverrides
=== RUN   TestAccRiskPolicy_BadParameters
=== PAUSE TestAccRiskPolicy_BadParameters
=== CONT  TestAccRiskPolicy_RemovalDrift
=== CONT  TestAccRiskPolicy_Weights
=== CONT  TestAccRiskPolicy_PolicyOverrides
=== CONT  TestAccRiskPolicy_Full
=== CONT  TestAccRiskPolicy_ChangeType
=== CONT  TestAccRiskPolicy_BadParameters
=== CONT  TestAccRiskPolicy_NewEnv
=== CONT  TestAccRiskPolicy_Scores
--- PASS: TestAccRiskPolicy_BadParameters (10.47s)
--- PASS: TestAccRiskPolicy_NewEnv (17.95s)
--- PASS: TestAccRiskPolicy_RemovalDrift (20.45s)
--- PASS: TestAccRiskPolicy_ChangeType (134.60s)
--- PASS: TestAccRiskPolicy_Full (154.11s)
--- PASS: TestAccRiskPolicy_Weights (158.22s)
--- PASS: TestAccRiskPolicy_Scores (167.70s)
--- PASS: TestAccRiskPolicy_PolicyOverrides (179.75s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/risk        181.056s
```

</details>