### PR TITLE
`resource/pingone_risk_policy`: Fix unconfigured predictors with weight/score of 0

### DIFF
--- a/.changelog/751.txt
+++ b/.changelog/751.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/pingone_risk_policy`: Fixed unconfigured predictors (predictors not configured in the policy) are included with a weight/score of 0.
+`resource/pingone_risk_policy`: Fixed predictors not configured in the policy get included with a weight/score of 0.
 ```

--- a/.changelog/751.txt
+++ b/.changelog/751.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/pingone_risk_policy`: Fixed predictors, that are not configured in the policy, get included with a weight/score of 0.
+`resource/pingone_risk_policy`: Fix for predictors, that are not configured in the policy, get included with a weight/score of 0.
 ```

--- a/.changelog/751.txt
+++ b/.changelog/751.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_risk_policy`: Fixed unconfigured predictors (predictors not configured in the policy) are included with a weight/score of 0.
+```

--- a/.changelog/751.txt
+++ b/.changelog/751.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/pingone_risk_policy`: Fixed predictors not configured in the policy get included with a weight/score of 0.
+`resource/pingone_risk_policy`: Fixed predictors, that are not configured in the policy, get included with a weight/score of 0.
 ```

--- a/internal/service/risk/resource_risk_policy.go
+++ b/internal/service/risk/resource_risk_policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -702,10 +703,32 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 		return
 	}
 
-	var plan riskPolicyResourceModel
+	var plan, state, config riskPolicyResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Evaluated Predictors
+	setEvaluatedPredictorsToUnknown := false
+
+	if !req.State.Raw.IsNull() && config.EvaluatedPredictors.IsNull() {
+		resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// If the policy is different, set the evaluated predictors as unknown
+		if plan.PolicyScores.IsUnknown() || plan.PolicyWeights.IsUnknown() {
+			setEvaluatedPredictorsToUnknown = true
+		} else if (state.PolicyScores.IsNull() && !plan.PolicyScores.IsNull()) || (state.PolicyWeights.IsNull() && !plan.PolicyWeights.IsNull()) {
+			setEvaluatedPredictorsToUnknown = true
+		}
 	}
 
 	// Set the max threshold score
@@ -720,10 +743,19 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 		referenceValueFmt = "${details.aggregatedWeights.%s}"
 		predictorAttrType = policyWeightsPredictorTFObjectTypes
 
-		var predictorsPlan []riskPolicyResourcePolicyWeightsPredictorModel
+		var predictorsPlan, predictorsState []riskPolicyResourcePolicyWeightsPredictorModel
 		resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root(rootPath).AtName("predictors"), &predictorsPlan)...)
 		if resp.Diagnostics.HasError() {
 			return
+		}
+
+		resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root(rootPath).AtName("predictors"), &predictorsState)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !req.State.Raw.IsNull() && config.EvaluatedPredictors.IsNull() && len(predictorsState) != len(predictorsPlan) {
+			setEvaluatedPredictorsToUnknown = true
 		}
 
 		for _, predictor := range predictorsPlan {
@@ -731,6 +763,20 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 				"predictor_reference_value": framework.StringToTF(fmt.Sprintf(referenceValueFmt, predictor.CompactName.ValueString())),
 				"compact_name":              predictor.CompactName,
 				"weight":                    predictor.Weight,
+			}
+
+			if config.EvaluatedPredictors.IsNull() && !setEvaluatedPredictorsToUnknown {
+				found := false
+				for _, statePredictor := range predictorsState {
+					if statePredictor.CompactName.Equal(predictor.CompactName) {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					setEvaluatedPredictorsToUnknown = true
+				}
 			}
 
 			flattenedObj, d := types.ObjectValue(policyWeightsPredictorTFObjectTypes, predictorObj)
@@ -746,10 +792,19 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 		referenceValueFmt = "${details.%s.level}"
 		predictorAttrType = policyScoresPredictorTFObjectTypes
 
-		var predictorsPlan []riskPolicyResourcePolicyScoresPredictorModel
+		var predictorsPlan, predictorsState []riskPolicyResourcePolicyScoresPredictorModel
 		resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root(rootPath).AtName("predictors"), &predictorsPlan)...)
 		if resp.Diagnostics.HasError() {
 			return
+		}
+
+		resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root(rootPath).AtName("predictors"), &predictorsState)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !req.State.Raw.IsNull() && config.EvaluatedPredictors.IsNull() && len(predictorsState) != len(predictorsPlan) {
+			setEvaluatedPredictorsToUnknown = true
 		}
 
 		for _, predictor := range predictorsPlan {
@@ -757,6 +812,20 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 				"predictor_reference_value": framework.StringToTF(fmt.Sprintf(referenceValueFmt, predictor.CompactName.ValueString())),
 				"compact_name":              predictor.CompactName,
 				"score":                     predictor.Score,
+			}
+
+			if config.EvaluatedPredictors.IsNull() && !setEvaluatedPredictorsToUnknown {
+				found := false
+				for _, statePredictor := range predictorsState {
+					if statePredictor.CompactName.Equal(predictor.CompactName) {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					setEvaluatedPredictorsToUnknown = true
+				}
 			}
 
 			flattenedObj, d := types.ObjectValue(policyScoresPredictorTFObjectTypes, predictorObj)
@@ -864,6 +933,10 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 		plannedOverrides, d := types.ListValue(types.ObjectType{AttrTypes: overridesTFObjectTypes}, flattenedOverrideList)
 		resp.Diagnostics.Append(d...)
 		resp.Plan.SetAttribute(ctx, path.Root("overrides"), plannedOverrides)
+	}
+
+	if setEvaluatedPredictorsToUnknown {
+		resp.Plan.SetAttribute(ctx, path.Root("evaluated_predictors"), types.SetUnknown(types.StringType))
 	}
 }
 
