### PR TITLE
Add global options to provider configuration, including the ability to force delete populations if they contain users

### DIFF
--- a/.changelog/773.txt
+++ b/.changelog/773.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+Added `global_options` provider parameter block to be able to override specific API behaviours.
+```
+
+```release-note:enhancement
+Added the `global_options.population.contains_users_force_delete` provider parameter to be able to force-delete populations if they contain users in sandbox environments.  Use of this provider option may result in loss of user data - use with caution.
+```
+
+```release-note:note
+Deprecated the `force_delete_production_type` provider parameter.  This parameter will be removed in the next major release.  Please use the `global_options.population.contains_users_force_delete` provider parameter going forward.  Use of this provider option may result in loss of user data - use with caution.
+```
+
+```release-note:note
+`resource/pingone_environment`: Code optimisation on plan modification.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,6 @@ provider "pingone" {
   client_secret  = var.client_secret
   environment_id = var.environment_id
   region         = var.region
-
-  force_delete_production_type = false
 }
 
 resource "pingone_environment" "my_environment" {
@@ -114,16 +112,54 @@ The PingOne provider allows custom information to be appended to the default use
 $ export PINGONE_TF_APPEND_USER_AGENT="Jenkins/2.426.2"
 ```
 
+## Global Options
+
+The PingOne provider provides global options to override API behaviours in PingOne, for example to override data protection features for development, testing and demo use cases.
+
+The following example shows how to configure the provider with global options to force-delete populations that contain users not managed by Terraform, and force-delete environments if they are of type `PRODUCTION`.
+
+```terraform
+provider "pingone" {
+  client_id      = var.client_id
+  client_secret  = var.client_secret
+  environment_id = var.environment_id
+  region         = var.region
+
+  global_options {
+
+    environment {
+      // This option should not be used in environments that contain production data.  Data loss may occur.
+      production_type_force_delete = true
+    }
+
+    population {
+      // This option should not be used in environments that contain production data.  Data loss may occur.
+      contains_users_force_delete = true
+    }
+
+  }
+}
+```
+
 ## Provider Schema Reference
 
 - `api_access_token` (String) The access token used for provider resource management against the PingOne management API.  Default value can be set with the `PINGONE_API_ACCESS_TOKEN` environment variable.  Must provide only one of `api_access_token` (when obtaining the worker token outside of the provider) and `client_id` (when the provider should fetch the worker token during operations).
 - `client_id` (String) Client ID for the worker app client.  Default value can be set with the `PINGONE_CLIENT_ID` environment variable.  Must provide only one of `api_access_token` (when obtaining the worker token outside of the provider) and `client_id` (when the provider should fetch the worker token during operations).  Must be configured with `client_secret` and `environment_id`.
 - `client_secret` (String) Client secret for the worker app client.  Default value can be set with the `PINGONE_CLIENT_SECRET` environment variable.  Must be configured with `client_id` and `environment_id`.
 - `environment_id` (String) Environment ID for the worker app client.  Default value can be set with the `PINGONE_ENVIRONMENT_ID` environment variable.  Must be configured with `client_id` and `client_secret`.
-- `force_delete_production_type` (Boolean) Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable.
+- `force_delete_production_type` (Boolean, Deprecated) **Deprecation notice**.  *This parameter is deprecated and will be removed in the next major release.  Use the `global_options` options going forward.*  Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable.
+- `global_options` (Block List) A single block containing configuration items to override API behaviours in PingOne. (see [below for nested schema](#nestedblock--global_options))
 - `http_proxy` (String) Full URL for the http/https proxy service, for example `http://127.0.0.1:8090`.  Default value can be set with the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
 - `region` (String) The PingOne region to use.  Options are `AsiaPacific` `Canada` `Europe` and `NorthAmerica`.  Default value can be set with the `PINGONE_REGION` environment variable.
 - `service_endpoints` (Block List) A single block containing configuration items to override the service API endpoints of PingOne. (see [below for nested schema](#nestedblock--service_endpoints))
+
+<a id="nestedblock--global_options"></a>
+### Nested Schema for `global_options`
+
+Optional:
+
+- `environment` (Block List) A single block containing global configuration items to override environment resource settings in PingOne. (see [below for nested schema](#nestedblock--global_options-environment))
+- `population` (Block List) A single block containing configuration items to override population resource settings in PingOne. (see [below for nested schema](#nestedblock--global_options))
 
 <a id="nestedblock--service_endpoints"></a>
 ### Nested Schema for `service_endpoints`
@@ -132,3 +168,17 @@ Required:
 
 - `api_hostname` (String) Hostname for the PingOne management service API.  Default value can be set with the `PINGONE_API_SERVICE_HOSTNAME` environment variable.
 - `auth_hostname` (String) Hostname for the PingOne authentication service API.  Default value can be set with the `PINGONE_AUTH_SERVICE_HOSTNAME` environment variable.
+
+<a id="nestedblock--global_options-environment"></a>
+### Nested Schema for `global_options.environment`
+
+Optional:
+
+- `production_type_force_delete` (Boolean) Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable. This option should not be set to `true` when the environment contains production data. Data loss may occur.
+
+<a id="nestedblock--global_options-population"></a>
+### Nested Schema for `global_options.population`
+
+Optional:
+
+- `contains_users_force_delete` (Boolean) Choose whether to force-delete populations that contain users not managed by Terraform.  Useful for development and testing use cases, and only applies if the environment that contains the population is of type `SANDBOX`, or the `global_options.environment.production_type_force_delete` parameter is set to `true`.  The platform default is that populations cannot be removed if they contain user data.  By default this parameter is set to `false`. This option should not be set to `true` when the environment contains production data. Data loss may occur.

--- a/examples/provider/provider-global-options.tf
+++ b/examples/provider/provider-global-options.tf
@@ -1,0 +1,20 @@
+provider "pingone" {
+  client_id      = var.client_id
+  client_secret  = var.client_secret
+  environment_id = var.environment_id
+  region         = var.region
+
+  global_options {
+
+    environment {
+      // This option should not be used in environments that contain production data.  Data loss may occur.
+      production_type_force_delete = true
+    }
+
+    population {
+      // This option should not be used in environments that contain production data.  Data loss may occur.
+      contains_users_force_delete = true
+    }
+
+  }
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -12,8 +12,6 @@ provider "pingone" {
   client_secret  = var.client_secret
   environment_id = var.environment_id
   region         = var.region
-
-  force_delete_production_type = false
 }
 
 resource "pingone_environment" "my_environment" {

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -305,7 +305,14 @@ func TestClient(ctx context.Context) (*client.Client, error) {
 		ClientSecret:  os.Getenv("PINGONE_CLIENT_SECRET"),
 		EnvironmentID: os.Getenv("PINGONE_ENVIRONMENT_ID"),
 		Region:        os.Getenv("PINGONE_REGION"),
-		ForceDelete:   false,
+		GlobalOptions: &client.GlobalOptions{
+			Environment: &client.EnvironmentOptions{
+				ProductionTypeForceDelete: false,
+			},
+			Population: &client.PopulationOptions{
+				ContainsUsersForceDelete: false,
+			},
+		},
 	}
 
 	return config.APIClient(ctx, getProviderTestingVersion())

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -15,7 +15,6 @@ import (
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
 	"github.com/pingidentity/terraform-provider-pingone/internal/provider"
-	"github.com/pingidentity/terraform-provider-pingone/internal/provider/sdkv2"
 )
 
 // ProviderFactories is a static map containing only the main provider instance
@@ -37,23 +36,6 @@ var Provider *schema.Provider
 // to create a provider server to which the CLI can reattach.
 
 var ProtoV6ProviderFactories map[string]func() (tfprotov6.ProviderServer, error) = protoV6ProviderFactoriesInit(context.Background(), "pingone")
-
-func init() {
-	Provider = sdkv2.New(getProviderTestingVersion())()
-
-	// Always allocate a new provider instance each invocation, otherwise gRPC
-	// ProviderConfigure() can overwrite configuration during concurrent testing.
-	ProviderFactories = map[string]func() (*schema.Provider, error){
-		"pingone": func() (*schema.Provider, error) {
-			provider := sdkv2.New(getProviderTestingVersion())()
-
-			if provider == nil {
-				return nil, fmt.Errorf("Cannot initiate provider factory")
-			}
-			return provider, nil
-		},
-	}
-}
 
 func protoV6ProviderFactoriesInit(ctx context.Context, providerNames ...string) map[string]func() (tfprotov6.ProviderServer, error) {
 	factories := make(map[string]func() (tfprotov6.ProviderServer, error), len(providerNames))
@@ -342,11 +324,15 @@ func MinimalSandboxEnvironment(resourceName, licenseID string) string {
 }
 
 func MinimalSandboxEnvironmentNoPopulation(resourceName, licenseID string) string {
+	return MinimalEnvironmentNoPopulation(resourceName, licenseID, management.ENUMENVIRONMENTTYPE_SANDBOX)
+}
+
+func MinimalEnvironmentNoPopulation(resourceName, licenseID string, environmentType management.EnumEnvironmentType) string {
 	return fmt.Sprintf(`
 	resource "pingone_environment" "%[1]s" {
 		name = "%[1]s"
-		type = "SANDBOX"
 		license_id = "%[2]s"
+		type = "%[3]s"
 
 		service {
 			type = "SSO"
@@ -364,7 +350,7 @@ func MinimalSandboxEnvironmentNoPopulation(resourceName, licenseID string) strin
 			type = "Verify"
 		}
 	}
-`, resourceName, licenseID)
+`, resourceName, licenseID, string(environmentType))
 }
 
 func GenericSandboxEnvironment() string {

--- a/internal/acctest/service/sso/user.go
+++ b/internal/acctest/service/sso/user.go
@@ -78,3 +78,26 @@ func User_RemovalDrift_PreConfig(ctx context.Context, apiClient *management.APIC
 		t.Fatalf("Failed to delete user: %v", err)
 	}
 }
+
+func User_CreateUser_PreConfig(ctx context.Context, apiClient *management.APIClient, t *testing.T, environmentID, name string, resourceID, populationID *string) {
+	if environmentID == "" || name == "" {
+		t.Fatalf("One of environment ID or user name cannot be determined. Environment ID: %s, User name: %s", environmentID, name)
+	}
+
+	userData := management.NewUser(
+		fmt.Sprintf("%s@ping-eng.com", name),
+		name,
+	)
+
+	if populationID != nil {
+		population := *management.NewUserPopulation(*populationID)
+		userData.SetPopulation(population)
+	}
+
+	fO, _, fErr := apiClient.UsersApi.CreateUser(context.Background(), environmentID).ContentType("application/vnd.pingidentity.user.import+json").User(*userData).Execute()
+	if fErr != nil {
+		t.Fatalf("Failed to create user: %v", fErr)
+	}
+
+	*resourceID = fO.GetId()
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,8 +10,8 @@ import (
 )
 
 type Client struct {
-	API         *pingone.Client
-	ForceDelete bool
+	API           *pingone.Client
+	GlobalOptions *GlobalOptions
 }
 
 func (c *Config) APIClient(ctx context.Context, version string) (*Client, error) {
@@ -40,8 +40,8 @@ func (c *Config) APIClient(ctx context.Context, version string) (*Client, error)
 	}
 
 	tfClient := &Client{
-		API:         client,
-		ForceDelete: c.ForceDelete,
+		API:           client,
+		GlobalOptions: c.GlobalOptions,
 	}
 
 	return tfClient, nil

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -9,5 +9,18 @@ type Config struct {
 	APIHostnameOverride  *string
 	AuthHostnameOverride *string
 	ProxyURL             *string
-	ForceDelete          bool
+	GlobalOptions        *GlobalOptions
+}
+
+type GlobalOptions struct {
+	Environment *EnvironmentOptions
+	Population  *PopulationOptions
+}
+
+type EnvironmentOptions struct {
+	ProductionTypeForceDelete bool
+}
+
+type PopulationOptions struct {
+	ContainsUsersForceDelete bool
 }

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -67,12 +67,53 @@ func New(version string) func() *schema.Provider {
 				"force_delete_production_type": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Deprecated:  "This parameter is deprecated and will be removed in the next major release. Use the `global_options.environment.production_type_force_delete` block going forward.",
 					Description: "Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable.",
 				},
 				"http_proxy": {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Description: "Full URL for the http/https proxy service, for example `http://127.0.0.1:8090`.  Default value can be set with the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.",
+				},
+				"global_options": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "A single block containing configuration items to override API behaviours in PingOne.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"environment": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								MaxItems:    1,
+								Description: "A single block containing global configuration items to override environment resource settings in PingOne.",
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"production_type_force_delete": {
+											Type:        schema.TypeBool,
+											Optional:    true,
+											Description: "Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable.",
+										},
+									},
+								},
+							},
+							"population": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								MaxItems:    1,
+								Description: "A single block containing configuration items to override population resource settings in PingOne.",
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"contains_users_force_delete": {
+											Type:        schema.TypeBool,
+											Optional:    true,
+											Description: "Choose whether to force-delete populations that contain users not managed by Terraform. Useful for development and testing use cases, and only applies if the environment that contains the population is of type `SANDBOX`. The platform default is that populations cannot be removed if they contain user data. By default this parameter is set to `false`.",
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				"service_endpoints": {
 					Type:        schema.TypeList,
@@ -167,18 +208,26 @@ func configure(version string) func(context.Context, *schema.ResourceData) (inte
 			config.Region = v
 		}
 
-		if v, ok := d.Get("force_delete_production_type").(bool); ok {
-			config.ForceDelete = v
-		} else {
-			forceDelete, err := strconv.ParseBool(os.Getenv("PINGONE_FORCE_DELETE_PRODUCTION_TYPE"))
-			if err != nil {
-				forceDelete = false
-			}
+		config.GlobalOptions = &client.GlobalOptions{
+			Environment: &client.EnvironmentOptions{
+				ProductionTypeForceDelete: false,
+			},
+			Population: &client.PopulationOptions{
+				ContainsUsersForceDelete: false,
+			},
+		}
+		if v, err := strconv.ParseBool(os.Getenv("PINGONE_FORCE_DELETE_PRODUCTION_TYPE")); err == nil && v {
 			tflog.Debug(ctx, fmt.Sprintf(debugLogMessage, "force_delete_production_type"), map[string]interface{}{
 				"env_var":       "PINGONE_FORCE_DELETE_PRODUCTION_TYPE",
-				"env_var_value": forceDelete,
+				"env_var_value": v,
 			})
-			config.ForceDelete = forceDelete
+			config.GlobalOptions.Environment.ProductionTypeForceDelete = v
+		}
+
+		deprecatedForceDeleteSet := false
+		if v, ok := d.Get("force_delete_production_type").(bool); ok {
+			config.GlobalOptions.Environment.ProductionTypeForceDelete = v
+			deprecatedForceDeleteSet = true
 		}
 
 		if v, ok := d.Get("http_proxy").(string); ok && v != "" {
@@ -192,6 +241,26 @@ func configure(version string) func(context.Context, *schema.ResourceData) (inte
 
 			if v, ok := d.Get("api_hostname").(string); ok && v != "" {
 				config.APIHostnameOverride = &v
+			}
+		}
+
+		if v, ok := d.Get("global_options").([]interface{}); ok && len(v) > 0 && v[0] != nil {
+
+			if v, ok := d.Get("environment").([]interface{}); ok && len(v) > 0 && v[0] != nil {
+				if v, ok := d.Get("production_type_force_delete").(bool); ok {
+
+					if deprecatedForceDeleteSet {
+						return nil, diag.FromErr(fmt.Errorf("Cannot set both `force_delete_production_type` and `global_options.environment.production_type_force_delete`"))
+					}
+
+					config.GlobalOptions.Environment.ProductionTypeForceDelete = v
+				}
+			}
+
+			if v, ok := d.Get("population").([]interface{}); ok && len(v) > 0 && v[0] != nil {
+				if v, ok := d.Get("contains_users_force_delete").(bool); ok {
+					config.GlobalOptions.Population.ContainsUsersForceDelete = v
+				}
 			}
 		}
 

--- a/internal/service/sso/resource_population.go
+++ b/internal/service/sso/resource_population.go
@@ -3,7 +3,6 @@ package sso
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"regexp"
 
@@ -266,8 +265,6 @@ func (r *PopulationResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	log.Printf("HERE!!!!! 1")
-
 	hasUsersAssigned, d := r.hasUsersAssigned(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString())
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
@@ -275,15 +272,12 @@ func (r *PopulationResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	if hasUsersAssigned {
-		log.Printf("HERE!!!!! 2")
 		d := r.checkControlsAndDeletePopulationUsers(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString())
 		resp.Diagnostics.Append(d...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		log.Printf("HERE!!!!! 3")
 	}
-	log.Printf("HERE!!!!! 4")
 
 	// Run the API call
 	resp.Diagnostics.Append(framework.ParseResponse(
@@ -480,20 +474,16 @@ func (r *PopulationResource) checkEnvironmentControls(ctx context.Context, envir
 func (r *PopulationResource) checkControlsAndDeletePopulationUsers(ctx context.Context, environmentID, populationID string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	log.Printf("HERE!!!!! 2.1")
 	environmentControlsOk, d := r.checkEnvironmentControls(ctx, environmentID, populationID)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
-	log.Printf("HERE!!!!! 2.2")
 
 	if environmentControlsOk {
-		log.Printf("HERE!!!!! 2.3")
 
 		loopCounter := 1
 		for loopCounter > 0 {
-			log.Printf("HERE!!!!! 2.5")
 
 			users, d := r.readUsers(ctx, environmentID, populationID)
 			diags.Append(d...)
@@ -503,10 +493,8 @@ func (r *PopulationResource) checkControlsAndDeletePopulationUsers(ctx context.C
 
 			// DELETE USERS
 			if len(users) == 0 {
-				log.Printf("HERE!!!!! 2.6")
 				break
 			} else {
-				log.Printf("HERE!!!!! 2.7")
 				for _, user := range users {
 					var entityArray *management.EntityArray
 					diags.Append(framework.ParseResponse(
@@ -529,7 +517,6 @@ func (r *PopulationResource) checkControlsAndDeletePopulationUsers(ctx context.C
 			}
 		}
 	}
-	log.Printf("HERE!!!!! 2.8")
 
 	return diags
 }

--- a/internal/service/sso/resource_population.go
+++ b/internal/service/sso/resource_population.go
@@ -3,6 +3,7 @@ package sso
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 
@@ -23,8 +24,7 @@ import (
 // Types
 type PopulationResource struct {
 	serviceClientType
-	options            client.PopulationOptions
-	environmentOptions client.EnvironmentOptions
+	options client.GlobalOptions
 }
 
 type PopulationResourceModel struct {
@@ -120,13 +120,7 @@ func (r *PopulationResource) Configure(ctx context.Context, req resource.Configu
 	}
 
 	if resourceConfig.Client.GlobalOptions != nil {
-		if resourceConfig.Client.GlobalOptions.Environment != nil {
-			r.environmentOptions = *resourceConfig.Client.GlobalOptions.Environment
-		}
-
-		if resourceConfig.Client.GlobalOptions.Population != nil {
-			r.options = *resourceConfig.Client.GlobalOptions.Population
-		}
+		r.options = *resourceConfig.Client.GlobalOptions
 	}
 
 }
@@ -272,13 +266,24 @@ func (r *PopulationResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	if r.options.ContainsUsersForceDelete {
-		d := r.deletePopulationUsers(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString())
+	log.Printf("HERE!!!!! 1")
+
+	hasUsersAssigned, d := r.hasUsersAssigned(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString())
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if hasUsersAssigned {
+		log.Printf("HERE!!!!! 2")
+		d := r.checkControlsAndDeletePopulationUsers(ctx, data.EnvironmentId.ValueString(), data.Id.ValueString())
 		resp.Diagnostics.Append(d...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
+		log.Printf("HERE!!!!! 3")
 	}
+	log.Printf("HERE!!!!! 4")
 
 	// Run the API call
 	resp.Diagnostics.Append(framework.ParseResponse(
@@ -376,104 +381,155 @@ func (p *PopulationResourceModel) toState(apiObject *management.Population) diag
 	return diags
 }
 
-func (r *PopulationResource) checkEnvironmentControls(ctx context.Context, environmentID string) (bool, diag.Diagnostics) {
+func (r *PopulationResource) hasUsersAssigned(ctx context.Context, environmentID, populationID string) (bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	// If the environment options are to force delete production types, then return true, because this will delete the population anyway
-	if r.environmentOptions.ProductionTypeForceDelete {
-		return true, diags
-	}
-
-	// Check if the environment is a sandbox type.  We'll only delete users in sandbox environments
-	var environmentResponse *management.Environment
-	diags.Append(framework.ParseResponse(
-		ctx,
-
-		func() (any, *http.Response, error) {
-			fO, fR, fErr := r.Client.ManagementAPIClient.EnvironmentsApi.ReadOneEnvironment(ctx, environmentID).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, environmentID, fO, fR, fErr)
-		},
-		"ReadOneEnvironment-DeletePopulation",
-		framework.DefaultCustomError,
-		nil,
-		&environmentResponse,
-	)...)
+	users, d := r.readUsers(ctx, environmentID, populationID)
+	diags.Append(d...)
 	if diags.HasError() {
 		return false, diags
 	}
 
-	if v, ok := environmentResponse.GetTypeOk(); ok && *v == management.ENUMENVIRONMENTTYPE_SANDBOX {
+	if len(users) > 0 {
 		return true, diags
 	}
 
 	return false, diags
 }
 
-func (r *PopulationResource) deletePopulationUsers(ctx context.Context, environmentID, populationID string) diag.Diagnostics {
+func (r *PopulationResource) readUsers(ctx context.Context, environmentID, populationID string) ([]management.User, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	environmentControlsOk, d := r.checkEnvironmentControls(ctx, environmentID)
+	if m, err := regexp.MatchString(verify.P1ResourceIDRegexpFullString.String(), populationID); err == nil && m {
+
+		scimFilter := fmt.Sprintf(`population.id eq "%s"`, populationID)
+
+		// Run the API call
+		var entityArray *management.EntityArray
+		diags.Append(framework.ParseResponse(
+			ctx,
+
+			func() (any, *http.Response, error) {
+				fO, fR, fErr := r.Client.ManagementAPIClient.UsersApi.ReadAllUsers(ctx, environmentID).Filter(scimFilter).Execute()
+				return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, environmentID, fO, fR, fErr)
+			},
+			"ReadAllUsers",
+			framework.DefaultCustomError,
+			sdk.DefaultCreateReadRetryable,
+			&entityArray,
+		)...)
+
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		return entityArray.Embedded.GetUsers(), nil
+	}
+
+	if r.options.Population.ContainsUsersForceDelete {
+		diags.AddError(
+			"Data protection notice",
+			fmt.Sprintf("For data protection reasons, it could not be determined whether users exist in the population %[2]s in environment %[1]s. Any users in this population will not be deleted.", environmentID, populationID),
+		)
+	}
+
+	return nil, diags
+}
+
+func (r *PopulationResource) checkEnvironmentControls(ctx context.Context, environmentID, populationID string) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if r.options.Population.ContainsUsersForceDelete {
+		// If the environment options are to force delete production types, then return true, because this will delete the population anyway
+		if r.options.Environment.ProductionTypeForceDelete {
+			return true, diags
+		}
+
+		// Check if the environment is a sandbox type.  We'll only delete users in sandbox environments
+		var environmentResponse *management.Environment
+		diags.Append(framework.ParseResponse(
+			ctx,
+
+			func() (any, *http.Response, error) {
+				fO, fR, fErr := r.Client.ManagementAPIClient.EnvironmentsApi.ReadOneEnvironment(ctx, environmentID).Execute()
+				return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, environmentID, fO, fR, fErr)
+			},
+			"ReadOneEnvironment-DeletePopulation",
+			framework.DefaultCustomError,
+			nil,
+			&environmentResponse,
+		)...)
+		if diags.HasError() {
+			return false, diags
+		}
+
+		if v, ok := environmentResponse.GetTypeOk(); ok && *v == management.ENUMENVIRONMENTTYPE_SANDBOX {
+			return true, diags
+		} else {
+			diags.AddWarning(
+				"Data protection notice",
+				fmt.Sprintf("For data protection reasons, the provider configuration `global_options.population.contains_users_force_delete` has no effect on environment ID %[1]s as it has a type set to `PRODUCTION`.  Users in this population will not be deleted.\n"+
+					"If you wish to force delete population %[2]s in environment %[1]s, please set the environment type to \"SANDBOX\" or set the `global_options.environment.production_type_force_delete` provider setting to `true`.", environmentID, populationID),
+			)
+		}
+	}
+
+	return false, diags
+}
+
+func (r *PopulationResource) checkControlsAndDeletePopulationUsers(ctx context.Context, environmentID, populationID string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	log.Printf("HERE!!!!! 2.1")
+	environmentControlsOk, d := r.checkEnvironmentControls(ctx, environmentID, populationID)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
+	log.Printf("HERE!!!!! 2.2")
 
 	if environmentControlsOk {
+		log.Printf("HERE!!!!! 2.3")
 
-		// VALIDATE POPULATION ID REGEX, so populationID is not empty and is a valid UUID
-		if m, err := regexp.MatchString(verify.P1ResourceIDRegexpFullString.String(), populationID); err == nil && m {
+		loopCounter := 1
+		for loopCounter > 0 {
+			log.Printf("HERE!!!!! 2.5")
 
-			scimFilter := fmt.Sprintf(`population.id eq "%s"`, populationID)
+			users, d := r.readUsers(ctx, environmentID, populationID)
+			diags.Append(d...)
+			if diags.HasError() {
+				return diags
+			}
 
-			loopCounter := 1
-			for loopCounter > 0 {
+			// DELETE USERS
+			if len(users) == 0 {
+				log.Printf("HERE!!!!! 2.6")
+				break
+			} else {
+				log.Printf("HERE!!!!! 2.7")
+				for _, user := range users {
+					var entityArray *management.EntityArray
+					diags.Append(framework.ParseResponse(
+						ctx,
 
-				// Run the API call
-				var entityArray *management.EntityArray
-				diags.Append(framework.ParseResponse(
-					ctx,
+						func() (any, *http.Response, error) {
+							fR, fErr := r.Client.ManagementAPIClient.UsersApi.DeleteUser(ctx, environmentID, user.GetId()).Execute()
+							return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, environmentID, nil, fR, fErr)
+						},
+						"DeleteUser-DeletePopulation",
+						framework.DefaultCustomError,
+						nil,
+						&entityArray,
+					)...)
 
-					func() (any, *http.Response, error) {
-						fO, fR, fErr := r.Client.ManagementAPIClient.UsersApi.ReadAllUsers(ctx, environmentID).Filter(scimFilter).Execute()
-						return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, environmentID, fO, fR, fErr)
-					},
-					"ReadAllUsers-DeletePopulation",
-					framework.DefaultCustomError,
-					sdk.DefaultCreateReadRetryable,
-					&entityArray,
-				)...)
-
-				if diags.HasError() {
-					return diags
-				}
-
-				// DELETE USERS
-				if len(entityArray.Embedded.GetUsers()) == 0 {
-					break
-				} else {
-					for _, user := range entityArray.Embedded.GetUsers() {
-						var entityArray *management.EntityArray
-						diags.Append(framework.ParseResponse(
-							ctx,
-
-							func() (any, *http.Response, error) {
-								fR, fErr := r.Client.ManagementAPIClient.UsersApi.DeleteUser(ctx, environmentID, user.GetId()).Execute()
-								return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, environmentID, nil, fR, fErr)
-							},
-							"DeleteUser-DeletePopulation",
-							framework.DefaultCustomError,
-							nil,
-							&entityArray,
-						)...)
-
-						if diags.HasError() {
-							return diags
-						}
+					if diags.HasError() {
+						return diags
 					}
 				}
 			}
 		}
 	}
+	log.Printf("HERE!!!!! 2.8")
 
 	return diags
 }

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -27,7 +27,14 @@ func SweepClient(ctx context.Context) (*client.Client, error) {
 		ClientSecret:  os.Getenv("PINGONE_CLIENT_SECRET"),
 		EnvironmentID: os.Getenv("PINGONE_ENVIRONMENT_ID"),
 		Region:        os.Getenv("PINGONE_REGION"),
-		ForceDelete:   true,
+		GlobalOptions: &client.GlobalOptions{
+			Environment: &client.EnvironmentOptions{
+				ProductionTypeForceDelete: true,
+			},
+			Population: &client.PopulationOptions{
+				ContainsUsersForceDelete: true,
+			},
+		},
 	}
 
 	return config.APIClient(ctx, getProviderTestingVersion())

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -48,16 +48,33 @@ The PingOne provider allows custom information to be appended to the default use
 
 {{ codefile "shell" (printf "%s" "examples/provider/provider-custom-user-agent.sh") }}
 
+## Global Options
+
+The PingOne provider provides global options to override API behaviours in PingOne, for example to override data protection features for development, testing and demo use cases.
+
+The following example shows how to configure the provider with global options to force-delete populations that contain users not managed by Terraform, and force-delete environments if they are of type `PRODUCTION`.
+
+{{ tffile "examples/provider/provider-global-options.tf" }}
+
 ## Provider Schema Reference
 
 - `api_access_token` (String) The access token used for provider resource management against the PingOne management API.  Default value can be set with the `PINGONE_API_ACCESS_TOKEN` environment variable.  Must provide only one of `api_access_token` (when obtaining the worker token outside of the provider) and `client_id` (when the provider should fetch the worker token during operations).
 - `client_id` (String) Client ID for the worker app client.  Default value can be set with the `PINGONE_CLIENT_ID` environment variable.  Must provide only one of `api_access_token` (when obtaining the worker token outside of the provider) and `client_id` (when the provider should fetch the worker token during operations).  Must be configured with `client_secret` and `environment_id`.
 - `client_secret` (String) Client secret for the worker app client.  Default value can be set with the `PINGONE_CLIENT_SECRET` environment variable.  Must be configured with `client_id` and `environment_id`.
 - `environment_id` (String) Environment ID for the worker app client.  Default value can be set with the `PINGONE_ENVIRONMENT_ID` environment variable.  Must be configured with `client_id` and `client_secret`.
-- `force_delete_production_type` (Boolean) Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable.
+- `force_delete_production_type` (Boolean, Deprecated) **Deprecation notice**.  *This parameter is deprecated and will be removed in the next major release.  Use the `global_options` options going forward.*  Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable.
+- `global_options` (Block List) A single block containing configuration items to override API behaviours in PingOne. (see [below for nested schema](#nestedblock--global_options))
 - `http_proxy` (String) Full URL for the http/https proxy service, for example `http://127.0.0.1:8090`.  Default value can be set with the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
 - `region` (String) The PingOne region to use.  Options are `AsiaPacific` `Canada` `Europe` and `NorthAmerica`.  Default value can be set with the `PINGONE_REGION` environment variable.
 - `service_endpoints` (Block List) A single block containing configuration items to override the service API endpoints of PingOne. (see [below for nested schema](#nestedblock--service_endpoints))
+
+<a id="nestedblock--global_options"></a>
+### Nested Schema for `global_options`
+
+Optional:
+
+- `environment` (Block List) A single block containing global configuration items to override environment resource settings in PingOne. (see [below for nested schema](#nestedblock--global_options-environment))
+- `population` (Block List) A single block containing configuration items to override population resource settings in PingOne. (see [below for nested schema](#nestedblock--global_options))
 
 <a id="nestedblock--service_endpoints"></a>
 ### Nested Schema for `service_endpoints`
@@ -66,3 +83,17 @@ Required:
 
 - `api_hostname` (String) Hostname for the PingOne management service API.  Default value can be set with the `PINGONE_API_SERVICE_HOSTNAME` environment variable.
 - `auth_hostname` (String) Hostname for the PingOne authentication service API.  Default value can be set with the `PINGONE_AUTH_SERVICE_HOSTNAME` environment variable.
+
+<a id="nestedblock--global_options-environment"></a>
+### Nested Schema for `global_options.environment`
+
+Optional:
+
+- `production_type_force_delete` (Boolean) Choose whether to force-delete any configuration that has a `PRODUCTION` type parameter.  The platform default is that `PRODUCTION` type configuration will not destroy without intervention to protect stored data.  By default this parameter is set to `false` and can be overridden with the `PINGONE_FORCE_DELETE_PRODUCTION_TYPE` environment variable. This option should not be set to `true` when the environment contains production data. Data loss may occur.
+
+<a id="nestedblock--global_options-population"></a>
+### Nested Schema for `global_options.population`
+
+Optional:
+
+- `contains_users_force_delete` (Boolean) Choose whether to force-delete populations that contain users not managed by Terraform.  Useful for development and testing use cases, and only applies if the environment that contains the population is of type `SANDBOX`, or the `global_options.environment.production_type_force_delete` parameter is set to `true`.  The platform default is that populations cannot be removed if they contain user data.  By default this parameter is set to `false`. This option should not be set to `true` when the environment contains production data. Data loss may occur.


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Added `global_options` provider parameter block to be able to override specific API behaviours.
- Added the `global_options.population.contains_users_force_delete` provider parameter to be able to force-delete populations if they contain users in sandbox environments.  Use of this provider option may result in loss of user data - use with caution.
- Deprecated the `force_delete_production_type` provider parameter.  This parameter will be removed in the next major release.  Please use the `global_options.population.contains_users_force_delete` provider parameter going forward.  Use of this provider option may result in loss of user data - use with caution.
- `resource/pingone_environment`: Code optimisation on plan modification.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccEnvironment_ github.com/pingidentity/terraform-provider-pingone/internal/service/base && \
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccPopulation_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccEnvironment_RemovalDrift
=== PAUSE TestAccEnvironment_RemovalDrift
=== RUN   TestAccEnvironment_Full
=== PAUSE TestAccEnvironment_Full
=== RUN   TestAccEnvironment_Minimal
=== PAUSE TestAccEnvironment_Minimal
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== RUN   TestAccEnvironment_DeleteProductionEnvironmentProtection
=== PAUSE TestAccEnvironment_DeleteProductionEnvironmentProtection
=== RUN   TestAccEnvironment_DeleteProductionEnvironment
=== PAUSE TestAccEnvironment_DeleteProductionEnvironment
=== RUN   TestAccEnvironment_MinimalWithPopulation
=== PAUSE TestAccEnvironment_MinimalWithPopulation
=== RUN   TestAccEnvironment_EnvironmentTypeSwitching
=== PAUSE TestAccEnvironment_EnvironmentTypeSwitching
=== RUN   TestAccEnvironment_ServiceSwitching
=== PAUSE TestAccEnvironment_ServiceSwitching
=== RUN   TestAccEnvironment_Services
=== PAUSE TestAccEnvironment_Services
=== RUN   TestAccEnvironment_ServicesTags
=== PAUSE TestAccEnvironment_ServicesTags
=== RUN   TestAccEnvironment_BadParameters
=== PAUSE TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_RemovalDrift
=== CONT  TestAccEnvironment_MinimalWithPopulation
=== CONT  TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_Minimal
=== CONT  TestAccEnvironment_Full
=== CONT  TestAccEnvironment_BadParameters
=== CONT  TestAccEnvironment_Services
=== CONT  TestAccEnvironment_EnvironmentTypeSwitching
=== CONT  TestAccEnvironment_ServicesTags
=== CONT  TestAccEnvironment_DeleteProductionEnvironmentProtection
=== CONT  TestAccEnvironment_DeleteProductionEnvironment
=== CONT  TestAccEnvironment_ServiceSwitching
=== NAME  TestAccEnvironment_DeleteProductionEnvironment
    resource_environment_test.go:294: Test to be defined
=== NAME  TestAccEnvironment_ServicesTags
    acctest.go:107: Skipping feature flag test.  Flag required: "DAVINCI"
--- SKIP: TestAccEnvironment_ServicesTags (0.00s)
--- SKIP: TestAccEnvironment_DeleteProductionEnvironment (0.00s)
=== NAME  TestAccEnvironment_DeleteProductionEnvironmentProtection
    resource_environment_test.go:267: Test to be defined
--- SKIP: TestAccEnvironment_DeleteProductionEnvironmentProtection (0.00s)
--- PASS: TestAccEnvironment_NonCompatibleRegion (2.58s)
--- PASS: TestAccEnvironment_RemovalDrift (6.13s)
--- PASS: TestAccEnvironment_Minimal (6.87s)
--- PASS: TestAccEnvironment_BadParameters (7.70s)
--- PASS: TestAccEnvironment_MinimalWithPopulation (8.88s)
--- PASS: TestAccEnvironment_ServiceSwitching (12.33s)
--- PASS: TestAccEnvironment_EnvironmentTypeSwitching (13.07s)
--- PASS: TestAccEnvironment_Full (14.85s)
--- PASS: TestAccEnvironment_Services (19.70s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        20.678s
=== RUN   TestAccPopulation_RemovalDrift
=== PAUSE TestAccPopulation_RemovalDrift
=== RUN   TestAccPopulation_NewEnv
=== PAUSE TestAccPopulation_NewEnv
=== RUN   TestAccPopulation_Full
=== PAUSE TestAccPopulation_Full
=== RUN   TestAccPopulation_Minimal
=== PAUSE TestAccPopulation_Minimal
=== RUN   TestAccPopulation_DataProtection
=== PAUSE TestAccPopulation_DataProtection
=== RUN   TestAccPopulation_BadParameters
=== PAUSE TestAccPopulation_BadParameters
=== CONT  TestAccPopulation_RemovalDrift
=== CONT  TestAccPopulation_Minimal
=== CONT  TestAccPopulation_Full
=== CONT  TestAccPopulation_BadParameters
=== CONT  TestAccPopulation_DataProtection
=== CONT  TestAccPopulation_NewEnv
--- PASS: TestAccPopulation_Minimal (4.95s)
--- PASS: TestAccPopulation_Full (6.86s)
--- PASS: TestAccPopulation_BadParameters (7.94s)
--- PASS: TestAccPopulation_NewEnv (13.16s)
--- PASS: TestAccPopulation_RemovalDrift (15.75s)
--- PASS: TestAccPopulation_DataProtection (21.94s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 23.221s
```

</details>