### PR TITLE
`resource/pingone_mfa_settings`: Migrate to framework and change data types

### DIFF
--- a/.changelog/797.txt
+++ b/.changelog/797.txt
@@ -1,0 +1,15 @@
+```release-note:note
+`resource/pingone_mfa_settings`: Migrated to plugin framework.
+```
+
+```release-note:breaking-change
+`resource/pingone_mfa_settings`: Changed the `pairing` and `lockout` data types.
+```
+
+```release-note:breaking-change
+`resource/pingone_mfa_settings`: Removed `phone_extensions_enabled` and moved into nested attribute object.  Use `phone_extensions.enabled` going forward.
+```
+
+```release-note:enhancement
+`resource/pingone_mfa_settings`: Added `users.mfa_enabled` that, when set to `true`, will enable MFA by default for new users.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -1831,6 +1831,92 @@ This parameter was previously deprecated and has been removed.  Use the `fido2` 
 
 This parameter was previously deprecated and has been removed.  Device authentication parameters have moved to the `pingone_mfa_device_policy` resource.
 
+### `lockout` schema type change
+
+This parameter `lockout` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  lockout {
+    failure_count    = 5
+    duration_seconds = 600
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  lockout = {
+    failure_count    = 5
+    duration_seconds = 600
+  }
+}
+```
+
+### `pairing` schema type change
+
+This parameter `pairing` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  pairing {
+    max_allowed_devices = 5
+    pairing_key_format  = "ALPHANUMERIC"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  pairing = {
+    max_allowed_devices = 5
+    pairing_key_format  = "ALPHANUMERIC"
+  }
+}
+```
+
+### `phone_extensions_enabled` parameter moved
+
+This parameter `phone_extensions_enabled` has moved to a nested object type at `phone_extensions.enabled`.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  phone_extensions_enabled = true
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  phone_extensions = {
+    enabled = true
+  }
+}
+```
+
 ## Resource: pingone_notification_policy
 
 ### `quota` schema type change

--- a/docs/resources/mfa_settings.md
+++ b/docs/resources/mfa_settings.md
@@ -2,12 +2,12 @@
 page_title: "pingone_mfa_settings Resource - terraform-provider-pingone"
 subcategory: "MFA"
 description: |-
-  Resource to create and manage a PingOne Environment's MFA Settings
+  Resource to manage the MFA settings for a PingOne environment.
 ---
 
 # pingone_mfa_settings (Resource)
 
-Resource to create and manage a PingOne Environment's MFA Settings
+Resource to manage the MFA settings for a PingOne environment.
 
 ~> Only one `pingone_mfa_settings` resource should be configured for an environment.  If multiple `pingone_mfa_settings` resource definitions exist in HCL code, these are likely to conflict with each other on apply.
 