@@ -1049,6 +1122,8 @@ func (r *RiskPolicyResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Create the state to save
 	state = plan
 
+	time.Sleep(60 * time.Second)
+
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(state.toState(response)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
@@ -1102,15 +1177,18 @@ func (r *RiskPolicyResource) Delete(ctx context.Context, req resource.DeleteRequ
 			resp, r, err := framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, data.EnvironmentId.ValueString(), fO, fR, fErr)
 
 			if err != nil {
+				if r.StatusCode == 404 {
+					return risk.RiskPolicySet{}, strconv.FormatInt(int64(r.StatusCode), base), nil
+				}
 				return nil, strconv.FormatInt(int64(r.StatusCode), base), err
 			}
 
 			return resp, strconv.FormatInt(int64(r.StatusCode), base), nil
 		},
 		Timeout:                   20 * time.Minute,
-		Delay:                     1 * time.Second,
-		MinTimeout:                5 * time.Second,
-		ContinuousTargetOccurence: 3,
+		Delay:                     5 * time.Second,
+		MinTimeout:                2 * time.Second,
+		ContinuousTargetOccurence: 5,
 	}
 	_, err := deleteStateConf.WaitForStateContext(ctx)
 	if err != nil {
@@ -1275,6 +1353,9 @@ func (p *riskPolicyResourceModel) expand(ctx context.Context, apiClient *risk.AP
 
 			if !conditionPlan.PredictorReferenceValue.IsNull() && !conditionPlan.PredictorReferenceValue.IsUnknown() {
 				condition.SetValue(conditionPlan.PredictorReferenceValue.ValueString())
+				if !slices.Contains(predictorCompactNames, conditionPlan.CompactName.ValueString()) {
+					predictorCompactNames = append(predictorCompactNames, conditionPlan.CompactName.ValueString())
+				}
 			}
 
 			if !conditionPlan.PredictorReferenceContains.IsNull() && !conditionPlan.PredictorReferenceContains.IsUnknown() {
@@ -1379,8 +1460,12 @@ func (p *riskPolicyResourceModel) expand(ctx context.Context, apiClient *risk.AP
 			return nil, diags
 		}
 
-		data.SetEvaluatedPredictors(evaluatedPredictors)
+	} else {
+		for _, predictorID := range riskPolicyPredictorsIDs {
+			evaluatedPredictors = append(evaluatedPredictors, *risk.NewRiskPolicySetEvaluatedPredictorsInner(predictorID))
+		}
 	}
+	data.SetEvaluatedPredictors(evaluatedPredictors)
 
 	return data, diags
 }

--- a/internal/service/risk/resource_risk_policy.go
+++ b/internal/service/risk/resource_risk_policy.go
@@ -1122,8 +1122,6 @@ func (r *RiskPolicyResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Create the state to save
 	state = plan
 
-	time.Sleep(60 * time.Second)
-
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(state.toState(response)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)

--- a/internal/service/risk/resource_risk_policy_test.go
+++ b/internal/service/risk/resource_risk_policy_test.go
@@ -120,10 +120,6 @@ func TestAccRiskPolicy_Full(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default_result.type", "VALUE"),
 		resource.TestCheckResourceAttr(resourceFullName, "default_result.level", "LOW"),
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
-		resource.TestCheckResourceAttr(resourceFullName, "evaluated_predictors.#", "3"),
-		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.0", verify.P1ResourceIDRegexpFullString),
-		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.1", verify.P1ResourceIDRegexpFullString),
-		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.2", verify.P1ResourceIDRegexpFullString),
 		resource.TestCheckResourceAttr(resourceFullName, "overrides.#", "0"),
 	)
 
@@ -134,7 +130,6 @@ func TestAccRiskPolicy_Full(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default_result.type", "VALUE"),
 		resource.TestCheckResourceAttr(resourceFullName, "default_result.level", "LOW"),
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
-		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.#", regexp.MustCompile(`^(?:[2-9]|[12]\d)\d*$`)),
 		resource.TestCheckResourceAttr(resourceFullName, "overrides.#", "0"),
 	)
 
@@ -206,6 +201,10 @@ func TestAccRiskPolicy_Scores(t *testing.T) {
 			"predictor_reference_value": fmt.Sprintf("${details.%s3.level}", name),
 			"score":                     "45",
 		}),
+		resource.TestCheckResourceAttr(resourceFullName, "evaluated_predictors.#", "3"),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.0", verify.P1ResourceIDRegexpFullString),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.1", verify.P1ResourceIDRegexpFullString),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.2", verify.P1ResourceIDRegexpFullString),
 	)
 
 	minimalCheck := resource.ComposeTestCheckFunc(
@@ -219,6 +218,8 @@ func TestAccRiskPolicy_Scores(t *testing.T) {
 			"predictor_reference_value": fmt.Sprintf("${details.%s2.level}", name),
 			"score":                     "45",
 		}),
