### PR TITLE
`pingone_verify_policy`: add support for `inspection_type` property in `government_id` configuration object.

### DIFF
--- a/.changelog/754.txt
+++ b/.changelog/754.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 `resource/pingone_verify_policy`: Added support for `inspection_type` property in `government_id` configuration object.
 ```
+
+```release-note:enhancement
+`data_source/pingone_verify_policy`: Added support for `inspection_type` property in `government_id` configuration object.
+```

--- a/.changelog/754.txt
+++ b/.changelog/754.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_verify_policy`: Added support for `inspection_type` property in `government_id` configuration object.
+```

--- a/docs/data-sources/verify_policy.md
+++ b/docs/data-sources/verify_policy.md
@@ -140,6 +140,7 @@ Read-Only:
 
 Read-Only:
 
+- `inspection_type` (String) Determine whether document authentication is automated, manual, or possibly both.  Options are `AUTOMATIC`, `MANUAL`, `STEP_UP`.
 - `verify` (String) Controls Government ID verification requirements.  Options are `DISABLED`, `OPTIONAL`, `REQUIRED`.  Defaults to `DISABLED`.
 
 

--- a/docs/resources/verify_policy.md
+++ b/docs/resources/verify_policy.md
@@ -269,6 +269,10 @@ Required:
 
 - `verify` (String) Controls Government ID verification requirements.  Options are `DISABLED`, `OPTIONAL`, `REQUIRED`.  Defaults to `DISABLED`.
 
+Optional:
+
+- `inspection_type` (String) Determine whether document authentication is automated, manual, or possibly both.  Options are `AUTOMATIC`, `MANUAL`, `STEP_UP`.
+
 
 <a id="nestedatt--liveness"></a>
 ### Nested Schema for `liveness`

--- a/internal/service/verify/data_source_verify_policy.go
+++ b/internal/service/verify/data_source_verify_policy.go
@@ -49,7 +49,8 @@ var (
 	}
 
 	governmentIdDataSourceServiceTFObjectTypes = map[string]attr.Type{
-		"verify": types.StringType,
+		"verify":          types.StringType,
+		"inspection_type": types.StringType,
 	}
 
 	facialComparisonDataSourceServiceTFObjectTypes = map[string]attr.Type{
@@ -364,6 +365,11 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 
 				Attributes: map[string]schema.Attribute{
 					"verify": schema.StringAttribute{
+						Description:         governmentIdVerifyDescription.Description,
+						MarkdownDescription: governmentIdVerifyDescription.MarkdownDescription,
+						Computed:            true,
+					},
+					"inspection_type": schema.StringAttribute{
 						Description:         governmentIdVerifyDescription.Description,
 						MarkdownDescription: governmentIdVerifyDescription.MarkdownDescription,
 						Computed:            true,
@@ -932,7 +938,8 @@ func (p *verifyPolicyDataSourceModel) toStateGovernmentId(apiObject *verify.Gove
 	}
 
 	objValue, d := types.ObjectValue(governmentIdDataSourceServiceTFObjectTypes, map[string]attr.Value{
-		"verify": framework.EnumOkToTF(apiObject.GetVerifyOk()),
+		"verify":          framework.EnumOkToTF(apiObject.GetVerifyOk()),
+		"inspection_type": framework.EnumOkToTF(apiObject.GetInspectionTypeOk()),
 	})
 	diags.Append(d...)
 

--- a/internal/service/verify/data_source_verify_policy.go
+++ b/internal/service/verify/data_source_verify_policy.go
@@ -193,6 +193,10 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 		"Controls Government ID verification requirements.",
 	).AllowedValuesEnum(verify.AllowedEnumVerifyEnumValues).DefaultValue(string(defaultVerify))
 
+	governmentIdInspectionTypeDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"Determine whether document authentication is automated, manual, or possibly both.",
+	).AllowedValuesEnum(verify.AllowedEnumInspectionTypeEnumValues)
+
 	facialComparisonVerifyDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"Controls Facial Comparison verification requirements.",
 	).AllowedValuesEnum(verify.AllowedEnumVerifyEnumValues).DefaultValue(string(defaultVerify))
@@ -370,8 +374,8 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 						Computed:            true,
 					},
 					"inspection_type": schema.StringAttribute{
-						Description:         governmentIdVerifyDescription.Description,
-						MarkdownDescription: governmentIdVerifyDescription.MarkdownDescription,
+						Description:         governmentIdInspectionTypeDescription.Description,
+						MarkdownDescription: governmentIdInspectionTypeDescription.MarkdownDescription,
 						Computed:            true,
 					},
 				},

--- a/internal/service/verify/data_source_verify_policy_test.go
+++ b/internal/service/verify/data_source_verify_policy_test.go
@@ -37,6 +37,7 @@ func TestAccVerifyPolicyDataSource_All(t *testing.T) {
 		resource.TestCheckResourceAttr(dataSourceFullName, "default", "false"),
 
 		resource.TestCheckResourceAttr(dataSourceFullName, "government_id.verify", "REQUIRED"),
+		resource.TestCheckResourceAttr(dataSourceFullName, "government_id.inspection_type", "AUTOMATIC"),
 
 		resource.TestCheckResourceAttr(dataSourceFullName, "facial_comparison.verify", "REQUIRED"),
 		resource.TestCheckResourceAttr(dataSourceFullName, "facial_comparison.threshold", "HIGH"),
@@ -94,6 +95,7 @@ func TestAccVerifyPolicyDataSource_All(t *testing.T) {
 		resource.TestCheckResourceAttr(dataSourceFullName, "default", "false"),
 
 		resource.TestCheckResourceAttr(dataSourceFullName, "government_id.verify", "DISABLED"),
+		resource.TestCheckNoResourceAttr(dataSourceFullName, "government_id.inspection_type"),
 
 		resource.TestCheckResourceAttr(dataSourceFullName, "facial_comparison.verify", "DISABLED"),
 		resource.TestCheckResourceAttr(dataSourceFullName, "facial_comparison.threshold", "MEDIUM"),

--- a/internal/service/verify/resource_verify_policy_test.go
+++ b/internal/service/verify/resource_verify_policy_test.go
@@ -122,6 +122,7 @@ func TestAccVerifyPolicy_Full(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 
 		resource.TestCheckResourceAttr(resourceFullName, "government_id.verify", "REQUIRED"),
+		resource.TestCheckResourceAttr(resourceFullName, "government_id.inspection_type", "AUTOMATIC"),
 
 		resource.TestCheckResourceAttr(resourceFullName, "facial_comparison.verify", "REQUIRED"),
 		resource.TestCheckResourceAttr(resourceFullName, "facial_comparison.threshold", "HIGH"),
@@ -179,6 +180,7 @@ func TestAccVerifyPolicy_Full(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 
 		resource.TestCheckResourceAttr(resourceFullName, "government_id.verify", "REQUIRED"),
+		resource.TestCheckResourceAttr(resourceFullName, "government_id.inspection_type", "AUTOMATIC"),
 
 		resource.TestCheckResourceAttr(resourceFullName, "facial_comparison.verify", "DISABLED"),
 		resource.TestCheckResourceAttr(resourceFullName, "facial_comparison.threshold", "MEDIUM"),
@@ -385,6 +387,11 @@ func TestAccVerifyPolicy_ValidationChecks(t *testing.T) {
 				ExpectError: regexp.MustCompile("Error: Provided value is not valid"),
 				Destroy:     true,
 			},
+			{
+				Config:      testAccVerifyPolicy_GovernmentIdInspectionTypeNotAllowed(resourceName, name),
+				ExpectError: regexp.MustCompile("Error: Invalid Attribute Value Match"),
+				Destroy:     true,
+			},
 		},
 	})
 }
@@ -465,7 +472,8 @@ resource "pingone_verify_policy" "%[2]s" {
   description    = "Description for %[3]s"
 
   government_id = {
-    verify = "REQUIRED"
+    verify          = "REQUIRED"
+    inspection_type = "AUTOMATIC"
   }
 
   facial_comparison = {
@@ -762,6 +770,42 @@ resource "pingone_verify_policy" "%[2]s" {
       timeout = {
         duration  = "20"
         time_unit = "MINUTES"
+      }
+    }
+  }
+
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccVerifyPolicy_GovernmentIdInspectionTypeNotAllowed(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+resource "pingone_verify_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  description    = "%[3]s"
+
+  government_id = {
+    verify    = "DISABLED"
+    threshold = "STEP_UP"
+  }
+
+  facial_comparison = {
+    verify    = "REQUIRED"
+    threshold = "HIGH"
+  }
+
+  transaction = {
+    timeout = {
+      duration  = "35"
+      time_unit = "MINUTES"
+    }
+
+    data_collection = {
+      timeout = {
+        duration  = "2000"
+        time_unit = "SECONDS"
       }
     }
   }

--- a/internal/service/verify/resource_verify_policy_test.go
+++ b/internal/service/verify/resource_verify_policy_test.go
@@ -236,6 +236,7 @@ func TestAccVerifyPolicy_Full(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 
 		resource.TestCheckResourceAttr(resourceFullName, "government_id.verify", "DISABLED"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "government_id.inspection_type"),
 
 		resource.TestCheckResourceAttr(resourceFullName, "facial_comparison.verify", "REQUIRED"),
 		resource.TestCheckResourceAttr(resourceFullName, "facial_comparison.threshold", "HIGH"),


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
```release-note:enhancement
```release-note:enhancement
`resource/pingone_verify_policy`: Added support for `inspection_type` property in `government_id` configuration object.
```

