### PR TITLE
Changed date-time fields to use custom RFC3339 data type

### DIFF
--- a/.changelog/784.txt
+++ b/.changelog/784.txt
@@ -1,0 +1,3 @@
+```release-note:note
+Changed date-time fields to use custom RFC3339 data type.
+```

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
+	github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0 h1:b8vZYB/SkXJT
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0/go.mod h1:tP9BC3icoXBz72evMS5UTFvi98CiKhPdXF6yLs1wS8A=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.0 h1:egR4InfakWkgepZNUATWGwkrPhaAYOTEybPfEol+G/I=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.3.0/go.mod h1:9vjvl36aY1p6KltaA5QCvGC5hdE/9t4YuhGftw6WOgE=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.22.1 h1:iTS7WHNVrn7uhe3cojtvWWn83cm2Z6ryIUDTRO0EV7w=

--- a/internal/framework/resource.go
+++ b/internal/framework/resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -79,11 +80,11 @@ func BoolOkToTF(b *bool, ok bool) basetypes.BoolValue {
 	}
 }
 
-func TimeOkToTF(v *time.Time, ok bool) basetypes.StringValue {
+func TimeOkToTF(v *time.Time, ok bool) timetypes.RFC3339 {
 	if !ok || v == nil {
-		return types.StringNull()
+		return timetypes.NewRFC3339Null()
 	} else {
-		return types.StringValue(v.Format(time.RFC3339))
+		return timetypes.NewRFC3339TimeValue(*v)
 	}
 }
 

--- a/internal/service/base/data_source_agreement.go
+++ b/internal/service/base/data_source_agreement.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -22,16 +23,16 @@ import (
 type AgreementDataSource serviceClientType
 
 type AgreementDataSourceModel struct {
-	Id                    types.String  `tfsdk:"id"`
-	EnvironmentId         types.String  `tfsdk:"environment_id"`
-	AgreementId           types.String  `tfsdk:"agreement_id"`
-	Name                  types.String  `tfsdk:"name"`
-	Enabled               types.Bool    `tfsdk:"enabled"`
-	Description           types.String  `tfsdk:"description"`
-	ReconsentPeriodDays   types.Float64 `tfsdk:"reconsent_period_days"`
-	TotalUserConsents     types.Int64   `tfsdk:"total_user_consent_count"`
-	ExpiredUserConsents   types.Int64   `tfsdk:"expired_user_consent_count"`
-	ConsentCountsUpdateAt types.String  `tfsdk:"consent_counts_updated_at"`
+	Id                    types.String      `tfsdk:"id"`
+	EnvironmentId         types.String      `tfsdk:"environment_id"`
+	AgreementId           types.String      `tfsdk:"agreement_id"`
+	Name                  types.String      `tfsdk:"name"`
+	Enabled               types.Bool        `tfsdk:"enabled"`
+	Description           types.String      `tfsdk:"description"`
+	ReconsentPeriodDays   types.Float64     `tfsdk:"reconsent_period_days"`
+	TotalUserConsents     types.Int64       `tfsdk:"total_user_consent_count"`
+	ExpiredUserConsents   types.Int64       `tfsdk:"expired_user_consent_count"`
+	ConsentCountsUpdateAt timetypes.RFC3339 `tfsdk:"consent_counts_updated_at"`
 }
 
 // Framework interfaces
@@ -121,6 +122,8 @@ func (r *AgreementDataSource) Schema(ctx context.Context, req datasource.SchemaR
 			"consent_counts_updated_at": schema.StringAttribute{
 				Description: "The date and time the consent user count metrics were last updated. This value is typically updated once every 24 hours.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/base/resource_agreement_localization_revision.go
+++ b/internal/service/base/resource_agreement_localization_revision.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -30,15 +31,15 @@ import (
 type AgreementLocalizationRevisionResource serviceClientType
 
 type AgreementLocalizationRevisionResourceModel struct {
-	Id                      types.String `tfsdk:"id"`
-	EnvironmentId           types.String `tfsdk:"environment_id"`
-	AgreementId             types.String `tfsdk:"agreement_id"`
-	AgreementLocalizationId types.String `tfsdk:"agreement_localization_id"`
-	ContentType             types.String `tfsdk:"content_type"`
-	EffectiveAt             types.String `tfsdk:"effective_at"`
-	NotValidAfter           types.String `tfsdk:"not_valid_after"`
-	RequireReconsent        types.Bool   `tfsdk:"require_reconsent"`
-	Text                    types.String `tfsdk:"text"`
+	Id                      types.String      `tfsdk:"id"`
+	EnvironmentId           types.String      `tfsdk:"environment_id"`
+	AgreementId             types.String      `tfsdk:"agreement_id"`
+	AgreementLocalizationId types.String      `tfsdk:"agreement_localization_id"`
+	ContentType             types.String      `tfsdk:"content_type"`
+	EffectiveAt             timetypes.RFC3339 `tfsdk:"effective_at"`
+	NotValidAfter           timetypes.RFC3339 `tfsdk:"not_valid_after"`
+	RequireReconsent        types.Bool        `tfsdk:"require_reconsent"`
+	Text                    types.String      `tfsdk:"text"`
 }
 
 // Framework interfaces
@@ -113,6 +114,9 @@ func (r *AgreementLocalizationRevisionResource) Schema(ctx context.Context, req 
 				Description: "The start date that the revision is presented to users.  The effective date must be unique for each language agreement, and the property value can be the present date or a future date only.  Must be a valid RFC3339 date/time string.  If left undefined, will default to the current date and time (the revision will be effective immediately).",
 				Optional:    true,
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
@@ -125,6 +129,8 @@ func (r *AgreementLocalizationRevisionResource) Schema(ctx context.Context, req 
 			"not_valid_after": schema.StringAttribute{
 				Description: "Specifies whether the revision is still valid in the context of all revisions for a language. This property is calculated dynamically at read time, taking into consideration the agreement language, the language enabled property, and the agreement enabled property. When a new revision is added, this attribute's property values for all other previous revisions might be impacted. For example, if a new revision becomes effective and it forces reconsent, then all older revisions are no longer valid.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"require_reconsent": schema.BoolAttribute{
@@ -374,21 +380,18 @@ func (r *AgreementLocalizationRevisionResource) ImportState(ctx context.Context,
 }
 
 func (p *AgreementLocalizationRevisionResourceModel) expand() (*management.AgreementLanguageRevision, diag.Diagnostics) {
-	var diags diag.Diagnostics
+	var diags, d diag.Diagnostics
 
 	var t time.Time
 
 	if !p.EffectiveAt.IsNull() && !p.EffectiveAt.IsUnknown() {
-		var e error
-		t, e = time.Parse(time.RFC3339, p.EffectiveAt.ValueString())
-		if e != nil {
-			diags.AddError(
-				"Invalid data format",
-				"Cannot convert effectve_at to a date/time.  Please check the format is a valid RFC3339 date time format.")
-			return nil, diags
-		}
+		t, d = p.EffectiveAt.ValueRFC3339Time()
+		diags.Append(d...)
 	} else {
 		t = time.Now().Local()
+	}
+	if diags.HasError() {
+		return nil, diags
 	}
 
 	data := management.NewAgreementLanguageRevision(

--- a/internal/service/base/resource_agreement_localization_revision.go
+++ b/internal/service/base/resource_agreement_localization_revision.go
@@ -121,9 +121,6 @@ func (r *AgreementLocalizationRevisionResource) Schema(ctx context.Context, req 
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(verify.RFC3339Regexp, "Attribute must be a valid RFC3339 date/time string."),
-				},
 			},
 
 			"not_valid_after": schema.StringAttribute{

--- a/internal/service/base/resource_custom_domain.go
+++ b/internal/service/base/resource_custom_domain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -24,12 +25,12 @@ import (
 type CustomDomainResource serviceClientType
 
 type CustomDomainResourceModel struct {
-	Id                   types.String `tfsdk:"id"`
-	EnvironmentId        types.String `tfsdk:"environment_id"`
-	DomainName           types.String `tfsdk:"domain_name"`
-	Status               types.String `tfsdk:"status"`
-	CanonicalName        types.String `tfsdk:"canonical_name"`
-	CertificateExpiresAt types.String `tfsdk:"certificate_expires_at"`
+	Id                   types.String      `tfsdk:"id"`
+	EnvironmentId        types.String      `tfsdk:"environment_id"`
+	DomainName           types.String      `tfsdk:"domain_name"`
+	Status               types.String      `tfsdk:"status"`
+	CanonicalName        types.String      `tfsdk:"canonical_name"`
+	CertificateExpiresAt timetypes.RFC3339 `tfsdk:"certificate_expires_at"`
 }
 
 // Framework interfaces
@@ -102,6 +103,8 @@ func (r *CustomDomainResource) Schema(ctx context.Context, req resource.SchemaRe
 			"certificate_expires_at": schema.StringAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("The time when the certificate expires.  If this property is not present, it indicates that an SSL certificate has not been setup for this custom domain.").Description,
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}
@@ -321,7 +324,7 @@ func (p *CustomDomainResourceModel) toState(apiObject *management.CustomDomain) 
 	if v, ok := apiObject.GetCertificateOk(); ok {
 		p.CertificateExpiresAt = framework.TimeOkToTF(v.GetExpiresAtOk())
 	} else {
-		p.CertificateExpiresAt = types.StringNull()
+		p.CertificateExpiresAt = timetypes.NewRFC3339Null()
 	}
 
 	return diags

--- a/internal/service/base/resource_custom_domain_ssl.go
+++ b/internal/service/base/resource_custom_domain_ssl.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -24,15 +25,15 @@ import (
 type CustomDomainSSLResource serviceClientType
 
 type CustomDomainSSLResourceModel struct {
-	Id                              types.String `tfsdk:"id"`
-	EnvironmentId                   types.String `tfsdk:"environment_id"`
-	CustomDomainId                  types.String `tfsdk:"custom_domain_id"`
-	CerificatePemFile               types.String `tfsdk:"certificate_pem_file"`
-	IntermediateCertificatesPemFile types.String `tfsdk:"intermediate_certificates_pem_file"`
-	PrivateKeyPemFile               types.String `tfsdk:"private_key_pem_file"`
-	DomainName                      types.String `tfsdk:"domain_name"`
-	Status                          types.String `tfsdk:"status"`
-	CertificateExpiresAt            types.String `tfsdk:"certificate_expires_at"`
+	Id                              types.String      `tfsdk:"id"`
+	EnvironmentId                   types.String      `tfsdk:"environment_id"`
+	CustomDomainId                  types.String      `tfsdk:"custom_domain_id"`
+	CerificatePemFile               types.String      `tfsdk:"certificate_pem_file"`
+	IntermediateCertificatesPemFile types.String      `tfsdk:"intermediate_certificates_pem_file"`
+	PrivateKeyPemFile               types.String      `tfsdk:"private_key_pem_file"`
+	DomainName                      types.String      `tfsdk:"domain_name"`
+	Status                          types.String      `tfsdk:"status"`
+	CertificateExpiresAt            timetypes.RFC3339 `tfsdk:"certificate_expires_at"`
 }
 
 // Framework interfaces
@@ -144,6 +145,8 @@ func (r *CustomDomainSSLResource) Schema(ctx context.Context, req resource.Schem
 			"certificate_expires_at": schema.StringAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("The time when the certificate expires.  If this property is not present, it indicates that an SSL certificate has not been setup for this custom domain.").Description,
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}
@@ -318,7 +321,7 @@ func (p *CustomDomainSSLResourceModel) toState(apiObject *management.CustomDomai
 	if v, ok := apiObject.GetCertificateOk(); ok {
 		p.CertificateExpiresAt = framework.TimeOkToTF(v.GetExpiresAtOk())
 	} else {
-		p.CertificateExpiresAt = types.StringNull()
+		p.CertificateExpiresAt = timetypes.NewRFC3339Null()
 	}
 
 	return diags

--- a/internal/service/base/resource_key.go
+++ b/internal/service/base/resource_key.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -36,24 +37,24 @@ import (
 type KeyResource serviceClientType
 
 type keyResourceModel struct {
-	Id                 types.String `tfsdk:"id"`
-	EnvironmentId      types.String `tfsdk:"environment_id"`
-	Name               types.String `tfsdk:"name"`
-	Algorithm          types.String `tfsdk:"algorithm"`
-	Default            types.Bool   `tfsdk:"default"`
-	ExpiresAt          types.String `tfsdk:"expires_at"`
-	IssuerDn           types.String `tfsdk:"issuer_dn"`
-	KeyLength          types.Int64  `tfsdk:"key_length"`
-	SerialNumber       types.String `tfsdk:"serial_number"`
-	SignatureAlgorithm types.String `tfsdk:"signature_algorithm"`
-	StartsAt           types.String `tfsdk:"starts_at"`
-	Status             types.String `tfsdk:"status"`
-	SubjectDn          types.String `tfsdk:"subject_dn"`
-	UsageType          types.String `tfsdk:"usage_type"`
-	ValidityPeriod     types.Int64  `tfsdk:"validity_period"`
-	CustomCrl          types.String `tfsdk:"custom_crl"`
-	PKCS12FileBase64   types.String `tfsdk:"pkcs12_file_base64"`
-	PKCS12FilePassword types.String `tfsdk:"pkcs12_file_password"`
+	Id                 types.String      `tfsdk:"id"`
+	EnvironmentId      types.String      `tfsdk:"environment_id"`
+	Name               types.String      `tfsdk:"name"`
+	Algorithm          types.String      `tfsdk:"algorithm"`
+	Default            types.Bool        `tfsdk:"default"`
+	ExpiresAt          timetypes.RFC3339 `tfsdk:"expires_at"`
+	IssuerDn           types.String      `tfsdk:"issuer_dn"`
+	KeyLength          types.Int64       `tfsdk:"key_length"`
+	SerialNumber       types.String      `tfsdk:"serial_number"`
+	SignatureAlgorithm types.String      `tfsdk:"signature_algorithm"`
+	StartsAt           timetypes.RFC3339 `tfsdk:"starts_at"`
+	Status             types.String      `tfsdk:"status"`
+	SubjectDn          types.String      `tfsdk:"subject_dn"`
+	UsageType          types.String      `tfsdk:"usage_type"`
+	ValidityPeriod     types.Int64       `tfsdk:"validity_period"`
+	CustomCrl          types.String      `tfsdk:"custom_crl"`
+	PKCS12FileBase64   types.String      `tfsdk:"pkcs12_file_base64"`
+	PKCS12FilePassword types.String      `tfsdk:"pkcs12_file_password"`
 }
 
 // Framework interfaces
@@ -221,6 +222,8 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the date and time the key resource expires.").Description,
 				Computed:    true,
 
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -328,6 +331,8 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"starts_at": schema.StringAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the date and time the validity period starts.").Description,
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),

--- a/internal/service/base/resource_key_rotation_policy.go
+++ b/internal/service/base/resource_key_rotation_policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -25,19 +26,19 @@ import (
 type KeyRotationPolicyResource serviceClientType
 
 type keyRotationPolicyResourceModel struct {
-	Id                 types.String `tfsdk:"id"`
-	EnvironmentId      types.String `tfsdk:"environment_id"`
-	Name               types.String `tfsdk:"name"`
-	Algorithm          types.String `tfsdk:"algorithm"`
-	CurrentKeyId       types.String `tfsdk:"current_key_id"`
-	SubjectDn          types.String `tfsdk:"subject_dn"`
-	KeyLength          types.Int64  `tfsdk:"key_length"`
-	NextKeyId          types.String `tfsdk:"next_key_id"`
-	RotatedAt          types.String `tfsdk:"rotated_at"`
-	RotationPeriod     types.Int64  `tfsdk:"rotation_period"`
-	SignatureAlgorithm types.String `tfsdk:"signature_algorithm"`
-	UsageType          types.String `tfsdk:"usage_type"`
-	ValidityPeriod     types.Int64  `tfsdk:"validity_period"`
+	Id                 types.String      `tfsdk:"id"`
+	EnvironmentId      types.String      `tfsdk:"environment_id"`
+	Name               types.String      `tfsdk:"name"`
+	Algorithm          types.String      `tfsdk:"algorithm"`
+	CurrentKeyId       types.String      `tfsdk:"current_key_id"`
+	SubjectDn          types.String      `tfsdk:"subject_dn"`
+	KeyLength          types.Int64       `tfsdk:"key_length"`
+	NextKeyId          types.String      `tfsdk:"next_key_id"`
+	RotatedAt          timetypes.RFC3339 `tfsdk:"rotated_at"`
+	RotationPeriod     types.Int64       `tfsdk:"rotation_period"`
+	SignatureAlgorithm types.String      `tfsdk:"signature_algorithm"`
+	UsageType          types.String      `tfsdk:"usage_type"`
+	ValidityPeriod     types.Int64       `tfsdk:"validity_period"`
 }
 
 // Framework interfaces
@@ -157,6 +158,8 @@ func (r *KeyRotationPolicyResource) Schema(ctx context.Context, req resource.Sch
 			"rotated_at": schema.StringAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("The last time the key rotation policy was rotated.").Description,
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"rotation_period": schema.Int64Attribute{

--- a/internal/service/base/resource_notification_settings.go
+++ b/internal/service/base/resource_notification_settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -29,14 +30,14 @@ import (
 type NotificationSettingsResource serviceClientType
 
 type NotificationSettingsResourceModel struct {
-	Id                    types.String `tfsdk:"id"`
-	EnvironmentId         types.String `tfsdk:"environment_id"`
-	DeliveryMode          types.String `tfsdk:"delivery_mode"`
-	ProviderFallbackChain types.List   `tfsdk:"provider_fallback_chain"`
-	From                  types.Object `tfsdk:"from"`
-	ReplyTo               types.Object `tfsdk:"reply_to"`
-	AllowedList           types.Set    `tfsdk:"allowed_list"`
-	UpdatedAt             types.String `tfsdk:"updated_at"`
+	Id                    types.String      `tfsdk:"id"`
+	EnvironmentId         types.String      `tfsdk:"environment_id"`
+	DeliveryMode          types.String      `tfsdk:"delivery_mode"`
+	ProviderFallbackChain types.List        `tfsdk:"provider_fallback_chain"`
+	From                  types.Object      `tfsdk:"from"`
+	ReplyTo               types.Object      `tfsdk:"reply_to"`
+	AllowedList           types.Set         `tfsdk:"allowed_list"`
+	UpdatedAt             timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 type NotificationSettingsAllowedListResourceModel struct {
@@ -213,6 +214,8 @@ func (r *NotificationSettingsResource) Schema(ctx context.Context, req resource.
 			"updated_at": schema.StringAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the time the resource was last updated in RFC3339 format.").Description,
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/base/resource_phone_delivery_settings.go
+++ b/internal/service/base/resource_phone_delivery_settings.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"slices"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -36,14 +37,14 @@ import (
 type PhoneDeliverySettingsResource serviceClientType
 
 type PhoneDeliverySettingsResourceModel struct {
-	Id                      types.String `tfsdk:"id"`
-	EnvironmentId           types.String `tfsdk:"environment_id"`
-	ProviderType            types.String `tfsdk:"provider_type"`
-	ProviderCustom          types.Object `tfsdk:"provider_custom"`
-	ProviderCustomTwilio    types.Object `tfsdk:"provider_custom_twilio"`
-	ProviderCustomSyniverse types.Object `tfsdk:"provider_custom_syniverse"`
-	CreatedAt               types.String `tfsdk:"created_at"`
-	UpdatedAt               types.String `tfsdk:"updated_at"`
+	Id                      types.String      `tfsdk:"id"`
+	EnvironmentId           types.String      `tfsdk:"environment_id"`
+	ProviderType            types.String      `tfsdk:"provider_type"`
+	ProviderCustom          types.Object      `tfsdk:"provider_custom"`
+	ProviderCustomTwilio    types.Object      `tfsdk:"provider_custom_twilio"`
+	ProviderCustomSyniverse types.Object      `tfsdk:"provider_custom_syniverse"`
+	CreatedAt               timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt               timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 type PhoneDeliverySettingsProviderCustomResourceModel struct {
@@ -927,6 +928,8 @@ func (r *PhoneDeliverySettingsResource) Schema(ctx context.Context, req resource
 				Description: "A string that specifies the time the resource was created.",
 				Computed:    true,
 
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -935,6 +938,8 @@ func (r *PhoneDeliverySettingsResource) Schema(ctx context.Context, req resource
 			"updated_at": schema.StringAttribute{
 				Description: "A string that specifies the time the resource was last updated.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/credentials/data_source_credential_issuer_profile.go
+++ b/internal/service/credentials/data_source_credential_issuer_profile.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -20,12 +21,12 @@ import (
 type CredentialIssuerProfileDataSource serviceClientType
 
 type CredentialIssuerProfileDataSourceModel struct {
-	Id                    types.String `tfsdk:"id"`
-	EnvironmentId         types.String `tfsdk:"environment_id"`
-	ApplicationInstanceId types.String `tfsdk:"application_instance_id"`
-	CreatedAt             types.String `tfsdk:"created_at"`
-	UpdatedAt             types.String `tfsdk:"updated_at"`
-	Name                  types.String `tfsdk:"name"`
+	Id                    types.String      `tfsdk:"id"`
+	EnvironmentId         types.String      `tfsdk:"environment_id"`
+	ApplicationInstanceId types.String      `tfsdk:"application_instance_id"`
+	CreatedAt             timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt             timetypes.RFC3339 `tfsdk:"updated_at"`
+	Name                  types.String      `tfsdk:"name"`
 }
 
 // Framework interfaces
@@ -65,11 +66,15 @@ func (r *CredentialIssuerProfileDataSource) Schema(ctx context.Context, req data
 			"created_at": schema.StringAttribute{
 				Description: "Date and time the issuer profile was created.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the issuer profile was last updated.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"name": schema.StringAttribute{

--- a/internal/service/credentials/data_source_credential_type.go
+++ b/internal/service/credentials/data_source_credential_type.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -19,18 +20,18 @@ import (
 type CredentialTypeDataSource serviceClientType
 
 type CredentialTypeDataSourceModel struct {
-	Id                 types.String `tfsdk:"id"`
-	EnvironmentId      types.String `tfsdk:"environment_id"`
-	IssuerId           types.String `tfsdk:"issuer_id"`
-	CredentialTypeId   types.String `tfsdk:"credential_type_id"`
-	Title              types.String `tfsdk:"title"`
-	Description        types.String `tfsdk:"description"`
-	CardType           types.String `tfsdk:"card_type"`
-	CardDesignTemplate types.String `tfsdk:"card_design_template"`
-	Metadata           types.Object `tfsdk:"metadata"`
-	RevokeOnDelete     types.Bool   `tfsdk:"revoke_on_delete"`
-	CreatedAt          types.String `tfsdk:"created_at"`
-	UpdatedAt          types.String `tfsdk:"updated_at"`
+	Id                 types.String      `tfsdk:"id"`
+	EnvironmentId      types.String      `tfsdk:"environment_id"`
+	IssuerId           types.String      `tfsdk:"issuer_id"`
+	CredentialTypeId   types.String      `tfsdk:"credential_type_id"`
+	Title              types.String      `tfsdk:"title"`
+	Description        types.String      `tfsdk:"description"`
+	CardType           types.String      `tfsdk:"card_type"`
+	CardDesignTemplate types.String      `tfsdk:"card_design_template"`
+	Metadata           types.Object      `tfsdk:"metadata"`
+	RevokeOnDelete     types.Bool        `tfsdk:"revoke_on_delete"`
+	CreatedAt          timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt          timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 type MetadataDataSourceModel struct {
@@ -234,11 +235,15 @@ func (r *CredentialTypeDataSource) Schema(ctx context.Context, req datasource.Sc
 			"created_at": schema.StringAttribute{
 				Description: "Date and time the object was created.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the object was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/credentials/resource_credential_issuer_profile.go
+++ b/internal/service/credentials/resource_credential_issuer_profile.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -31,13 +32,13 @@ import (
 type CredentialIssuerProfileResource serviceClientType
 
 type CredentialIssuerProfileResourceModel struct {
-	Id                    types.String   `tfsdk:"id"`
-	EnvironmentId         types.String   `tfsdk:"environment_id"`
-	ApplicationInstanceId types.String   `tfsdk:"application_instance_id"`
-	CreatedAt             types.String   `tfsdk:"created_at"`
-	UpdatedAt             types.String   `tfsdk:"updated_at"`
-	Name                  types.String   `tfsdk:"name"`
-	Timeouts              timeouts.Value `tfsdk:"timeouts"`
+	Id                    types.String      `tfsdk:"id"`
+	EnvironmentId         types.String      `tfsdk:"environment_id"`
+	ApplicationInstanceId types.String      `tfsdk:"application_instance_id"`
+	CreatedAt             timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt             timetypes.RFC3339 `tfsdk:"updated_at"`
+	Name                  types.String      `tfsdk:"name"`
+	Timeouts              timeouts.Value    `tfsdk:"timeouts"`
 }
 
 // Framework interfaces
@@ -86,6 +87,8 @@ func (r *CredentialIssuerProfileResource) Schema(ctx context.Context, req resour
 				Description: "Date and time the issuer profile was created.",
 				Computed:    true,
 
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -94,6 +97,8 @@ func (r *CredentialIssuerProfileResource) Schema(ctx context.Context, req resour
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the issuer profile was last updated.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"name": schema.StringAttribute{

--- a/internal/service/credentials/resource_credential_type.go
+++ b/internal/service/credentials/resource_credential_type.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -35,17 +36,17 @@ import (
 type CredentialTypeResource serviceClientType
 
 type CredentialTypeResourceModel struct {
-	Id                 types.String `tfsdk:"id"`
-	EnvironmentId      types.String `tfsdk:"environment_id"`
-	IssuerId           types.String `tfsdk:"issuer_id"`
-	CardType           types.String `tfsdk:"card_type"`
-	CardDesignTemplate types.String `tfsdk:"card_design_template"`
-	Description        types.String `tfsdk:"description"`
-	Metadata           types.Object `tfsdk:"metadata"`
-	RevokeOnDelete     types.Bool   `tfsdk:"revoke_on_delete"`
-	Title              types.String `tfsdk:"title"`
-	CreatedAt          types.String `tfsdk:"created_at"`
-	UpdatedAt          types.String `tfsdk:"updated_at"`
+	Id                 types.String      `tfsdk:"id"`
+	EnvironmentId      types.String      `tfsdk:"environment_id"`
+	IssuerId           types.String      `tfsdk:"issuer_id"`
+	CardType           types.String      `tfsdk:"card_type"`
+	CardDesignTemplate types.String      `tfsdk:"card_design_template"`
+	Description        types.String      `tfsdk:"description"`
+	Metadata           types.Object      `tfsdk:"metadata"`
+	RevokeOnDelete     types.Bool        `tfsdk:"revoke_on_delete"`
+	Title              types.String      `tfsdk:"title"`
+	CreatedAt          timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt          timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 type MetadataModel struct {
@@ -439,6 +440,8 @@ func (r *CredentialTypeResource) Schema(ctx context.Context, req resource.Schema
 				Description: "Date and time the object was created.",
 				Computed:    true,
 
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -447,6 +450,8 @@ func (r *CredentialTypeResource) Schema(ctx context.Context, req resource.Schema
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the object was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/risk/resource_risk_predictor.go
+++ b/internal/service/risk/resource_risk_predictor.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -109,8 +109,8 @@ type predictorCustomMapHMLList struct {
 
 // New device
 type predictorDevice struct {
-	ActivationAt types.String `tfsdk:"activation_at"`
-	Detect       types.String `tfsdk:"detect"`
+	ActivationAt timetypes.RFC3339 `tfsdk:"activation_at"`
+	Detect       types.String      `tfsdk:"detect"`
 }
 
 // User Location Anomaly
@@ -255,7 +255,7 @@ var (
 
 	// Device
 	predictorDeviceTFObjectTypes = map[string]attr.Type{
-		"activation_at": types.StringType,
+		"activation_at": timetypes.RFC3339Type{},
 		"detect":        types.StringType,
 	}
 
@@ -846,8 +846,10 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 						Description:         predictorDeviceActivationAtDescription.Description,
 						MarkdownDescription: predictorDeviceActivationAtDescription.MarkdownDescription,
 						Optional:            true,
+
+						CustomType: timetypes.RFC3339Type{},
+
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(verify.RFC3339Regexp, "Attribute must be a valid RFC3339 date/time string."),
 							stringvalidatorinternal.ConflictsIfMatchesPathValue(
 								types.StringValue(string(risk.ENUMPREDICTORNEWDEVICEDETECTTYPE_SUSPICIOUS_DEVICE)),
 								path.MatchRelative().AtParent().AtName("detect"),
@@ -2404,11 +2406,9 @@ func (p *riskPredictorResourceModel) expandPredictorDevice(ctx context.Context, 
 	data.SetDetect(risk.EnumPredictorNewDeviceDetectType(predictorPlan.Detect.ValueString()))
 
 	if !predictorPlan.ActivationAt.IsNull() && !predictorPlan.ActivationAt.IsUnknown() {
-		t, e := time.Parse(time.RFC3339, predictorPlan.ActivationAt.ValueString())
-		if e != nil {
-			diags.AddError(
-				"Invalid data format",
-				"Cannot convert activation_at to a date/time.  Please check the format is a valid RFC3339 date time format.")
+		t, d := predictorPlan.ActivationAt.ValueRFC3339Time()
+		diags.Append(d...)
+		if diags.HasError() {
 			return nil, diags
 		}
 

--- a/internal/service/sso/utils_application_secret.go
+++ b/internal/service/sso/utils_application_secret.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -17,8 +18,8 @@ import (
 var (
 	ApplicationSecretPreviousTFObjectTypes = map[string]attr.Type{
 		"secret":     types.StringType,
-		"expires_at": types.StringType,
-		"last_used":  types.StringType,
+		"expires_at": timetypes.RFC3339Type{},
+		"last_used":  timetypes.RFC3339Type{},
 	}
 )
 

--- a/internal/service/verify/data_source_verify_policy.go
+++ b/internal/service/verify/data_source_verify_policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -25,21 +26,21 @@ import (
 type VerifyPolicyDataSource serviceClientType
 
 type verifyPolicyDataSourceModel struct {
-	Id               types.String `tfsdk:"id"`
-	EnvironmentId    types.String `tfsdk:"environment_id"`
-	VerifyPolicyId   types.String `tfsdk:"verify_policy_id"`
-	Name             types.String `tfsdk:"name"`
-	Default          types.Bool   `tfsdk:"default"`
-	Description      types.String `tfsdk:"description"`
-	GovernmentId     types.Object `tfsdk:"government_id"`
-	FacialComparison types.Object `tfsdk:"facial_comparison"`
-	Liveness         types.Object `tfsdk:"liveness"`
-	Email            types.Object `tfsdk:"email"`
-	Phone            types.Object `tfsdk:"phone"`
-	Transaction      types.Object `tfsdk:"transaction"`
-	Voice            types.Object `tfsdk:"voice"`
-	CreatedAt        types.String `tfsdk:"created_at"`
-	UpdatedAt        types.String `tfsdk:"updated_at"`
+	Id               types.String      `tfsdk:"id"`
+	EnvironmentId    types.String      `tfsdk:"environment_id"`
+	VerifyPolicyId   types.String      `tfsdk:"verify_policy_id"`
+	Name             types.String      `tfsdk:"name"`
+	Default          types.Bool        `tfsdk:"default"`
+	Description      types.String      `tfsdk:"description"`
+	GovernmentId     types.Object      `tfsdk:"government_id"`
+	FacialComparison types.Object      `tfsdk:"facial_comparison"`
+	Liveness         types.Object      `tfsdk:"liveness"`
+	Email            types.Object      `tfsdk:"email"`
+	Phone            types.Object      `tfsdk:"phone"`
+	Transaction      types.Object      `tfsdk:"transaction"`
+	Voice            types.Object      `tfsdk:"voice"`
+	CreatedAt        timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt        timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 var (
@@ -719,11 +720,15 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 			"created_at": schema.StringAttribute{
 				Description: "Date and time the verify policy was created.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the verify policy was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/verify/data_source_verify_voice_phrase.go
+++ b/internal/service/verify/data_source_verify_voice_phrase.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -22,12 +23,12 @@ import (
 type VoicePhraseDataSource serviceClientType
 
 type voicePhraseDataSourceModel struct {
-	Id            types.String `tfsdk:"id"`
-	EnvironmentId types.String `tfsdk:"environment_id"`
-	VoicePhraseId types.String `tfsdk:"voice_phrase_id"`
-	DisplayName   types.String `tfsdk:"display_name"`
-	CreatedAt     types.String `tfsdk:"created_at"`
-	UpdatedAt     types.String `tfsdk:"updated_at"`
+	Id            types.String      `tfsdk:"id"`
+	EnvironmentId types.String      `tfsdk:"environment_id"`
+	VoicePhraseId types.String      `tfsdk:"voice_phrase_id"`
+	DisplayName   types.String      `tfsdk:"display_name"`
+	CreatedAt     timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt     timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 // Framework interfaces
@@ -101,11 +102,15 @@ func (r *VoicePhraseDataSource) Schema(ctx context.Context, req datasource.Schem
 			"created_at": schema.StringAttribute{
 				Description: "Date and time the verify phrase was created.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the verify phrase was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/verify/data_source_verify_voice_phrase_content.go
+++ b/internal/service/verify/data_source_verify_voice_phrase_content.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -21,14 +22,14 @@ import (
 type VoicePhraseContentDataSource serviceClientType
 
 type voicePhraseContentDataSourceModel struct {
-	Id                   types.String `tfsdk:"id"`
-	EnvironmentId        types.String `tfsdk:"environment_id"`
-	VoicePhraseContentId types.String `tfsdk:"voice_phrase_content_id"`
-	VoicePhraseId        types.String `tfsdk:"voice_phrase_id"`
-	Locale               types.String `tfsdk:"locale"`
-	Content              types.String `tfsdk:"content"`
-	CreatedAt            types.String `tfsdk:"created_at"`
-	UpdatedAt            types.String `tfsdk:"updated_at"`
+	Id                   types.String      `tfsdk:"id"`
+	EnvironmentId        types.String      `tfsdk:"environment_id"`
+	VoicePhraseContentId types.String      `tfsdk:"voice_phrase_content_id"`
+	VoicePhraseId        types.String      `tfsdk:"voice_phrase_id"`
+	Locale               types.String      `tfsdk:"locale"`
+	Content              types.String      `tfsdk:"content"`
+	CreatedAt            timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt            timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 // Framework interfaces
@@ -101,11 +102,15 @@ func (r *VoicePhraseContentDataSource) Schema(ctx context.Context, req datasourc
 			"created_at": schema.StringAttribute{
 				Description: "Date and time the verify phrase content was created.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the verify phrase content was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/verify/resource_verify_policy.go
+++ b/internal/service/verify/resource_verify_policy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -35,20 +36,20 @@ import (
 type VerifyPolicyResource serviceClientType
 
 type verifyPolicyResourceModel struct {
-	Id               types.String `tfsdk:"id"`
-	EnvironmentId    types.String `tfsdk:"environment_id"`
-	Name             types.String `tfsdk:"name"`
-	Default          types.Bool   `tfsdk:"default"`
-	Description      types.String `tfsdk:"description"`
-	GovernmentId     types.Object `tfsdk:"government_id"`
-	FacialComparison types.Object `tfsdk:"facial_comparison"`
-	Liveness         types.Object `tfsdk:"liveness"`
-	Email            types.Object `tfsdk:"email"`
-	Phone            types.Object `tfsdk:"phone"`
-	Transaction      types.Object `tfsdk:"transaction"`
-	Voice            types.Object `tfsdk:"voice"`
-	CreatedAt        types.String `tfsdk:"created_at"`
-	UpdatedAt        types.String `tfsdk:"updated_at"`
+	Id               types.String      `tfsdk:"id"`
+	EnvironmentId    types.String      `tfsdk:"environment_id"`
+	Name             types.String      `tfsdk:"name"`
+	Default          types.Bool        `tfsdk:"default"`
+	Description      types.String      `tfsdk:"description"`
+	GovernmentId     types.Object      `tfsdk:"government_id"`
+	FacialComparison types.Object      `tfsdk:"facial_comparison"`
+	Liveness         types.Object      `tfsdk:"liveness"`
+	Email            types.Object      `tfsdk:"email"`
+	Phone            types.Object      `tfsdk:"phone"`
+	Transaction      types.Object      `tfsdk:"transaction"`
+	Voice            types.Object      `tfsdk:"voice"`
+	CreatedAt        timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt        timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 type governmentIdModel struct {
@@ -1272,6 +1273,8 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 				Description: "Date and time the verify policy was created.",
 				Computed:    true,
 
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -1280,6 +1283,8 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the verify policy was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/verify/resource_verify_voice_phrase.go
+++ b/internal/service/verify/resource_verify_voice_phrase.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -24,11 +25,11 @@ import (
 type VoicePhraseResource serviceClientType
 
 type voicePhraseResourceModel struct {
-	Id            types.String `tfsdk:"id"`
-	EnvironmentId types.String `tfsdk:"environment_id"`
-	DisplayName   types.String `tfsdk:"display_name"`
-	CreatedAt     types.String `tfsdk:"created_at"`
-	UpdatedAt     types.String `tfsdk:"updated_at"`
+	Id            types.String      `tfsdk:"id"`
+	EnvironmentId types.String      `tfsdk:"environment_id"`
+	DisplayName   types.String      `tfsdk:"display_name"`
+	CreatedAt     timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt     timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 // Framework interfaces
@@ -77,6 +78,8 @@ func (r *VoicePhraseResource) Schema(ctx context.Context, req resource.SchemaReq
 				Description: "Date and time the verify phrase was created.",
 				Computed:    true,
 
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -85,6 +88,8 @@ func (r *VoicePhraseResource) Schema(ctx context.Context, req resource.SchemaReq
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the verify phrase was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}

--- a/internal/service/verify/resource_verify_voice_phrase_content.go
+++ b/internal/service/verify/resource_verify_voice_phrase_content.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -24,13 +25,13 @@ import (
 type VoicePhraseContentResource serviceClientType
 
 type voicePhraseContentResourceModel struct {
-	Id            types.String `tfsdk:"id"`
-	EnvironmentId types.String `tfsdk:"environment_id"`
-	VoicePhraseId types.String `tfsdk:"voice_phrase_id"`
-	Locale        types.String `tfsdk:"locale"`
-	Content       types.String `tfsdk:"content"`
-	CreatedAt     types.String `tfsdk:"created_at"`
-	UpdatedAt     types.String `tfsdk:"updated_at"`
+	Id            types.String      `tfsdk:"id"`
+	EnvironmentId types.String      `tfsdk:"environment_id"`
+	VoicePhraseId types.String      `tfsdk:"voice_phrase_id"`
+	Locale        types.String      `tfsdk:"locale"`
+	Content       types.String      `tfsdk:"content"`
+	CreatedAt     timetypes.RFC3339 `tfsdk:"created_at"`
+	UpdatedAt     timetypes.RFC3339 `tfsdk:"updated_at"`
 }
 
 // Framework interfaces
@@ -109,6 +110,8 @@ func (r *VoicePhraseContentResource) Schema(ctx context.Context, req resource.Sc
 				Description: "Date and time the verify phrase content was created.",
 				Computed:    true,
 
+				CustomType: timetypes.RFC3339Type{},
+
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -117,6 +120,8 @@ func (r *VoicePhraseContentResource) Schema(ctx context.Context, req resource.Sc
 			"updated_at": schema.StringAttribute{
 				Description: "Date and time the verify phrase content was updated. Can be null.",
 				Computed:    true,
+
+				CustomType: timetypes.RFC3339Type{},
 			},
 		},
 	}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

Changed date-time fields to use custom RFC3339 data type.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing

Deferred to nightly