+		resource.TestCheckResourceAttr(resourceFullName, "evaluated_predictors.#", "1"),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.0", verify.P1ResourceIDRegexpFullString),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -318,6 +319,10 @@ func TestAccRiskPolicy_Weights(t *testing.T) {
 			"predictor_reference_value": fmt.Sprintf("${details.aggregatedWeights.%s3}", name),
 			"weight":                    "6",
 		}),
+		resource.TestCheckResourceAttr(resourceFullName, "evaluated_predictors.#", "3"),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.0", verify.P1ResourceIDRegexpFullString),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.1", verify.P1ResourceIDRegexpFullString),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.2", verify.P1ResourceIDRegexpFullString),
 	)
 
 	minimalCheck := resource.ComposeTestCheckFunc(
@@ -331,6 +336,8 @@ func TestAccRiskPolicy_Weights(t *testing.T) {
 			"predictor_reference_value": fmt.Sprintf("${details.aggregatedWeights.%s2}", name),
 			"weight":                    "3",
 		}),
+		resource.TestCheckResourceAttr(resourceFullName, "evaluated_predictors.#", "1"),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.0", verify.P1ResourceIDRegexpFullString),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -430,24 +437,25 @@ func TestAccRiskPolicy_ChangeType(t *testing.T) {
 			"predictor_reference_value": fmt.Sprintf("${details.%s3.level}", name),
 			"score":                     "45",
 		}),
+		resource.TestCheckResourceAttr(resourceFullName, "evaluated_predictors.#", "3"),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.0", verify.P1ResourceIDRegexpFullString),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.1", verify.P1ResourceIDRegexpFullString),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.2", verify.P1ResourceIDRegexpFullString),
 	)
 
 	weightsCheck := resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.policy_threshold_medium.min_score", "30"),