@@ -17,18 +17,23 @@ Resource to create and manage a PingOne Environment's MFA Settings
 resource "pingone_mfa_settings" "mfa_settings" {
   environment_id = pingone_environment.my_environment.id
 
-  pairing {
+  pairing = {
     max_allowed_devices = 5
     pairing_key_format  = "ALPHANUMERIC"
   }
 
-  lockout {
+  lockout = {
     failure_count    = 5
     duration_seconds = 600
   }
 
-  phone_extensions_enabled = true
+  phone_extensions = {
+    enabled = true
+  }
 
+  users = {
+    mfa_enabled = true
+  }
 }
 ```
 
@@ -37,31 +42,28 @@ resource "pingone_mfa_settings" "mfa_settings" {
 
 ### Required
 
-- `environment_id` (String) The ID of the environment to create the sign on policy in.
-- `pairing` (Block List, Min: 1, Max: 1) An object that contains pairing settings. (see [below for nested schema](#nestedblock--pairing))
+- `environment_id` (String) The ID of the environment to manage MFA settings for.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `pairing` (Attributes) A single object that contains information about the MFA policy device pairing settings. (see [below for nested schema](#nestedatt--pairing))
 
 ### Optional
 
-- `lockout` (Block List, Max: 1) An object that contains lockout settings. (see [below for nested schema](#nestedblock--lockout))
-- `phone_extensions_enabled` (Boolean) A boolean when set to `true` allows one-time passwords to be delivered via voice to phone numbers that include extensions. Set to `false` to disable support for extensions. Defaults to `false`.
+- `lockout` (Attributes) A single object that contains information about the MFA policy lockout settings. (see [below for nested schema](#nestedatt--lockout))
+- `phone_extensions` (Attributes) A single object that contains settings for phone extension support. (see [below for nested schema](#nestedatt--phone_extensions))
+- `users` (Attributes) A single object that contains information about the default settings for new users. (see [below for nested schema](#nestedatt--users))
 
-### Read-Only
-
-- `id` (String) The ID of this resource.
-
-<a id="nestedblock--pairing"></a>
+<a id="nestedatt--pairing"></a>
 ### Nested Schema for `pairing`
 
 Required:
 
-- `pairing_key_format` (String) String that controls the type of pairing key issued. The valid values are `NUMERIC` (12-digit key) and `ALPHANUMERIC` (16-character alphanumeric key).
+- `pairing_key_format` (String) A string that controls the type of pairing key issued.  Options are `ALPHANUMERIC` (16-character alphanumeric key), `NUMERIC` (12-digit key).
 
 Optional:
 
-- `max_allowed_devices` (Number) An integer that defines the maximum number of MFA devices each user can have. This can be any number up to 15. The default value is 5. Defaults to `5`.
+- `max_allowed_devices` (Number) An integer that defines the maximum number of MFA devices each user can have. This can be any number up to 15. The default value is 5.  All devices that are Active or Blocked are subject to this limit.
 
 
-<a id="nestedblock--lockout"></a>
+<a id="nestedatt--lockout"></a>
 ### Nested Schema for `lockout`
 
 Required:
@@ -70,7 +72,23 @@ Required:
 
 Optional:
 
-- `duration_seconds` (Number) An integer that defines the number of seconds to keep the account in a locked state.
+- `duration_seconds` (Number) An integer that defines the number of seconds to keep the account in a locked state
+
+
+<a id="nestedatt--phone_extensions"></a>
+### Nested Schema for `phone_extensions`
+
+Required:
+
+- `enabled` (Boolean) A boolean when set to `true` to allow one-time passwords to be delivered via voice to phone numbers that include extensions. Set to `false` to disable support for phone numbers with extensions. By default, support for extensions is disabled.
+
+
+<a id="nestedatt--users"></a>
+### Nested Schema for `users`
+
+Required:
+
+- `mfa_enabled` (Boolean) A boolean that, when set to `true`, will enable MFA by default for new users.
 
 ## Import
 

--- a/examples/resources/pingone_mfa_settings/resource.tf
+++ b/examples/resources/pingone_mfa_settings/resource.tf
@@ -1,16 +1,21 @@
 resource "pingone_mfa_settings" "mfa_settings" {
   environment_id = pingone_environment.my_environment.id
 
-  pairing {
+  pairing = {
     max_allowed_devices = 5
     pairing_key_format  = "ALPHANUMERIC"
   }
 
-  lockout {
+  lockout = {
     failure_count    = 5
     duration_seconds = 600
   }
 
-  phone_extensions_enabled = true
+  phone_extensions = {
+    enabled = true
+  }
 
+  users = {
+    mfa_enabled = true
+  }
 }

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -159,7 +159,6 @@ func New(version string) func() *schema.Provider {
 				"pingone_sign_on_policy_action":                 sso.ResourceSignOnPolicyAction(),
 
 				"pingone_mfa_device_policy": mfa.ResourceMFADevicePolicy(),
-				"pingone_mfa_settings":      mfa.ResourceMFASettings(),
 			},
 		}
 

--- a/internal/service/mfa/resource_mfa_settings.go
+++ b/internal/service/mfa/resource_mfa_settings.go
@@ -5,87 +5,215 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/patrickcping/pingone-go-sdk-v2/mfa"
-	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
+	"github.com/pingidentity/terraform-provider-pingone/internal/utils"
 	"github.com/pingidentity/terraform-provider-pingone/internal/verify"
 )
 
-func ResourceMFASettings() *schema.Resource {
-	return &schema.Resource{
+// Types
+type MFASettingsResource serviceClientType
 
+type MFASettingsResourceModel struct {
+	EnvironmentId   pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
+	Lockout         types.Object                 `tfsdk:"lockout"`
+	Pairing         types.Object                 `tfsdk:"pairing"`
+	PhoneExtensions types.Object                 `tfsdk:"phone_extensions"`
+	Users           types.Object                 `tfsdk:"users"`
+}
+
+type MFASettingsLockoutResourceModel struct {
+	FailureCount    types.Int64 `tfsdk:"failure_count"`
+	DurationSeconds types.Int64 `tfsdk:"duration_seconds"`
+}
+
+type MFASettingsPairingResourceModel struct {
+	MaxAllowedDevices types.Int64  `tfsdk:"max_allowed_devices"`
+	PairingKeyFormat  types.String `tfsdk:"pairing_key_format"`
+}
+
+type MFASettingsPhoneExtensionsResourceModel struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+type MFASettingsUsersResourceModel struct {
+	MFAEnabled types.Bool `tfsdk:"mfa_enabled"`
+}
+
+var (
+	MFASettingsLockoutTFObjectTypes = map[string]attr.Type{
+		"failure_count":    types.Int64Type,
+		"duration_seconds": types.Int64Type,
+	}
+
+	MFASettingsPairingTFObjectTypes = map[string]attr.Type{
+		"max_allowed_devices": types.Int64Type,
+		"pairing_key_format":  types.StringType,
+	}
+
+	MFASettingsPhoneExtensionsTFObjectTypes = map[string]attr.Type{
+		"enabled": types.BoolType,
+	}
+
+	MFASettingsUsersTFObjectTypes = map[string]attr.Type{
+		"mfa_enabled": types.BoolType,
+	}
+)
+
+// Framework interfaces
+var (
+	_ resource.Resource                = &MFASettingsResource{}
+	_ resource.ResourceWithConfigure   = &MFASettingsResource{}
+	_ resource.ResourceWithImportState = &MFASettingsResource{}
+)
+
+// New Object
+func NewMFASettingsResource() resource.Resource {
+	return &MFASettingsResource{}
+}
+
+// Metadata
+func (r *MFASettingsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_mfa_settings"
+}
+
+func (r *MFASettingsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+
+	// schema descriptions and validation settings
+	const maxAllowedDevicesDefault = 5
+	const maxAllowedDevicesMin = 1
+	const maxAllowedDevicesMax = 15
+
+	pairingPairingKeyFormatDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A string that controls the type of pairing key issued.",
+	).AllowedValuesComplex(map[string]string{
+		string(mfa.ENUMMFASETTINGSPAIRINGKEYFORMAT_NUMERIC):      "12-digit key",
+		string(mfa.ENUMMFASETTINGSPAIRINGKEYFORMAT_ALPHANUMERIC): "16-character alphanumeric key",
+	})
+
+	phoneExtensionsEnabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A boolean when set to `true` to allow one-time passwords to be delivered via voice to phone numbers that include extensions. Set to `false` to disable support for phone numbers with extensions. By default, support for extensions is disabled.",
+	)
+
+	usersMfaEnabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A boolean that, when set to `true`, will enable MFA by default for new users.",
+	)
+
+	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		Description: "Resource to create and manage a PingOne Environment's MFA Settings",
+		Description: "Resource to manage the MFA settings for a PingOne environment.",
 
-		CreateContext: resourceMFASettingsCreate,
-		ReadContext:   resourceMFASettingsRead,
-		UpdateContext: resourceMFASettingsUpdate,
-		DeleteContext: resourceMFASettingsDelete,
+		Attributes: map[string]schema.Attribute{
+			"environment_id": framework.Attr_LinkID(
+				framework.SchemaAttributeDescriptionFromMarkdown("The ID of the environment to manage MFA settings for."),
+			),
 
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceMFASettingsImport,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"environment_id": {
-				Description:      "The ID of the environment to create the sign on policy in.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(verify.ValidP1ResourceID),
-			},
-			"phone_extensions_enabled": {
-				Description: "A boolean when set to `true` allows one-time passwords to be delivered via voice to phone numbers that include extensions. Set to `false` to disable support for extensions.",
-				Type:        schema.TypeBool,
+			"lockout": schema.SingleNestedAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that contains information about the MFA policy lockout settings.").Description,
 				Optional:    true,
-				Default:     false,
-			},
-			"pairing": {
-				Description: "An object that contains pairing settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Required:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"max_allowed_devices": {
-							Description:      "An integer that defines the maximum number of MFA devices each user can have. This can be any number up to 15. The default value is 5.",
-							Type:             schema.TypeInt,
-							Optional:         true,
-							Default:          5,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 15)),
+
+				Attributes: map[string]schema.Attribute{
+					"failure_count": schema.Int64Attribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the maximum number of incorrect authentication attempts before the account is locked.").Description,
+						Required:    true,
+
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
 						},
-						"pairing_key_format": {
-							Description:      fmt.Sprintf("String that controls the type of pairing key issued. The valid values are `%s` (12-digit key) and `%s` (16-character alphanumeric key).", string(mfa.ENUMMFASETTINGSPAIRINGKEYFORMAT_NUMERIC), string(mfa.ENUMMFASETTINGSPAIRINGKEYFORMAT_ALPHANUMERIC)),
-							Type:             schema.TypeString,
-							Required:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{string(mfa.ENUMMFASETTINGSPAIRINGKEYFORMAT_NUMERIC), string(mfa.ENUMMFASETTINGSPAIRINGKEYFORMAT_ALPHANUMERIC)}, false)),
+					},
+
+					"duration_seconds": schema.Int64Attribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the number of seconds to keep the account in a locked state").Description,
+						Optional:    true,
+
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
 						},
 					},
 				},
 			},
-			"lockout": {
-				Description: "An object that contains lockout settings.",
-				Type:        schema.TypeList,
-				MaxItems:    1,
+
+			"pairing": schema.SingleNestedAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that contains information about the MFA policy device pairing settings.").Description,
+				Required:    true,
+
+				Attributes: map[string]schema.Attribute{
+					"max_allowed_devices": schema.Int64Attribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the maximum number of MFA devices each user can have. This can be any number up to 15. The default value is 5.  All devices that are Active or Blocked are subject to this limit.").Description,
+						Optional:    true,
+						Computed:    true,
+
+						Default: int64default.StaticInt64(maxAllowedDevicesDefault),
+
+						Validators: []validator.Int64{
+							int64validator.Between(maxAllowedDevicesMin, maxAllowedDevicesMax),
+						},
+					},
+
+					"pairing_key_format": schema.StringAttribute{
+						Description:         pairingPairingKeyFormatDescription.Description,
+						MarkdownDescription: pairingPairingKeyFormatDescription.MarkdownDescription,
+						Required:            true,
+
+						Validators: []validator.String{
+							stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumMFASettingsPairingKeyFormatEnumValues)...),
+						},
+					},
+				},
+			},
+
+			"phone_extensions": schema.SingleNestedAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that contains settings for phone extension support.").Description,
 				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"failure_count": {
-							Description:      "An integer that defines the maximum number of incorrect authentication attempts before the account is locked.",
-							Type:             schema.TypeInt,
-							Required:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
-						},
-						"duration_seconds": {
-							Description:      "An integer that defines the number of seconds to keep the account in a locked state.",
-							Type:             schema.TypeInt,
-							Optional:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
-						},
+				Computed:    true,
+
+				Default: objectdefault.StaticValue(types.ObjectValueMust(
+					MFASettingsPhoneExtensionsTFObjectTypes,
+					map[string]attr.Value{
+						"enabled": types.BoolValue(false),
+					},
+				)),
+
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description:         phoneExtensionsEnabledDescription.Description,
+						MarkdownDescription: phoneExtensionsEnabledDescription.MarkdownDescription,
+						Required:            true,
+					},
+				},
+			},
+
+			"users": schema.SingleNestedAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that contains information about the default settings for new users.").Description,
+				Optional:    true,
+				Computed:    true,
+
+				Default: objectdefault.StaticValue(types.ObjectValueMust(
+					MFASettingsUsersTFObjectTypes,
+					map[string]attr.Value{
+						"mfa_enabled": types.BoolValue(false),
+					},
+				)),
+
+				Attributes: map[string]schema.Attribute{
+					"mfa_enabled": schema.BoolAttribute{
+						Description:         usersMfaEnabledDescription.Description,
+						MarkdownDescription: usersMfaEnabledDescription.MarkdownDescription,
+						Required:            true,
 					},
 				},
 			},
@@ -93,206 +221,419 @@ func ResourceMFASettings() *schema.Resource {
 	}
 }
 
-func resourceMFASettingsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
-
-	var diags diag.Diagnostics
-
-	mfaSettings := *mfa.NewMFASettings(expandMFASettingsPairing(d.Get("pairing").([]interface{})))
-
-	if v, ok := d.GetOk("lockout"); ok {
-		mfaSettings.SetLockout(expandMFASettingsLockout(v.([]interface{})))
+func (r *MFASettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
 	}
 
-	if v, ok := d.GetOk("phone_extensions_enabled"); ok {
-		mfaSettings.SetPhoneExtensions(expandMFASettingsPhoneExtensions(v))
+	resourceConfig, ok := req.ProviderData.(framework.ResourceType)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected the provider client, got: %T. Please report this issue to the provider maintainers.", req.ProviderData),
+		)
+
+		return
 	}
 
-	resp, diags := sdk.ParseResponse(
+	r.Client = resourceConfig.Client.API
+	if r.Client == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialised",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.",
+		)
+		return
+	}
+}
+
+func (r *MFASettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan, state MFASettingsResourceModel
+
+	if r.Client.MFAAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Build the model for the API
+	mFASettings, d := plan.expand(ctx)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	var response *mfa.MFASettings
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.MFASettingsApi.UpdateMFASettings(ctx, d.Get("environment_id").(string)).MFASettings(mfaSettings).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, p1Client.API.ManagementAPIClient, d.Get("environment_id").(string), fO, fR, fErr)
+			fO, fR, fErr := r.Client.MFAAPIClient.MFASettingsApi.UpdateMFASettings(ctx, plan.EnvironmentId.ValueString()).MFASettings(*mFASettings).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, plan.EnvironmentId.ValueString(), fO, fR, fErr)
 		},
 		"UpdateMFASettings",
-		sdk.DefaultCustomError,
+		framework.DefaultCustomError,
 		sdk.DefaultCreateReadRetryable,
-	)
-	if diags.HasError() {
-		return diags
+		&response,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	respObject := resp.(*mfa.MFASettings)
+	// Create the state to save
+	state = plan
 
-	d.SetId(*respObject.GetEnvironment().Id)
-
-	return resourceMFASettingsRead(ctx, d, meta)
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(state.toState(response)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func resourceMFASettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
+func (r *MFASettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *MFASettingsResourceModel
 
-	var diags diag.Diagnostics
+	if r.Client.MFAAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
 
-	resp, diags := sdk.ParseResponse(
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	var response *mfa.MFASettings
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.MFASettingsApi.ReadMFASettings(ctx, d.Get("environment_id").(string)).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, p1Client.API.ManagementAPIClient, d.Get("environment_id").(string), fO, fR, fErr)
+			fO, fR, fErr := r.Client.MFAAPIClient.MFASettingsApi.ReadMFASettings(ctx, data.EnvironmentId.ValueString()).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, data.EnvironmentId.ValueString(), fO, fR, fErr)
 		},
 		"ReadMFASettings",
-		sdk.CustomErrorResourceNotFoundWarning,
+		framework.CustomErrorResourceNotFoundWarning,
 		sdk.DefaultCreateReadRetryable,
-	)
-	if diags.HasError() {
-		return diags
+		&response,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if resp == nil {
-		d.SetId("")
-		return nil
+	// Remove from state if resource is not found
+	if response == nil {
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
-	respObject := resp.(*mfa.MFASettings)
-
-	d.Set("pairing", flattenMFASettingPairing(respObject.GetPairing()))
-
-	if v, ok := respObject.GetLockoutOk(); ok {
-		d.Set("lockout", flattenMFASettingLockout(*v))
-	} else {
-		d.Set("lockout", nil)
-	}
-
-	if v, ok := respObject.GetPhoneExtensionsOk(); ok {
-		d.Set("phone_extensions_enabled", v.GetEnabled())
-	} else {
-		d.Set("phone_extensions_enabled", nil)
-	}
-
-	return diags
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(data.toState(response)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func resourceMFASettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
+func (r *MFASettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state MFASettingsResourceModel
 
-	var diags diag.Diagnostics
-
-	mfaSettings := *mfa.NewMFASettings(expandMFASettingsPairing(d.Get("pairing").([]interface{})))
-
-	if v, ok := d.GetOk("lockout"); ok {
-		mfaSettings.SetLockout(expandMFASettingsLockout(v.([]interface{})))
+	if r.Client.MFAAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
 	}
 
-	if v, ok := d.GetOk("phone_extensions_enabled"); ok {
-		mfaSettings.SetPhoneExtensions(expandMFASettingsPhoneExtensions(v))
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	_, diags = sdk.ParseResponse(
+	// Build the model for the API
+	mFASettings, d := plan.expand(ctx)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	var response *mfa.MFASettings
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.MFASettingsApi.UpdateMFASettings(ctx, d.Get("environment_id").(string)).MFASettings(mfaSettings).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, p1Client.API.ManagementAPIClient, d.Get("environment_id").(string), fO, fR, fErr)
+			fO, fR, fErr := r.Client.MFAAPIClient.MFASettingsApi.UpdateMFASettings(ctx, plan.EnvironmentId.ValueString()).MFASettings(*mFASettings).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, plan.EnvironmentId.ValueString(), fO, fR, fErr)
 		},
 		"UpdateMFASettings",
-		sdk.DefaultCustomError,
+		framework.DefaultCustomError,
 		nil,
-	)
-	if diags.HasError() {
-		return diags
+		&response,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	return resourceMFASettingsRead(ctx, d, meta)
+	// Update the state to save
+	state = plan
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(state.toState(response)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func resourceMFASettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	p1Client := meta.(*client.Client)
-	apiClient := p1Client.API.MFAAPIClient
+func (r *MFASettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *MFASettingsResourceModel
 
-	var diags diag.Diagnostics
+	if r.Client.MFAAPIClient == nil {
+		resp.Diagnostics.AddError(
+			"Client not initialized",
+			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
+		return
+	}
 
-	_, diags = sdk.ParseResponse(
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Run the API call
+	resp.Diagnostics.Append(framework.ParseResponse(
 		ctx,
 
 		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.MFASettingsApi.ResetMFASettings(ctx, d.Get("environment_id").(string)).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, p1Client.API.ManagementAPIClient, d.Get("environment_id").(string), fO, fR, fErr)
+			f0, fR, fErr := r.Client.MFAAPIClient.MFASettingsApi.ResetMFASettings(ctx, data.EnvironmentId.ValueString()).Execute()
+			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, data.EnvironmentId.ValueString(), f0, fR, fErr)
 		},
 		"ResetMFASettings",
-		sdk.CustomErrorResourceNotFoundWarning,
+		framework.CustomErrorResourceNotFoundWarning,
 		nil,
-	)
-	if diags.HasError() {
-		return diags
+		nil,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-
-	return diags
 }
 
-func resourceMFASettingsImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func (r *MFASettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 
 	idComponents := []framework.ImportComponent{
 		{
-			Label:  "environment_id",
-			Regexp: verify.P1ResourceIDRegexp,
+			Label:     "environment_id",
+			Regexp:    verify.P1ResourceIDRegexp,
+			PrimaryID: true,
 		},
 	}
 
-	attributes, err := framework.ParseImportID(d.Id(), idComponents...)
+	attributes, err := framework.ParseImportID(req.ID, idComponents...)
 	if err != nil {
-		return nil, err
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			err.Error(),
+		)
+		return
 	}
 
-	d.SetId(attributes["environment_id"])
-	d.Set("environment_id", attributes["environment_id"])
+	for _, idComponent := range idComponents {
+		pathKey := idComponent.Label
 
-	resourceMFASettingsRead(ctx, d, meta)
+		if idComponent.PrimaryID {
+			pathKey = "environment_id"
+		}
 
-	return []*schema.ResourceData{d}, nil
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(pathKey), attributes[idComponent.Label])...)
+	}
 }
 
-func expandMFASettingsPairing(v []interface{}) mfa.MFASettingsPairing {
-	obj := v[0].(map[string]interface{})
+func (p *MFASettingsResourceModel) expand(ctx context.Context) (*mfa.MFASettings, diag.Diagnostics) {
+	var diags diag.Diagnostics
 
-	return *mfa.NewMFASettingsPairing(int32(obj["max_allowed_devices"].(int)), mfa.EnumMFASettingsPairingKeyFormat(obj["pairing_key_format"].(string)))
-}
+	// Pairing
+	var pairingPlan MFASettingsPairingResourceModel
+	diags.Append(p.Pairing.As(ctx, &pairingPlan, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    false,
+		UnhandledUnknownAsEmpty: false,
+	})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	pairing := mfa.NewMFASettingsPairing(
+		int32(pairingPlan.MaxAllowedDevices.ValueInt64()),
+		mfa.EnumMFASettingsPairingKeyFormat(pairingPlan.PairingKeyFormat.ValueString()),
+	)
 
-func expandMFASettingsLockout(v []interface{}) mfa.MFASettingsLockout {
-	obj := v[0].(map[string]interface{})
+	// Main object
+	data := mfa.NewMFASettings(
+		*pairing,
+	)
 
-	mfa := *mfa.NewMFASettingsLockout(int32(obj["failure_count"].(int)))
+	// Lockout
+	if !p.Lockout.IsNull() && !p.Lockout.IsUnknown() {
+		var lockoutPlan MFASettingsLockoutResourceModel
+		diags.Append(p.Lockout.As(ctx, &lockoutPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		lockout := mfa.NewMFASettingsLockout(
+			int32(lockoutPlan.FailureCount.ValueInt64()),
+		)
 
-	if v, ok := obj["duration_seconds"].(int); ok && v > 0 {
-		mfa.SetDurationSeconds(int32(v))
+		if !lockoutPlan.DurationSeconds.IsNull() && !lockoutPlan.DurationSeconds.IsUnknown() {
+			lockout.SetDurationSeconds(int32(lockoutPlan.DurationSeconds.ValueInt64()))
+		}
+
+		data.SetLockout(*lockout)
 	}
 
-	return mfa
+	// Phone Extensions
+	if !p.PhoneExtensions.IsNull() && !p.PhoneExtensions.IsUnknown() {
+		var phoneExtensionsPlan MFASettingsPhoneExtensionsResourceModel
+		diags.Append(p.PhoneExtensions.As(ctx, &phoneExtensionsPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		phoneExtensions := mfa.NewMFASettingsPhoneExtensions()
+
+		if !phoneExtensionsPlan.Enabled.IsNull() && !phoneExtensionsPlan.Enabled.IsUnknown() {
+			phoneExtensions.SetEnabled(phoneExtensionsPlan.Enabled.ValueBool())
+		}
+
+		data.SetPhoneExtensions(*phoneExtensions)
+	}
+
+	// Users
+	if !p.Users.IsNull() && !p.Users.IsUnknown() {
+		var usersPlan MFASettingsUsersResourceModel
+		diags.Append(p.Users.As(ctx, &usersPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		users := mfa.NewMFASettingsUsers()
+
+		if !usersPlan.MFAEnabled.IsNull() && !usersPlan.MFAEnabled.IsUnknown() {
+			users.SetMfaEnabled(usersPlan.MFAEnabled.ValueBool())
+		}
+
+		data.SetUsers(*users)
+	}
+
+	return data, diags
 }
 
-func expandMFASettingsPhoneExtensions(v interface{}) mfa.MFASettingsPhoneExtensions {
-	mfa := *mfa.NewMFASettingsPhoneExtensions()
-	mfa.SetEnabled(v.(bool))
+func (p *MFASettingsResourceModel) toState(apiObject *mfa.MFASettings) diag.Diagnostics {
+	var diags diag.Diagnostics
 
-	return mfa
+	if apiObject == nil {
+		diags.AddError(
+			"Data object missing",
+			"Cannot convert the data object to state as the data object is nil.  Please report this to the provider maintainers.",
+		)
+		return diags
+	}
+
+	var d diag.Diagnostics
+
+	p.EnvironmentId = framework.PingOneResourceIDToTF(*apiObject.GetEnvironment().Id)
+
+	p.Lockout, d = toStateLockout(apiObject.GetLockoutOk())
+	diags.Append(d...)
+
+	p.Pairing, d = toStatePairing(apiObject.GetPairingOk())
+	diags.Append(d...)
+
+	p.PhoneExtensions, d = toStatePhoneExtensions(apiObject.GetPhoneExtensionsOk())
+	diags.Append(d...)
+
+	p.Users, d = toStateUsers(apiObject.GetUsersOk())
+	diags.Append(d...)
+
+	return diags
 }
 
-func flattenMFASettingLockout(v mfa.MFASettingsLockout) []map[string]interface{} {
-	c := make([]map[string]interface{}, 0)
-	return append(c, map[string]interface{}{
-		"failure_count":    v.GetFailureCount(),
-		"duration_seconds": v.GetDurationSeconds(),
-	})
+func toStateLockout(apiObject *mfa.MFASettingsLockout, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFASettingsLockoutTFObjectTypes), nil
+	}
+
+	o := map[string]attr.Value{
+		"failure_count":    framework.Int32OkToTF(apiObject.GetFailureCountOk()),
+		"duration_seconds": framework.Int32OkToTF(apiObject.GetDurationSecondsOk()),
+	}
+
+	objValue, d := types.ObjectValue(MFASettingsLockoutTFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
 }
 
-func flattenMFASettingPairing(v mfa.MFASettingsPairing) []map[string]interface{} {
-	c := make([]map[string]interface{}, 0)
-	return append(c, map[string]interface{}{
-		"max_allowed_devices": v.GetMaxAllowedDevices(),
-		"pairing_key_format":  string(v.GetPairingKeyFormat()),
-	})
+func toStatePairing(apiObject *mfa.MFASettingsPairing, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFASettingsPairingTFObjectTypes), nil
+	}
+
+	o := map[string]attr.Value{
+		"max_allowed_devices": framework.Int32OkToTF(apiObject.GetMaxAllowedDevicesOk()),
+		"pairing_key_format":  framework.EnumOkToTF(apiObject.GetPairingKeyFormatOk()),
+	}
+
+	objValue, d := types.ObjectValue(MFASettingsPairingTFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
+}
+
+func toStatePhoneExtensions(apiObject *mfa.MFASettingsPhoneExtensions, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFASettingsPhoneExtensionsTFObjectTypes), nil
+	}
+
+	o := map[string]attr.Value{
+		"enabled": framework.BoolOkToTF(apiObject.GetEnabledOk()),
+	}
+
+	objValue, d := types.ObjectValue(MFASettingsPhoneExtensionsTFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
+}
+
+func toStateUsers(apiObject *mfa.MFASettingsUsers, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFASettingsUsersTFObjectTypes), nil
+	}
+
+	o := map[string]attr.Value{
+		"mfa_enabled": framework.BoolOkToTF(apiObject.GetMfaEnabledOk()),
+	}
+
+	objValue, d := types.ObjectValue(MFASettingsUsersTFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
 }

--- a/internal/service/mfa/resource_mfa_settings_test.go
+++ b/internal/service/mfa/resource_mfa_settings_test.go
@@ -94,15 +94,13 @@ func TestAccMFASettings_Full(t *testing.T) {
 			{
 				Config: testAccMFASettingsConfig_Full(environmentName, licenseID, resourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.max_allowed_devices", "7"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "8"),
-					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.max_allowed_devices", "7"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.pairing_key_format", "NUMERIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "lockout.failure_count", "13"),
+					resource.TestCheckResourceAttr(resourceFullName, "lockout.duration_seconds", "8"),
+					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "users.mfa_enabled", "true"),
 				),
 			},
 			// Test importing the resource
@@ -115,11 +113,12 @@ func TestAccMFASettings_Full(t *testing.T) {
 							return "", fmt.Errorf("Resource Not found: %s", resourceFullName)
 						}
 
-						return rs.Primary.ID, nil
+						return rs.Primary.Attributes["environment_id"], nil
 					}
 				}(),
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "environment_id",
 			},
 		},
 	})
@@ -148,27 +147,25 @@ func TestAccMFASettings_Minimal(t *testing.T) {
 			{
 				Config: testAccMFASettingsConfig_Minimal(environmentName, licenseID, resourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.max_allowed_devices", "5"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.max_allowed_devices", "5"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.pairing_key_format", "NUMERIC"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "lockout.failure_count"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "lockout.duration_seconds"),
+					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "users.mfa_enabled", "false"),
 				),
 			},
 			{
 				Config: testAccMFASettingsConfig_LockoutMinimal(environmentName, licenseID, resourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.max_allowed_devices", "5"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.max_allowed_devices", "5"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.pairing_key_format", "NUMERIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "lockout.failure_count", "13"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "lockout.duration_seconds"),
+					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "users.mfa_enabled", "false"),
 				),
 			},
 		},
@@ -198,41 +195,37 @@ func TestAccMFASettings_Change(t *testing.T) {
 			{
 				Config: testAccMFASettingsConfig_Full(environmentName, licenseID, resourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.max_allowed_devices", "7"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "8"),
-					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.max_allowed_devices", "7"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.pairing_key_format", "NUMERIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "lockout.failure_count", "13"),
+					resource.TestCheckResourceAttr(resourceFullName, "lockout.duration_seconds", "8"),
+					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "users.mfa_enabled", "true"),
 				),
 			},
 			{
 				Config: testAccMFASettingsConfig_Minimal(environmentName, licenseID, resourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.max_allowed_devices", "5"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "0"),
-					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.max_allowed_devices", "5"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.pairing_key_format", "NUMERIC"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "lockout.failure_count"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "lockout.duration_seconds"),
+					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "users.mfa_enabled", "false"),
 				),
 			},
 			{
 				Config: testAccMFASettingsConfig_Full(environmentName, licenseID, resourceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.max_allowed_devices", "7"),
-					resource.TestCheckResourceAttr(resourceFullName, "pairing.0.pairing_key_format", "NUMERIC"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.#", "1"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.failure_count", "13"),
-					resource.TestCheckResourceAttr(resourceFullName, "lockout.0.duration_seconds", "8"),
-					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.max_allowed_devices", "7"),
+					resource.TestCheckResourceAttr(resourceFullName, "pairing.pairing_key_format", "NUMERIC"),
+					resource.TestCheckResourceAttr(resourceFullName, "lockout.failure_count", "13"),
+					resource.TestCheckResourceAttr(resourceFullName, "lockout.duration_seconds", "8"),
+					resource.TestCheckResourceAttr(resourceFullName, "phone_extensions.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "users.mfa_enabled", "true"),
 				),
 			},
 		},
@@ -267,13 +260,13 @@ func TestAccMFASettings_BadParameters(t *testing.T) {
 				ResourceName:  resourceFullName,
 				ImportStateId: "/",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 			{
 				ResourceName:  resourceFullName,
 				ImportStateId: "badformat/badformat",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 		},
 	})
@@ -286,17 +279,23 @@ func testAccMFASettingsConfig_Full(environmentName, licenseID, resourceName stri
 resource "pingone_mfa_settings" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  pairing {
-    max_allowed_devices = 7
-    pairing_key_format  = "NUMERIC"
-  }
-
-  lockout {
+  lockout = {
     failure_count    = 13
     duration_seconds = 8
   }
 
-  phone_extensions_enabled = true
+  pairing = {
+    max_allowed_devices = 7
+    pairing_key_format  = "NUMERIC"
+  }
+
+  phone_extensions = {
+    enabled = true
+  }
+
+  users = {
+    mfa_enabled = true
+  }
 
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }
@@ -308,11 +307,9 @@ func testAccMFASettingsConfig_Minimal(environmentName, licenseID, resourceName s
 resource "pingone_mfa_settings" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  pairing {
+  pairing = {
     pairing_key_format = "NUMERIC"
   }
-
-
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }
 
@@ -323,13 +320,12 @@ func testAccMFASettingsConfig_LockoutMinimal(environmentName, licenseID, resourc
 resource "pingone_mfa_settings" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  pairing {
+  pairing = {
     pairing_key_format = "NUMERIC"
   }
 
-  lockout {
+  lockout = {
     failure_count = 13
   }
-
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }

--- a/internal/service/mfa/service.go
+++ b/internal/service/mfa/service.go
@@ -14,6 +14,7 @@ func Resources() []func() resource.Resource {
 	return []func() resource.Resource{
 		NewApplicationPushCredentialResource,
 		NewFIDO2PolicyResource,
+		NewMFASettingsResource,
 	}
 }
 

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -1831,6 +1831,92 @@ This parameter was previously deprecated and has been removed.  Use the `fido2` 
 
 This parameter was previously deprecated and has been removed.  Device authentication parameters have moved to the `pingone_mfa_device_policy` resource.
 
+### `lockout` schema type change
+
+This parameter `lockout` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  lockout {
+    failure_count    = 5
+    duration_seconds = 600
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  lockout = {
+    failure_count    = 5
+    duration_seconds = 600
+  }
+}
+```
+
+### `pairing` schema type change
+
+This parameter `pairing` was previously a block data type, and is now a single nested object type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  pairing {
+    max_allowed_devices = 5
+    pairing_key_format  = "ALPHANUMERIC"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  pairing = {
+    max_allowed_devices = 5
+    pairing_key_format  = "ALPHANUMERIC"
+  }
+}
+```
+
+### `phone_extensions_enabled` parameter moved
+
+This parameter `phone_extensions_enabled` has moved to a nested object type at `phone_extensions.enabled`.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  phone_extensions_enabled = true
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_mfa_settings" "my_awesome_mfa_settings" {
+  # ... other configuration parameters
+
+  phone_extensions = {
+    enabled = true
+  }
+}
+```
+
 ## Resource: pingone_notification_policy
 
 ### `quota` schema type change


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Migrated to plugin framework.
- Breaking change: `resource/pingone_mfa_settings`: Changed the `pairing` and `lockout` data types.
- Breaking change: Removed `phone_extensions_enabled` and moved into nested attribute object.  Use `phone_extensions.enabled` going forward.
- Enhancement: Added `users.mfa_enabled` that, when set to `true`, will enable MFA by default for new users.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccMFASettings_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccMFASettings_RemovalDrift
=== PAUSE TestAccMFASettings_RemovalDrift
=== RUN   TestAccMFASettings_Full
=== PAUSE TestAccMFASettings_Full
=== RUN   TestAccMFASettings_Minimal
=== PAUSE TestAccMFASettings_Minimal
=== RUN   TestAccMFASettings_Change
=== PAUSE TestAccMFASettings_Change
=== RUN   TestAccMFASettings_BadParameters
=== PAUSE TestAccMFASettings_BadParameters
=== CONT  TestAccMFASettings_RemovalDrift
=== CONT  TestAccMFASettings_Change
=== CONT  TestAccMFASettings_Minimal
=== CONT  TestAccMFASettings_Full
=== CONT  TestAccMFASettings_BadParameters
--- PASS: TestAccMFASettings_BadParameters (42.32s)
--- PASS: TestAccMFASettings_Full (43.78s)
--- PASS: TestAccMFASettings_Minimal (47.60s)
--- PASS: TestAccMFASettings_RemovalDrift (53.51s)
--- PASS: TestAccMFASettings_Change (56.14s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 57.624s
```

</details>