### PR TITLE
`resource/pingone_custom_domain_verify`: Fix timeouts param and change data type

### DIFF
--- a/.changelog/786.txt
+++ b/.changelog/786.txt
@@ -1,5 +1,5 @@
 ```release-note:breaking-change
-`resource/pingone_custom_domain_verify`: Changed the `timeouts` data types.
+`resource/pingone_custom_domain_verify`: Changed the `timeouts` data type.
 ```
 
 ```release-note:bug

--- a/.changelog/786.txt
+++ b/.changelog/786.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+`resource/pingone_custom_domain_verify`: Changed the `timeouts` data types.
+```
+
+```release-note:bug
+`resource/pingone_custom_domain_verify`: Fixed ineffectual `timeouts` configuration.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -1024,6 +1024,36 @@ resource "pingone_branding_theme" "my_awesome_theme" {
 }
 ```
 
+## Resource: pingone_custom_domain_verify
+
+### `timeouts` optional parameter data type changed
+
+The `timeouts` parameter data type is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_custom_domain_verify" "my_awesome_domain" {
+  # ... other configuration parameters
+
+  timeouts {
+    create = "5s"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_custom_domain_verify" "my_awesome_domain" {
+  # ... other configuration parameters
+
+  timeouts = {
+    create = "5s"
+  }
+}
+```
+
 ## Resource: pingone_environment
 
 ### `default_population` optional parameter removed

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -1037,7 +1037,7 @@ resource "pingone_custom_domain_verify" "my_awesome_domain" {
   # ... other configuration parameters
 
   timeouts {
-    create = "5s"
+    create = "10m"
   }
 }
 ```
@@ -1049,7 +1049,7 @@ resource "pingone_custom_domain_verify" "my_awesome_domain" {
   # ... other configuration parameters
 
   timeouts = {
-    create = "5s"
+    create = "10m"
   }
 }
 ```

--- a/docs/resources/custom_domain_verify.md
+++ b/docs/resources/custom_domain_verify.md
@@ -33,7 +33,7 @@ resource "pingone_custom_domain_verify" "my_custom_domain" {
 
 ### Optional
 
-- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
 
@@ -41,9 +41,9 @@ resource "pingone_custom_domain_verify" "my_custom_domain" {
 - `id` (String) The ID of this resource.
 - `status` (String) A string that specifies the status of the custom domain.  Options are `ACTIVE`, `SSL_CERTIFICATE_REQUIRED`, `VERIFICATION_REQUIRED`.
 
-<a id="nestedblock--timeouts"></a>
+<a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`
 
 Optional:
 
-- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m", as a time to wait for DNS record changes to propagate for validation. Valid time units are "s" (seconds), "m" (minutes), "h" (hours). The default is 60 minutes.

--- a/internal/service/base/resource_custom_domain_verify_test.go
+++ b/internal/service/base/resource_custom_domain_verify_test.go
@@ -53,7 +53,7 @@ resource "pingone_custom_domain_verify" "%[3]s" {
 
   custom_domain_id = pingone_custom_domain.%[3]s.id
 
-  timeouts {
+  timeouts = {
     create = "5s"
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -1024,6 +1024,36 @@ resource "pingone_branding_theme" "my_awesome_theme" {
 }
 ```
 
+## Resource: pingone_custom_domain_verify
+
+### `timeouts` optional parameter data type changed
+
+The `timeouts` parameter data type is now a nested object type and no longer a block type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_custom_domain_verify" "my_awesome_domain" {
+  # ... other configuration parameters
+
+  timeouts {
+    create = "5s"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_custom_domain_verify" "my_awesome_domain" {
+  # ... other configuration parameters
+
+  timeouts = {
+    create = "5s"
+  }
+}
+```
+
 ## Resource: pingone_environment
 
 ### `default_population` optional parameter removed

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -1037,7 +1037,7 @@ resource "pingone_custom_domain_verify" "my_awesome_domain" {
   # ... other configuration parameters
 
   timeouts {
-    create = "5s"
+    create = "10m"
   }
 }
 ```
@@ -1049,7 +1049,7 @@ resource "pingone_custom_domain_verify" "my_awesome_domain" {
   # ... other configuration parameters
 
   timeouts = {
-    create = "5s"
+    create = "10m"
   }
 }
 ```


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_custom_domain_verify`: Changed the `timeouts` data types.
- `resource/pingone_custom_domain_verify`: Fixed ineffectual `timeouts` configuration.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing

Deferred to RC1