-		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.policy_threshold_medium.max_score", "80"),
-		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.policy_threshold_high.min_score", "80"),
+		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.policy_threshold_medium.min_score", "40"),
+		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.policy_threshold_medium.max_score", "70"),
+		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.policy_threshold_high.min_score", "70"),
 		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.policy_threshold_high.max_score", "100"),
-		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.predictors.#", "2"),
+		resource.TestCheckResourceAttr(resourceFullName, "policy_weights.predictors.#", "1"),
 		resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "policy_weights.predictors.*", map[string]string{
-			"compact_name":              fmt.Sprintf("%s1", name),
-			"predictor_reference_value": fmt.Sprintf("${details.aggregatedWeights.%s1}", name),
-			"weight":                    "4",
+			"compact_name":              fmt.Sprintf("%s2", name),
+			"predictor_reference_value": fmt.Sprintf("${details.aggregatedWeights.%s2}", name),
+			"weight":                    "3",
 		}),
-		resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "policy_weights.predictors.*", map[string]string{
-			"compact_name":              fmt.Sprintf("%s3", name),
-			"predictor_reference_value": fmt.Sprintf("${details.aggregatedWeights.%s3}", name),
-			"weight":                    "6",
-		}),
+		resource.TestCheckResourceAttr(resourceFullName, "evaluated_predictors.#", "1"),
+		resource.TestMatchResourceAttr(resourceFullName, "evaluated_predictors.0", verify.P1ResourceIDRegexpFullString),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -464,7 +472,7 @@ func TestAccRiskPolicy_ChangeType(t *testing.T) {
 				Check:  scoresCheck,
 			},
 			{
-				Config: testAccRiskPolicyConfig_Weights_Full(resourceName, name),
+				Config: testAccRiskPolicyConfig_Weights_Minimal(resourceName, name),
 				Check:  weightsCheck,
 			},
 			{


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_risk_policy`: Fixed unconfigured predictors (predictors not configured in the policy) are included with a weight/score of 0.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccRiskPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/ris
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

**Note** Testing includes workaround for state inconsistency issue raised in STAGING-22374

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccRiskPolicy_RemovalDrift
=== PAUSE TestAccRiskPolicy_RemovalDrift
=== RUN   TestAccRiskPolicy_NewEnv
=== PAUSE TestAccRiskPolicy_NewEnv
=== RUN   TestAccRiskPolicy_Full
=== PAUSE TestAccRiskPolicy_Full
=== RUN   TestAccRiskPolicy_Scores
=== PAUSE TestAccRiskPolicy_Scores
=== RUN   TestAccRiskPolicy_Weights
=== PAUSE TestAccRiskPolicy_Weights
=== RUN   TestAccRiskPolicy_ChangeType
=== PAUSE TestAccRiskPolicy_ChangeType
=== RUN   TestAccRiskPolicy_PolicyOverrides
=== PAUSE TestAccRiskPolicy_PolicyOverrides
=== RUN   TestAccRiskPolicy_BadParameters
=== PAUSE TestAccRiskPolicy_BadParameters
=== CONT  TestAccRiskPolicy_RemovalDrift
=== CONT  TestAccRiskPolicy_Weights
=== CONT  TestAccRiskPolicy_Full
=== CONT  TestAccRiskPolicy_NewEnv
=== CONT  TestAccRiskPolicy_ChangeType
=== CONT  TestAccRiskPolicy_BadParameters
=== CONT  TestAccRiskPolicy_Scores
=== CONT  TestAccRiskPolicy_PolicyOverrides
--- PASS: TestAccRiskPolicy_NewEnv (25.24s)
--- PASS: TestAccRiskPolicy_RemovalDrift (26.13s)
--- PASS: TestAccRiskPolicy_BadParameters (113.46s)
--- PASS: TestAccRiskPolicy_ChangeType (174.55s)
--- PASS: TestAccRiskPolicy_Full (304.38s)
--- PASS: TestAccRiskPolicy_PolicyOverrides (351.73s)
--- PASS: TestAccRiskPolicy_Scores (393.60s)
--- PASS: TestAccRiskPolicy_Weights (461.76s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/risk        463.125s
```

</details>