### PR TITLE
Fix error when attempting to move a user between populations

### DIFF
--- a/.changelog/770.txt
+++ b/.changelog/770.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_user`: Fixed error when attempting to move a user between populations by changing the `population_id` value.
+```

--- a/internal/service/sso/resource_user.go
+++ b/internal/service/sso/resource_user.go
@@ -1230,7 +1230,28 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	// Run the API call
+	// Run the API calls
+	if state.PopulationId.ValueString() != plan.PopulationId.ValueString() {
+
+		userPopulation := management.NewUserPopulation(plan.PopulationId.ValueString())
+
+		resp.Diagnostics.Append(framework.ParseResponse(
+			ctx,
+
+			func() (any, *http.Response, error) {
+				fO, fR, fErr := r.Client.ManagementAPIClient.UserPopulationsApi.UpdateUserPopulation(ctx, plan.EnvironmentId.ValueString(), plan.Id.ValueString()).UserPopulation(*userPopulation).Execute()
+				return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, plan.EnvironmentId.ValueString(), fO, fR, fErr)
+			},
+			"UpdateUserPopulation",
+			framework.DefaultCustomError,
+			userAccountEnabledRetryable,
+			nil,
+		)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 

--- a/internal/service/sso/resource_user_test.go
+++ b/internal/service/sso/resource_user_test.go
@@ -868,11 +868,17 @@ resource "pingone_population" "%[2]s" {
   name = "%[3]s"
 }
 
+resource "pingone_population" "%[2]s-new" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s-new"
+}
+
 resource "pingone_user" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
 
   username      = "%[3]s"
   email         = "%[3]s@pingidentity.com"
-  population_id = pingone_population.%[2]s.id
+  population_id = pingone_population.%[2]s-new.id
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_user`: Fixed error when attempting to move a user between populations by changing the `population_id` value.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccUser_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccUser_RemovalDrift
=== PAUSE TestAccUser_RemovalDrift
=== RUN   TestAccUser_NewEnv
=== PAUSE TestAccUser_NewEnv
=== RUN   TestAccUser_All
=== PAUSE TestAccUser_All
=== RUN   TestAccUser_AllWithoutReplacement
=== PAUSE TestAccUser_AllWithoutReplacement
=== RUN   TestAccUser_AccountLocked
=== PAUSE TestAccUser_AccountLocked
=== RUN   TestAccUser_ChangePopulation
=== PAUSE TestAccUser_ChangePopulation
=== RUN   TestAccUser_ChangeMFA
=== PAUSE TestAccUser_ChangeMFA
=== RUN   TestAccUser_ChangeUsernameAndEmail
=== PAUSE TestAccUser_ChangeUsernameAndEmail
=== RUN   TestAccUser_BadParameters
=== PAUSE TestAccUser_BadParameters
=== CONT  TestAccUser_RemovalDrift
=== CONT  TestAccUser_AllWithoutReplacement
=== CONT  TestAccUser_ChangeMFA
=== CONT  TestAccUser_All
=== CONT  TestAccUser_NewEnv
=== CONT  TestAccUser_ChangePopulation
=== CONT  TestAccUser_BadParameters
=== CONT  TestAccUser_ChangeUsernameAndEmail
=== CONT  TestAccUser_AccountLocked
--- PASS: TestAccUser_BadParameters (10.32s)
--- PASS: TestAccUser_ChangePopulation (12.86s)
--- PASS: TestAccUser_NewEnv (14.35s)
--- PASS: TestAccUser_ChangeUsernameAndEmail (18.32s)
--- PASS: TestAccUser_ChangeMFA (18.77s)
--- PASS: TestAccUser_RemovalDrift (20.08s)
--- PASS: TestAccUser_AccountLocked (22.37s)
--- PASS: TestAccUser_AllWithoutReplacement (31.26s)
--- PASS: TestAccUser_All (32.69s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 34.312s
```

</details>