### PR TITLE
`resource/pingone_notification_settings_email`: Change the `from` and `reply_to` data types

### DIFF
--- a/.changelog/796.txt
+++ b/.changelog/796.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`resource/pingone_notification_settings_email`: Changed the `from` and `reply_to` data types.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -1878,6 +1878,74 @@ resource "pingone_notification_policy" "my_awesome_notification_policy" {
 }
 ```
 
+## Resource: pingone_notification_settings_email
+
+### `from` schema type change
+
+This parameter `from` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from {
+    email_address = "noreply@bxretail.org"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from = {
+    email_address = "noreply@bxretail.org"
+  }
+}
+```
+
+### `reply_to` schema type change
+
+This parameter `reply_to` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from {
+    email_address = "noreply@bxretail.org"
+  }
+
+  reply_to {
+    email_address = "customerservices@bxretail.org"
+    name          = "BXRetail Customer Services"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from = {
+    email_address = "noreply@bxretail.org"
+  }
+
+  reply_to = {
+    email_address = "customerservices@bxretail.org"
+    name          = "BXRetail Customer Services"
+  }
+}
+```
+
 ## Resource: pingone_resource_attribute
 
 ### `resource_id` parameter changed

--- a/docs/resources/notification_settings_email.md
+++ b/docs/resources/notification_settings_email.md
@@ -26,7 +26,7 @@ resource "pingone_notification_settings_email" "my_awesome_smtp_settings" {
   username = var.smtp_server_username
   password = var.smtp_server_password
 
-  from {
+  from = {
     email_address = "services@bxretail.org"
     name          = "Customer Services"
   }
@@ -39,6 +39,7 @@ resource "pingone_notification_settings_email" "my_awesome_smtp_settings" {
 ### Required
 
 - `environment_id` (String) The ID of the environment to configure email settings in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `from` (Attributes) A required single block that specifies the email sender's "from" name and email address. (see [below for nested schema](#nestedatt--from))
 - `host` (String) A string that specifies the organization's SMTP server.
 - `password` (String, Sensitive) A string that specifies the organization's SMTP server's password.
 - `port` (Number) An integer that specifies the port used by the organization's SMTP server to send emails (default: `465`). Note that the protocol used depends upon the port specified. If you specify port `25`, `587`, or `2525`, SMTP with `STARTTLS` is used. Otherwise, `SMTPS` is used.
@@ -46,15 +47,14 @@ resource "pingone_notification_settings_email" "my_awesome_smtp_settings" {
 
 ### Optional
 
-- `from` (Block List) A required single block that specifies the email sender's "from" name and email address. (see [below for nested schema](#nestedblock--from))
-- `reply_to` (Block List) A single block that specifies the email sender's "reply to" name and email address. (see [below for nested schema](#nestedblock--reply_to))
+- `reply_to` (Attributes) A single block that specifies the email sender's "reply to" name and email address. (see [below for nested schema](#nestedatt--reply_to))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
 - `protocol` (String) A string that specifies the current protocol in use.
 
-<a id="nestedblock--from"></a>
+<a id="nestedatt--from"></a>
 ### Nested Schema for `from`
 
 Required:
@@ -66,7 +66,7 @@ Optional:
 - `name` (String) A string that specifies the email sender's "from" name.
 
 
-<a id="nestedblock--reply_to"></a>
+<a id="nestedatt--reply_to"></a>
 ### Nested Schema for `reply_to`
 
 Required:

--- a/examples/resources/pingone_notification_settings_email/resource.tf
+++ b/examples/resources/pingone_notification_settings_email/resource.tf
@@ -10,7 +10,7 @@ resource "pingone_notification_settings_email" "my_awesome_smtp_settings" {
   username = var.smtp_server_username
   password = var.smtp_server_password
 
-  from {
+  from = {
     email_address = "services@bxretail.org"
     name          = "Customer Services"
   }

--- a/internal/service/base/resource_notification_settings_email_test.go
+++ b/internal/service/base/resource_notification_settings_email_test.go
@@ -78,8 +78,6 @@ func TestAccNotificationSettingsEmail_Full(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "protocol", "SMTPS"),
 			resource.TestCheckResourceAttr(resourceFullName, "username", "smtpuser"),
 			resource.TestCheckResourceAttr(resourceFullName, "password", "smtpuserpassword"),
-			resource.TestCheckResourceAttr(resourceFullName, "from.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.#", "1"),
 		),
 	}
 
@@ -131,44 +129,40 @@ func TestAccNotificationSettingsEmail_EmailSources(t *testing.T) {
 	fromFull := resource.TestStep{
 		Config: testAccNotificationSettingsEmailConfig_FromFull(environmentName, licenseID, resourceName),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceFullName, "from.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "from.0.email_address", "noreply@pingidentity.com"),
-			resource.TestCheckResourceAttr(resourceFullName, "from.0.name", "Stubbed From Address"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "from.email_address", "noreply@pingidentity.com"),
+			resource.TestCheckResourceAttr(resourceFullName, "from.name", "Stubbed From Address"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "reply_to.email_address"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "reply_to.name"),
 		),
 	}
 
 	fromMinimal := resource.TestStep{
 		Config: testAccNotificationSettingsEmailConfig_FromMinimal(environmentName, licenseID, resourceName),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceFullName, "from.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "from.0.email_address", "noreply@pingidentity.com"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "from.0.name"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "from.email_address", "noreply@pingidentity.com"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "from.name"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "reply_to.email_address"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "reply_to.name"),
 		),
 	}
 
 	replyToFull := resource.TestStep{
 		Config: testAccNotificationSettingsEmailConfig_ReplyToFull(environmentName, licenseID, resourceName),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceFullName, "from.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "from.0.email_address", "noreply@pingidentity.com"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "from.0.name"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.0.email_address", "reply@pingidentity.com"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.0.name", "Stubbed Reply To Address"),
+			resource.TestCheckResourceAttr(resourceFullName, "from.email_address", "noreply@pingidentity.com"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "from.name"),
+			resource.TestCheckResourceAttr(resourceFullName, "reply_to.email_address", "reply@pingidentity.com"),
+			resource.TestCheckResourceAttr(resourceFullName, "reply_to.name", "Stubbed Reply To Address"),
 		),
 	}
 
 	replyToMinimal := resource.TestStep{
 		Config: testAccNotificationSettingsEmailConfig_ReplyToMinimal(environmentName, licenseID, resourceName),
 		Check: resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(resourceFullName, "from.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "from.0.email_address", "noreply@pingidentity.com"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "from.0.name"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "reply_to.0.email_address", "reply@pingidentity.com"),
-			resource.TestCheckNoResourceAttr(resourceFullName, "reply_to.0.name"),
+			resource.TestCheckResourceAttr(resourceFullName, "from.email_address", "noreply@pingidentity.com"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "from.name"),
+			resource.TestCheckResourceAttr(resourceFullName, "reply_to.email_address", "reply@pingidentity.com"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "reply_to.name"),
 		),
 	}
 
@@ -271,11 +265,11 @@ resource "pingone_notification_settings_email" "%[3]s" {
   username = "smtpuser"
   password = "smtpuserpassword"
 
-  from {
+  from = {
     email_address = "noreply@pingidentity.com"
   }
 
-  reply_to {
+  reply_to = {
     email_address = "reply@pingidentity.com"
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
@@ -293,7 +287,7 @@ resource "pingone_notification_settings_email" "%[3]s" {
   username = "smtpuser"
   password = "smtpuserpassword"
 
-  from {
+  from = {
     email_address = "noreply@pingidentity.com"
     name          = "Stubbed From Address"
   }
@@ -312,7 +306,7 @@ resource "pingone_notification_settings_email" "%[3]s" {
   username = "smtpuser"
   password = "smtpuserpassword"
 
-  from {
+  from = {
     email_address = "noreply@pingidentity.com"
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
@@ -330,11 +324,11 @@ resource "pingone_notification_settings_email" "%[3]s" {
   username = "smtpuser"
   password = "smtpuserpassword"
 
-  from {
+  from = {
     email_address = "noreply@pingidentity.com"
   }
 
-  reply_to {
+  reply_to = {
     email_address = "reply@pingidentity.com"
     name          = "Stubbed Reply To Address"
   }
@@ -353,11 +347,11 @@ resource "pingone_notification_settings_email" "%[3]s" {
   username = "smtpuser"
   password = "smtpuserpassword"
 
-  from {
+  from = {
     email_address = "noreply@pingidentity.com"
   }
 
-  reply_to {
+  reply_to = {
     email_address = "reply@pingidentity.com"
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -1878,6 +1878,74 @@ resource "pingone_notification_policy" "my_awesome_notification_policy" {
 }
 ```
 
