### PR TITLE
Fix "resource with the specified name already exists" error

### DIFF
--- a/.changelog/752.txt
+++ b/.changelog/752.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 `resource/pingone_credential_issuer_profile`: Fixed race condition leading to a "A resource with the specified name already exists" error when creating a credential issuer profile at the same time as creating a new environment.
 ```
+
+```release-note:note
+`resource/pingone_credential_issuer_profile`: Added customisable timeout for resource creation, used to tune the polling of a platform bootstrapped credential issuer profile, before one is forcefully created.
+```

--- a/.changelog/752.txt
+++ b/.changelog/752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_credential_issuer_profile`: Fixed race condition leading to a "A resource with the specified name already exists" error when creating a credential issuer profile at the same time as creating a new environment.
+```

--- a/docs/resources/credential_issuer_profile.md
+++ b/docs/resources/credential_issuer_profile.md
@@ -35,12 +35,23 @@ resource "pingone_credential_issuer_profile" "my_credential_issuer" {
 - `environment_id` (String) The ID of the environment to create the credential issuer in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
 - `name` (String) The name of the credential issuer. The name is included in the metadata of an issued verifiable credential.
 
+### Optional
+
+- `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
+
 ### Read-Only
 
 - `application_instance_id` (String) Identifier (UUID) of the application instance registered with the PingOne platform service. This enables the client to send messages to the service.
 - `created_at` (String) Date and time the issuer profile was created.
 - `id` (String) The ID of this resource.
 - `updated_at` (String) Date and time the issuer profile was last updated.
+
+<a id="nestedatt--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 ## Import
 

