### PR TITLE
`resource/pingone_notification_template_content`: Fixed `Invalid import ID specified` error when attempting to import `credential_issued` and `verification_code_template` templates

### DIFF
--- a/.changelog/778.txt
+++ b/.changelog/778.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_notification_template_content`: Fixed `Invalid import ID specified` error when attempting to import `credential_issued` and `verification_code_template` templates.
+```

--- a/internal/service/base/resource_notification_template_content.go
+++ b/internal/service/base/resource_notification_template_content.go
@@ -482,7 +482,7 @@ func resourceNotificationTemplateContentImport(ctx context.Context, d *schema.Re
 		},
 		{
 			Label:  "template_name",
-			Regexp: regexp.MustCompile(fmt.Sprintf("`%s`", strings.Join(utils.EnumSliceToStringSlice(management.AllowedEnumTemplateNameEnumValues), "|"))),
+			Regexp: regexp.MustCompile(fmt.Sprintf("(%s)", strings.Join(utils.EnumSliceToStringSlice(management.AllowedEnumTemplateNameEnumValues), "|"))),
 		},
 		{
 			Label:  "notification_template_content_id",

--- a/internal/service/base/resource_notification_template_content_test.go
+++ b/internal/service/base/resource_notification_template_content_test.go
@@ -233,7 +233,7 @@ func TestAccNotificationTemplateContent_NewVariant(t *testing.T) {
 
 	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
-	name := "strong_authentication"
+	name := "verification_code_template"
 	locale := "en"
 	variant := "My New Variant"
 
@@ -244,8 +244,8 @@ func TestAccNotificationTemplateContent_NewVariant(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 		resource.TestCheckResourceAttr(resourceFullName, "variant", variant),
-		resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-		resource.TestCheckResourceAttr(resourceFullName, "push.#", "1"),
+		resource.TestCheckResourceAttr(resourceFullName, "email.#", "1"),
+		resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
 		resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
 		resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
 	)
@@ -303,7 +303,7 @@ func TestAccNotificationTemplateContent_ChangeVariant(t *testing.T) {
 
 	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
-	name := "strong_authentication"
+	name := "verification_code_template"
 	locale := "en"
 
 	variant1 := "My New Variant"
@@ -341,7 +341,7 @@ func TestAccNotificationTemplateContent_ChangeVariant(t *testing.T) {
 			},
 			// From no variant, to variant
 			{
-				Config: testAccNotificationTemplateContentConfig_DefaultVariant_Push_Minimal(environmentName, licenseID, resourceName, name, locale),
+				Config: testAccNotificationTemplateContentConfig_NoVariant_Minimal(environmentName, licenseID, resourceName, name, locale),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "variant", ""),
 				),
@@ -863,11 +863,31 @@ resource "pingone_notification_template_content" "%[3]s" {
   locale         = "%[5]s"
   variant        = "%[6]s"
 
-  push {
-    body  = "Min - Please approve this transaction."
-    title = "Min - BX Retail Transaction Request"
+  email {
+    body    = <<EOT
+Test $${code.value}
+EOT
+    subject = "Test"
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, locale, variant)
+}
+
+func testAccNotificationTemplateContentConfig_NoVariant_Minimal(environmentName, licenseID, resourceName, name, locale string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_notification_template_content" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  template_name  = "%[4]s"
+  locale         = "%[5]s"
+
+  email {
+    body    = <<EOT
+Test $${code.value}
+EOT
+    subject = "Test"
+  }
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, locale)
 }
 
 func testAccNotificationTemplateContentConfig_DuplicateLocale(environmentName, licenseID, resourceName, name, locale string) string {


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_notification_template_content`: Fixed `Invalid import ID specified` error when attempting to import `credential_issued` and `verification_code_template` templates

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccNotificationTemplateContent_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccNotificationTemplateContent_RemovalDrift
=== PAUSE TestAccNotificationTemplateContent_RemovalDrift
=== RUN   TestAccNotificationTemplateContent_OverrideDefaultLocale
=== PAUSE TestAccNotificationTemplateContent_OverrideDefaultLocale
=== RUN   TestAccNotificationTemplateContent_NewLocale
=== PAUSE TestAccNotificationTemplateContent_NewLocale
=== RUN   TestAccNotificationTemplateContent_NewVariant
=== PAUSE TestAccNotificationTemplateContent_NewVariant
=== RUN   TestAccNotificationTemplateContent_ChangeVariant
=== PAUSE TestAccNotificationTemplateContent_ChangeVariant
=== RUN   TestAccNotificationTemplateContent_InvalidData
=== PAUSE TestAccNotificationTemplateContent_InvalidData
=== RUN   TestAccNotificationTemplateContent_Email
=== PAUSE TestAccNotificationTemplateContent_Email
=== RUN   TestAccNotificationTemplateContent_Push
=== PAUSE TestAccNotificationTemplateContent_Push
=== RUN   TestAccNotificationTemplateContent_SMS
=== PAUSE TestAccNotificationTemplateContent_SMS
=== RUN   TestAccNotificationTemplateContent_Voice
=== PAUSE TestAccNotificationTemplateContent_Voice
=== RUN   TestAccNotificationTemplateContent_BadParameters
=== PAUSE TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_RemovalDrift
=== CONT  TestAccNotificationTemplateContent_Email
=== CONT  TestAccNotificationTemplateContent_NewVariant
=== CONT  TestAccNotificationTemplateContent_InvalidData
=== CONT  TestAccNotificationTemplateContent_Voice
=== CONT  TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_ChangeVariant
=== CONT  TestAccNotificationTemplateContent_Push
=== CONT  TestAccNotificationTemplateContent_NewLocale
=== CONT  TestAccNotificationTemplateContent_OverrideDefaultLocale
=== CONT  TestAccNotificationTemplateContent_SMS
--- PASS: TestAccNotificationTemplateContent_InvalidData (11.36s)
--- PASS: TestAccNotificationTemplateContent_BadParameters (16.93s)
--- PASS: TestAccNotificationTemplateContent_RemovalDrift (27.83s)
--- PASS: TestAccNotificationTemplateContent_OverrideDefaultLocale (32.32s)
--- PASS: TestAccNotificationTemplateContent_NewVariant (33.13s)
--- PASS: TestAccNotificationTemplateContent_ChangeVariant (44.79s)
--- PASS: TestAccNotificationTemplateContent_NewLocale (44.83s)
--- PASS: TestAccNotificationTemplateContent_Email (61.76s)
--- PASS: TestAccNotificationTemplateContent_Voice (71.74s)
--- PASS: TestAccNotificationTemplateContent_SMS (73.56s)
--- PASS: TestAccNotificationTemplateContent_Push (74.72s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        75.992s
```

</details>