+## Resource: pingone_notification_settings_email
+
+### `from` schema type change
+
+This parameter `from` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from {
+    email_address = "noreply@bxretail.org"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from = {
+    email_address = "noreply@bxretail.org"
+  }
+}
+```
+
+### `reply_to` schema type change
+
+This parameter `reply_to` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from {
+    email_address = "noreply@bxretail.org"
+  }
+
+  reply_to {
+    email_address = "customerservices@bxretail.org"
+    name          = "BXRetail Customer Services"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_settings_email" "my_awesome_email_settings" {
+  # ... other configuration parameters
+
+  from = {
+    email_address = "noreply@bxretail.org"
+  }
+
+  reply_to = {
+    email_address = "customerservices@bxretail.org"
+    name          = "BXRetail Customer Services"
+  }
+}
+```
+
 ## Resource: pingone_resource_attribute
 
 ### `resource_id` parameter changed


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_notification_settings_email`: Changed the `from` and `reply_to` data types.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccNotificationSettingsEmail_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccNotificationSettingsEmail_RemovalDrift
=== PAUSE TestAccNotificationSettingsEmail_RemovalDrift
=== RUN   TestAccNotificationSettingsEmail_Full
=== PAUSE TestAccNotificationSettingsEmail_Full
=== RUN   TestAccNotificationSettingsEmail_EmailSources
=== PAUSE TestAccNotificationSettingsEmail_EmailSources
=== RUN   TestAccNotificationSettingsEmail_BadParameters
=== PAUSE TestAccNotificationSettingsEmail_BadParameters
=== CONT  TestAccNotificationSettingsEmail_RemovalDrift
=== CONT  TestAccNotificationSettingsEmail_EmailSources
=== CONT  TestAccNotificationSettingsEmail_Full
=== CONT  TestAccNotificationSettingsEmail_BadParameters
--- PASS: TestAccNotificationSettingsEmail_RemovalDrift (41.60s)
--- PASS: TestAccNotificationSettingsEmail_Full (42.49s)
--- PASS: TestAccNotificationSettingsEmail_BadParameters (43.44s)
--- PASS: TestAccNotificationSettingsEmail_EmailSources (259.55s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        260.568s
```

</details>