```release-note:enhancement
`data_source/pingone_verify_policy`: Added support for `inspection_type` property in `government_id` configuration object.
```
```

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->
N/A

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG=INFO TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s  -run TestAccVerifyPolicy github.com/pingidentity/terraform-provider-pingone/internal/service/verify
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
% TF_LOG=INFO TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s  -run TestAccVerifyPolicy github.com/pingidentity/terraform-provider-pingone/internal/service/verify
=== RUN   TestAccVerifyPolicyDataSource_All
=== PAUSE TestAccVerifyPolicyDataSource_All
=== RUN   TestAccVerifyPolicyDataSource_FailureChecks
=== PAUSE TestAccVerifyPolicyDataSource_FailureChecks
=== RUN   TestAccVerifyPolicy_RemovalDrift
=== PAUSE TestAccVerifyPolicy_RemovalDrift
=== RUN   TestAccVerifyPolicy_NewEnv
=== PAUSE TestAccVerifyPolicy_NewEnv
=== RUN   TestAccVerifyPolicy_Full
=== PAUSE TestAccVerifyPolicy_Full
=== RUN   TestAccVerifyPolicy_ValidationChecks
=== PAUSE TestAccVerifyPolicy_ValidationChecks
=== RUN   TestAccVerifyPolicy_BadParameters
=== PAUSE TestAccVerifyPolicy_BadParameters
=== CONT  TestAccVerifyPolicyDataSource_All
=== CONT  TestAccVerifyPolicy_Full
=== CONT  TestAccVerifyPolicy_BadParameters
=== CONT  TestAccVerifyPolicy_RemovalDrift
=== CONT  TestAccVerifyPolicy_ValidationChecks
=== CONT  TestAccVerifyPolicy_NewEnv
=== CONT  TestAccVerifyPolicyDataSource_FailureChecks
--- PASS: TestAccVerifyPolicy_ValidationChecks (0.78s)
--- PASS: TestAccVerifyPolicy_BadParameters (5.09s)
--- PASS: TestAccVerifyPolicyDataSource_FailureChecks (11.32s)
--- PASS: TestAccVerifyPolicy_NewEnv (11.68s)
--- PASS: TestAccVerifyPolicy_RemovalDrift (12.95s)
--- PASS: TestAccVerifyPolicy_Full (18.40s)
--- PASS: TestAccVerifyPolicyDataSource_All (40.20s)
PASS
```

</details>