--- a/internal/service/credentials/resource_credential_issuer_profile.go
+++ b/internal/service/credentials/resource_credential_issuer_profile.go
@@ -156,7 +156,9 @@ func (r *CredentialIssuerProfileResource) Create(ctx context.Context, req resour
 	// Historical:  Pre-EA and initial-EA environments required creation of the issuer profile. Environments created after 2023.05.01 no longer have this requirement.
 	// On 'create' [adding to state], check to see if the profile exists, and if not, create it.  Otherwise, only update the profile, while still adding to TF state.
 
-	timeout, d := plan.Timeouts.Create(ctx, 10*time.Minute)
+	defaultTimeout := 10
+
+	timeout, d := plan.Timeouts.Create(ctx, time.Duration(defaultTimeout)*time.Minute)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_credential_issuer_profile`: Fixed race condition leading to a "A resource with the specified name already exists" error when creating a credential issuer profile at the same time as creating a new environment.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccCredential github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== PAUSE TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== RUN   TestAccCredentialIssuanceRuleDataSource_NotFound
=== PAUSE TestAccCredentialIssuanceRuleDataSource_NotFound
=== RUN   TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== PAUSE TestAccCredentialIssuanceRuleDataSource_InvalidConfig
=== RUN   TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
=== PAUSE TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
=== RUN   TestAccCredentialIssuerProfileDataSource_NotFound
=== PAUSE TestAccCredentialIssuerProfileDataSource_NotFound
=== RUN   TestAccCredentialTypeDataSource_ByIDFull
=== PAUSE TestAccCredentialTypeDataSource_ByIDFull
=== RUN   TestAccCredentialTypeDataSource_NotFound
=== PAUSE TestAccCredentialTypeDataSource_NotFound
=== RUN   TestAccCredentialTypeDataSource_InvalidConfig
=== PAUSE TestAccCredentialTypeDataSource_InvalidConfig
=== RUN   TestAccCredentialTypesDataSource_NoFilter
=== PAUSE TestAccCredentialTypesDataSource_NoFilter
=== RUN   TestAccCredentialTypesDataSource_NotFound
=== PAUSE TestAccCredentialTypesDataSource_NotFound
=== RUN   TestAccCredentialIssuanceRule_RemovalDrift
=== PAUSE TestAccCredentialIssuanceRule_RemovalDrift
=== RUN   TestAccCredentialIssuanceRule_Full
=== PAUSE TestAccCredentialIssuanceRule_Full
=== RUN   TestAccCredentialIssuanceRule_InvalidConfigs
=== PAUSE TestAccCredentialIssuanceRule_InvalidConfigs
=== RUN   TestAccCredentialIssuanceRule_BadParameters
=== PAUSE TestAccCredentialIssuanceRule_BadParameters
=== RUN   TestAccCredentialIssuerProfile_RemovalDrift
=== PAUSE TestAccCredentialIssuerProfile_RemovalDrift
=== RUN   TestAccCredentialIssuerProfile_Full
=== PAUSE TestAccCredentialIssuerProfile_Full
=== RUN   TestAccCredentialIssuerProfile_InvalidConfig
=== PAUSE TestAccCredentialIssuerProfile_InvalidConfig
=== RUN   TestAccCredentialIssuerProfile_BadParameters
=== PAUSE TestAccCredentialIssuerProfile_BadParameters
=== RUN   TestAccCredentialType_RemovalDrift
=== PAUSE TestAccCredentialType_RemovalDrift
=== RUN   TestAccCredentialType_NewEnv
=== PAUSE TestAccCredentialType_NewEnv
=== RUN   TestAccCredentialType_Full
=== PAUSE TestAccCredentialType_Full
=== RUN   TestAccCredentialType_MetaData
=== PAUSE TestAccCredentialType_MetaData
=== RUN   TestAccCredentialType_CardDesignTemplate
=== PAUSE TestAccCredentialType_CardDesignTemplate
=== RUN   TestAccCredentialType_BadParameters
=== PAUSE TestAccCredentialType_BadParameters
=== CONT  TestAccCredentialIssuanceRuleDataSource_ByIDFull
=== CONT  TestAccCredentialIssuanceRule_InvalidConfigs
=== CONT  TestAccCredentialType_RemovalDrift
=== CONT  TestAccCredentialType_MetaData
=== CONT  TestAccCredentialType_CardDesignTemplate
=== CONT  TestAccCredentialIssuerProfile_Full
=== CONT  TestAccCredentialIssuerProfile_BadParameters
=== CONT  TestAccCredentialIssuerProfile_InvalidConfig
=== CONT  TestAccCredentialIssuerProfile_RemovalDrift
=== CONT  TestAccCredentialIssuanceRule_BadParameters
=== CONT  TestAccCredentialType_Full
=== CONT  TestAccCredentialTypeDataSource_NotFound
=== CONT  TestAccCredentialIssuanceRule_Full
=== CONT  TestAccCredentialIssuanceRule_RemovalDrift
=== CONT  TestAccCredentialTypesDataSource_NotFound
=== CONT  TestAccCredentialTypesDataSource_NoFilter
--- PASS: TestAccCredentialIssuerProfile_InvalidConfig (3.42s)
=== CONT  TestAccCredentialTypeDataSource_InvalidConfig
--- PASS: TestAccCredentialTypeDataSource_NotFound (3.66s)
=== CONT  TestAccCredentialType_NewEnv
--- PASS: TestAccCredentialType_MetaData (4.72s)
=== CONT  TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull
--- PASS: TestAccCredentialType_CardDesignTemplate (5.45s)
=== CONT  TestAccCredentialTypeDataSource_ByIDFull
--- PASS: TestAccCredentialTypeDataSource_InvalidConfig (2.15s)
=== CONT  TestAccCredentialIssuerProfileDataSource_NotFound
--- PASS: TestAccCredentialIssuanceRule_InvalidConfigs (5.91s)
=== CONT  TestAccCredentialIssuanceRuleDataSource_InvalidConfig
--- PASS: TestAccCredentialIssuanceRuleDataSource_InvalidConfig (1.72s)
=== CONT  TestAccCredentialIssuanceRuleDataSource_NotFound
--- PASS: TestAccCredentialIssuanceRuleDataSource_ByIDFull (9.84s)
=== CONT  TestAccCredentialType_BadParameters
--- PASS: TestAccCredentialIssuanceRuleDataSource_NotFound (3.31s)
--- PASS: TestAccCredentialIssuerProfileDataSource_NotFound (5.60s)
--- PASS: TestAccCredentialIssuanceRule_BadParameters (13.24s)
--- PASS: TestAccCredentialTypeDataSource_ByIDFull (8.05s)
--- PASS: TestAccCredentialTypesDataSource_NotFound (16.99s)
--- PASS: TestAccCredentialType_BadParameters (7.98s)
--- PASS: TestAccCredentialType_NewEnv (14.49s)
--- PASS: TestAccCredentialTypesDataSource_NoFilter (19.65s)
--- PASS: TestAccCredentialType_RemovalDrift (20.50s)
--- PASS: TestAccCredentialType_Full (32.41s)
--- PASS: TestAccCredentialIssuerProfile_RemovalDrift (37.35s)
--- PASS: TestAccCredentialIssuanceRule_Full (38.56s)
--- PASS: TestAccCredentialIssuanceRule_RemovalDrift (39.53s)
--- PASS: TestAccCredentialIssuerProfile_BadParameters (40.82s)
--- PASS: TestAccCredentialIssuerProfileDataSource_ByEnvironmentIDFull (40.29s)
--- PASS: TestAccCredentialIssuerProfile_Full (135.26s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/credentials 136.300s
```

</details>