### PR TITLE
`resource/pingone_notification_settings_email`: Fix panic crash when attempting to import environment default notification email settings

### DIFF
--- a/.changelog/782.txt
+++ b/.changelog/782.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_notification_settings_email`: Fixed panic crash when attempting to import environment default notification email settings.
+```

--- a/internal/service/base/resource_notification_settings_email.go
+++ b/internal/service/base/resource_notification_settings_email.go
@@ -472,8 +472,7 @@ func (p *NotificationSettingsEmailResourceModel) toState(apiObject *management.N
 		return diags
 	}
 
-	p.Id = framework.StringToTF(*apiObject.GetEnvironment().Id)
-	p.EnvironmentId = framework.StringToTF(*apiObject.GetEnvironment().Id)
+	p.Id = p.EnvironmentId
 
 	p.Host = framework.StringOkToTF(apiObject.GetHostOk())
 	p.Port = framework.Int32OkToTF(apiObject.GetPortOk())


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_notification_settings_email`: Fixed panic crash when attempting to import environment default notification email settings.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccNotificationSettingsEmail_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccNotificationSettingsEmail_RemovalDrift
=== PAUSE TestAccNotificationSettingsEmail_RemovalDrift
=== RUN   TestAccNotificationSettingsEmail_Full
=== PAUSE TestAccNotificationSettingsEmail_Full
=== RUN   TestAccNotificationSettingsEmail_EmailSources
=== PAUSE TestAccNotificationSettingsEmail_EmailSources
=== RUN   TestAccNotificationSettingsEmail_BadParameters
=== PAUSE TestAccNotificationSettingsEmail_BadParameters
=== CONT  TestAccNotificationSettingsEmail_RemovalDrift
=== CONT  TestAccNotificationSettingsEmail_EmailSources
=== CONT  TestAccNotificationSettingsEmail_BadParameters
=== CONT  TestAccNotificationSettingsEmail_Full
--- PASS: TestAccNotificationSettingsEmail_RemovalDrift (11.98s)
--- PASS: TestAccNotificationSettingsEmail_Full (14.01s)
--- PASS: TestAccNotificationSettingsEmail_BadParameters (14.15s)
--- PASS: TestAccNotificationSettingsEmail_EmailSources (117.77s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        118.828s
```

</details>