### PR TITLE
`resource/pingone_notification_template_content`: Fix `expected length of content to be in the range (1 - 153)` error when attempting to import longer length SMS templates configured in the console.

### DIFF
--- a/.changelog/780.txt
+++ b/.changelog/780.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_notification_template_content`: Fixed `expected length of content to be in the range (1 - 153)` error when attempting to import longer length SMS templates configured in the console.
+```

--- a/internal/service/base/resource_notification_template_content.go
+++ b/internal/service/base/resource_notification_template_content.go
@@ -190,10 +190,10 @@ func ResourceNotificationTemplateContent() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"content": {
-							Description:      "The SMS text. UC-2 encoding is used for text that contains non GSM-7 characters. UC-2 encoded text cannot exceed 67 characters. GSM-7 encoded text cannot exceed 153 characters. This can include variables.",
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 153)),
+							Description: "The SMS text. UC-2 encoding is used for text that contains non GSM-7 characters. UC-2 encoded text cannot exceed 67 characters. GSM-7 encoded text cannot exceed 153 characters. This can include variables.",
+							Type:        schema.TypeString,
+							Required:    true,
+							// ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(1, 153)),
 						},
 						"sender": {
 							Description: "The SMS sender ID. This property can contain only alphanumeric characters and spaces, and its length cannot exceed 11 characters. In some countries, it is impossible to send an SMS with an alphanumeric sender ID. For those countries, the sender ID must be empty. For SMS recipients in specific countries, refer to Twilio's documentation on [International support for Alphanumeric Sender ID](https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID).",


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_notification_template_content`: Fixed `expected length of content to be in the range (1 - 153)` error when attempting to import longer length SMS templates configured in the console.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccNotificationTemplateContent_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccNotificationTemplateContent_RemovalDrift
=== PAUSE TestAccNotificationTemplateContent_RemovalDrift
=== RUN   TestAccNotificationTemplateContent_OverrideDefaultLocale
=== PAUSE TestAccNotificationTemplateContent_OverrideDefaultLocale
=== RUN   TestAccNotificationTemplateContent_NewLocale
=== PAUSE TestAccNotificationTemplateContent_NewLocale
=== RUN   TestAccNotificationTemplateContent_NewVariant
=== PAUSE TestAccNotificationTemplateContent_NewVariant
=== RUN   TestAccNotificationTemplateContent_ChangeVariant
=== PAUSE TestAccNotificationTemplateContent_ChangeVariant
=== RUN   TestAccNotificationTemplateContent_InvalidData
=== PAUSE TestAccNotificationTemplateContent_InvalidData
=== RUN   TestAccNotificationTemplateContent_Email
=== PAUSE TestAccNotificationTemplateContent_Email
=== RUN   TestAccNotificationTemplateContent_Push
=== PAUSE TestAccNotificationTemplateContent_Push
=== RUN   TestAccNotificationTemplateContent_SMS
=== PAUSE TestAccNotificationTemplateContent_SMS
=== RUN   TestAccNotificationTemplateContent_Voice
=== PAUSE TestAccNotificationTemplateContent_Voice
=== RUN   TestAccNotificationTemplateContent_BadParameters
=== PAUSE TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_RemovalDrift
=== CONT  TestAccNotificationTemplateContent_Email
=== CONT  TestAccNotificationTemplateContent_Voice
=== CONT  TestAccNotificationTemplateContent_SMS
=== CONT  TestAccNotificationTemplateContent_Push
=== CONT  TestAccNotificationTemplateContent_NewVariant
=== CONT  TestAccNotificationTemplateContent_NewLocale
=== CONT  TestAccNotificationTemplateContent_InvalidData
=== CONT  TestAccNotificationTemplateContent_OverrideDefaultLocale
=== CONT  TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_ChangeVariant
--- PASS: TestAccNotificationTemplateContent_InvalidData (11.63s)
--- PASS: TestAccNotificationTemplateContent_BadParameters (18.68s)
--- PASS: TestAccNotificationTemplateContent_RemovalDrift (28.56s)
--- PASS: TestAccNotificationTemplateContent_NewVariant (34.59s)
--- PASS: TestAccNotificationTemplateContent_OverrideDefaultLocale (34.67s)
--- PASS: TestAccNotificationTemplateContent_NewLocale (47.03s)
--- PASS: TestAccNotificationTemplateContent_ChangeVariant (50.64s)
--- PASS: TestAccNotificationTemplateContent_Email (64.08s)
--- PASS: TestAccNotificationTemplateContent_Push (75.88s)
--- PASS: TestAccNotificationTemplateContent_SMS (78.30s)
--- PASS: TestAccNotificationTemplateContent_Voice (78.30s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        79.736s
```

</details>