### PR TITLE
`resource/pingone_identity_provider`: Add the `pkce_method` property for OIDC Identity Providers

### DIFF
--- a/.changelog/829.txt
+++ b/.changelog/829.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_identity_provider`: Added the `pkce_method` property for OIDC Identity Providers.
+```

--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -186,6 +186,7 @@ Required:
 Optional:
 
 - `discovery_endpoint` (String) A string that specifies the OIDC identity provider's discovery endpoint. This value must be a URL that uses https.
+- `pkce_method` (String) A string that specifies the method for PKCE. This value auto-populates from a discovery endpoint if the OpenID Provider includes `S256` in its `code_challenge_methods_supported` claim. The plain method is not currently supported.  Options are `NONE`, `S256`.  Defaults to `NONE`.
 - `token_endpoint_auth_method` (String) A string that specifies the OIDC identity provider's token endpoint authentication method.  Options are `CLIENT_SECRET_BASIC`, `CLIENT_SECRET_POST`, `NONE`.  Defaults to `CLIENT_SECRET_BASIC`.
 - `userinfo_endpoint` (String) A string that specifies the OIDC identity provider's userInfo endpoint. This value must be a URL that uses https.
 

--- a/internal/service/sso/resource_identity_provider_test.go
+++ b/internal/service/sso/resource_identity_provider_test.go
@@ -965,6 +965,7 @@ func TestAccIdentityProvider_OIDC(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.client_secret", "dummyclientsecret1"),
 			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.discovery_endpoint", "https://www.pingidentity.com/discovery"),
 			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.issuer", "https://www.pingidentity.com/issuer"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.pkce_method", "S256"),
 			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.jwks_endpoint", "https://www.pingidentity.com/jwks"),
 			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "openid"),
 			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "scope1"),
@@ -995,6 +996,7 @@ func TestAccIdentityProvider_OIDC(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.client_secret", "dummyclientsecret2"),
 			resource.TestCheckNoResourceAttr(resourceFullName, "openid_connect.discovery_endpoint"),
 			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.issuer", "https://www.pingidentity.com/issuer2"),
+			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.pkce_method", "NONE"),
 			resource.TestCheckResourceAttr(resourceFullName, "openid_connect.jwks_endpoint", "https://www.pingidentity.com/jwks2"),
 			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "openid"),
 			resource.TestCheckTypeSetElemAttr(resourceFullName, "openid_connect.scopes.*", "scope3"),
@@ -1676,6 +1678,7 @@ resource "pingone_identity_provider" "%[2]s" {
     client_secret              = "dummyclientsecret1"
     discovery_endpoint         = "https://www.pingidentity.com/discovery"
     issuer                     = "https://www.pingidentity.com/issuer"
+    pkce_method                = "S256"
     jwks_endpoint              = "https://www.pingidentity.com/jwks"
     scopes                     = ["openid", "scope1", "scope2"]
     token_endpoint             = "https://www.pingidentity.com/token"


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_identity_provider`: Added the `pkce_method` property for OIDC Identity Providers.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccIdentityProvider_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccIdentityProvider_RemovalDrift
=== PAUSE TestAccIdentityProvider_RemovalDrift
=== RUN   TestAccIdentityProvider_NewEnv
=== PAUSE TestAccIdentityProvider_NewEnv
=== RUN   TestAccIdentityProvider_Change
=== PAUSE TestAccIdentityProvider_Change
=== RUN   TestAccIdentityProvider_Facebook
=== PAUSE TestAccIdentityProvider_Facebook
=== RUN   TestAccIdentityProvider_Google
=== PAUSE TestAccIdentityProvider_Google
=== RUN   TestAccIdentityProvider_LinkedIn
=== PAUSE TestAccIdentityProvider_LinkedIn
=== RUN   TestAccIdentityProvider_Yahoo
=== PAUSE TestAccIdentityProvider_Yahoo
=== RUN   TestAccIdentityProvider_Amazon
=== PAUSE TestAccIdentityProvider_Amazon
=== RUN   TestAccIdentityProvider_Twitter
=== PAUSE TestAccIdentityProvider_Twitter
=== RUN   TestAccIdentityProvider_Apple
=== PAUSE TestAccIdentityProvider_Apple
=== RUN   TestAccIdentityProvider_Paypal
=== PAUSE TestAccIdentityProvider_Paypal
=== RUN   TestAccIdentityProvider_Microsoft
=== PAUSE TestAccIdentityProvider_Microsoft
=== RUN   TestAccIdentityProvider_Github
=== PAUSE TestAccIdentityProvider_Github
=== RUN   TestAccIdentityProvider_OIDC
=== PAUSE TestAccIdentityProvider_OIDC
=== RUN   TestAccIdentityProvider_SAML
=== PAUSE TestAccIdentityProvider_SAML
=== RUN   TestAccIdentityProvider_ChangeProvider
=== PAUSE TestAccIdentityProvider_ChangeProvider
=== RUN   TestAccIdentityProvider_BadParameters
=== PAUSE TestAccIdentityProvider_BadParameters
=== CONT  TestAccIdentityProvider_RemovalDrift
=== CONT  TestAccIdentityProvider_Apple
=== CONT  TestAccIdentityProvider_OIDC
=== CONT  TestAccIdentityProvider_LinkedIn
=== CONT  TestAccIdentityProvider_Facebook
=== CONT  TestAccIdentityProvider_Google
=== CONT  TestAccIdentityProvider_ChangeProvider
=== CONT  TestAccIdentityProvider_Github
=== CONT  TestAccIdentityProvider_Amazon
=== CONT  TestAccIdentityProvider_Change
=== CONT  TestAccIdentityProvider_NewEnv
=== CONT  TestAccIdentityProvider_Twitter
=== CONT  TestAccIdentityProvider_BadParameters
=== CONT  TestAccIdentityProvider_Yahoo
=== CONT  TestAccIdentityProvider_Microsoft
=== CONT  TestAccIdentityProvider_Paypal
--- PASS: TestAccIdentityProvider_ChangeProvider (18.92s)
=== CONT  TestAccIdentityProvider_SAML
--- PASS: TestAccIdentityProvider_Google (21.44s)
--- PASS: TestAccIdentityProvider_Microsoft (21.77s)
--- PASS: TestAccIdentityProvider_Yahoo (21.82s)
--- PASS: TestAccIdentityProvider_Facebook (21.93s)
--- PASS: TestAccIdentityProvider_BadParameters (22.31s)
--- PASS: TestAccIdentityProvider_LinkedIn (22.47s)
--- PASS: TestAccIdentityProvider_Apple (22.73s)
--- PASS: TestAccIdentityProvider_Amazon (22.79s)
--- PASS: TestAccIdentityProvider_Paypal (22.95s)
--- PASS: TestAccIdentityProvider_Twitter (23.10s)
--- PASS: TestAccIdentityProvider_Github (23.13s)
--- PASS: TestAccIdentityProvider_Change (38.52s)
--- PASS: TestAccIdentityProvider_OIDC (41.11s)
--- PASS: TestAccIdentityProvider_NewEnv (43.88s)
--- PASS: TestAccIdentityProvider_SAML (30.21s)
--- PASS: TestAccIdentityProvider_RemovalDrift (55.18s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 57.036s
```

</details>