### PR TITLE
`resource/pingone_identity_provider`: Update SAML sp signing and idp verification schema

### DIFF
--- a/.changelog/830.txt
+++ b/.changelog/830.txt
@@ -1,0 +1,11 @@
+```release-note:enhancement
+`resource/pingone_identity_provider`: Added ability to set the SP signing key algorithm.
+```
+
+```release-note:breaking-change
+`resource/pingone_identity_provider`: Replaced `saml.sp_signing_key_id` with `saml.sp_signing.key.id`.
+```
+
+```release-note:breaking-change
+`resource/pingone_identity_provider`: Replaced `saml.idp_verification_certificate_ids` with `saml.idp_verification.certificates.*.id`.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -1895,6 +1895,78 @@ resource "pingone_identity_provider" "my_awesome_identity_provider" {
 }
 ```
 
+### `saml.idp_verification_certificate_ids` parameter moved
+
+The `saml.idp_verification_certificate_ids` parameter has been moved to `saml.idp_verification.certificates.*.id`
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml {
+    idp_verification_certificate_ids = [
+      var.saml_idp_verification_certificate_id_1,
+      var.saml_idp_verification_certificate_id_2,
+    ]
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml = {
+    idp_verification = {
+      certificates = [
+        {
+          id = var.saml_idp_verification_certificate_id_1
+        },
+        {
+          id = var.saml_idp_verification_certificate_id_2
+        }
+      ]
+    }
+  }
+}
+```
+
+### `saml.sp_signing_key_id` parameter moved
+
+The `saml.sp_signing_key_id` parameter has been moved to `saml.sp_signing.key.id`
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml {
+    sp_signing_key_id = var.saml_sp_signing_key_id
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml = {
+    sp_signing = {
+      key = {
+        id = var.saml_sp_signing_key_id
+      }
+    }
+  }
+}
+```
+
 ### `twitter` parameter data type change
 
 The `twitter` parameter is now a nested object type and no longer a block type.

--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -207,7 +207,7 @@ Required:
 Required:
 
 - `idp_entity_id` (String) A string that specifies the entity ID URI that is checked against the `issuerId` tag in the incoming response.
-- `idp_verification_certificate_ids` (Set of String) An unordered list that specifies the identity provider's certificate IDs used to verify the signature on the signed assertion from the identity provider. Signing is done with a private key and verified with a public key.  Items must be valid PingOne resource IDs.
+- `idp_verification` (Attributes) A single object that specifies settings for SAML IdP verification, including the list of IdP certificates used to verify the signature on the signed assertion of the identity provider. (see [below for nested schema](#nestedatt--saml--idp_verification))
 - `sp_entity_id` (String) A string that specifies the service provider's entity ID, used to look up the application.
 - `sso_binding` (String) A string that specifies the binding for the authentication request.  Options are `HTTP_POST`, `HTTP_REDIRECT`.
 - `sso_endpoint` (String) A string that specifies the SSO endpoint for the authentication request.  This value must be a URL that uses http or https.
@@ -219,7 +219,40 @@ Optional:
 - `slo_endpoint` (String) A string that specifies the logout endpoint URL. This is an optional property. However, if a logout endpoint URL is not defined, logout actions result in an error.  This value must be a URL that uses http or https.
 - `slo_response_endpoint` (String) A string that specifies the endpoint URL to submit the logout response.  If a value is not provided, the `slo_endpoint` property value is used to submit SLO response.  This value must be a URL that uses http or https.
 - `slo_window` (Number) An integer that defines how long (hours) PingOne can exchange logout messages with the application, specifically a logout request from the application, since the initial request. The minimum value is `1` hour and the maximum is `24` hours.
-- `sp_signing_key_id` (String) A string that specifies the service provider's signing key ID.  Must be a valid PingOne resource ID.
+- `sp_signing` (Attributes) A single object that specifies settings for SAML assertion signing, including the key and the signature algorithm. (see [below for nested schema](#nestedatt--saml--sp_signing))
+
+<a id="nestedatt--saml--idp_verification"></a>
+### Nested Schema for `saml.idp_verification`
+
+Required:
+
+- `certificates` (Attributes Set) An unordered list that specifies the identity provider's certificate IDs used to verify the signature on the signed assertion from the identity provider. Signing is done with a private key and verified with a public key. (see [below for nested schema](#nestedatt--saml--idp_verification--certificates))
+
+<a id="nestedatt--saml--idp_verification--certificates"></a>
+### Nested Schema for `saml.idp_verification.certificates`
+
+Required:
+
+- `id` (String) A string that specifies the identity provider's certificate ID used to verify the signature on the signed assertion from the identity provider.  Must be a valid PingOne resource ID.
+
+
+
+<a id="nestedatt--saml--sp_signing"></a>
+### Nested Schema for `saml.sp_signing`
+
+Optional:
+
+- `algorithm` (String) The signing key algorithm used by PingOne. The value will depend on which key algorithm and signature algorithm you chose when creating your signing key.  Options are `SHA256withECDSA`, `SHA256withRSA`, `SHA384withECDSA`, `SHA384withRSA`, `SHA512eithEDCSA`, `SHA512withRSA`.
+- `key` (Attributes) A single object that specifies settings for the SAML Sp Signing key. (see [below for nested schema](#nestedatt--saml--sp_signing--key))
+
+<a id="nestedatt--saml--sp_signing--key"></a>
+### Nested Schema for `saml.sp_signing.key`
+
+Required:
+
+- `id` (String) A string that specifies the service provider's signing key ID.  Must be a valid PingOne resource ID.
+
+
 
 
 <a id="nestedatt--twitter"></a>

--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -219,7 +219,7 @@ Optional:
 - `slo_endpoint` (String) A string that specifies the logout endpoint URL. This is an optional property. However, if a logout endpoint URL is not defined, logout actions result in an error.  This value must be a URL that uses http or https.
 - `slo_response_endpoint` (String) A string that specifies the endpoint URL to submit the logout response.  If a value is not provided, the `slo_endpoint` property value is used to submit SLO response.  This value must be a URL that uses http or https.
 - `slo_window` (Number) An integer that defines how long (hours) PingOne can exchange logout messages with the application, specifically a logout request from the application, since the initial request. The minimum value is `1` hour and the maximum is `24` hours.
-- `sp_signing` (Attributes) A single object that specifies settings for SAML assertion signing, including the key and the signature algorithm. (see [below for nested schema](#nestedatt--saml--sp_signing))
+- `sp_signing` (Attributes) A single object that specifies settings for SAML assertion signing, including the key and the signature algorithm.  Required when `authentication_request_signed` is set to `true`. (see [below for nested schema](#nestedatt--saml--sp_signing))
 
 <a id="nestedatt--saml--idp_verification"></a>
 ### Nested Schema for `saml.idp_verification`
@@ -240,10 +240,13 @@ Required:
 <a id="nestedatt--saml--sp_signing"></a>
 ### Nested Schema for `saml.sp_signing`
 
+Required:
+
+- `key` (Attributes) A single object that specifies settings for the SAML Sp Signing key. (see [below for nested schema](#nestedatt--saml--sp_signing--key))
+
 Optional:
 
 - `algorithm` (String) The signing key algorithm used by PingOne. The value will depend on which key algorithm and signature algorithm you chose when creating your signing key.  Options are `SHA256withECDSA`, `SHA256withRSA`, `SHA384withECDSA`, `SHA384withRSA`, `SHA512eithEDCSA`, `SHA512withRSA`.
-- `key` (Attributes) A single object that specifies settings for the SAML Sp Signing key. (see [below for nested schema](#nestedatt--saml--sp_signing--key))
 
 <a id="nestedatt--saml--sp_signing--key"></a>
 ### Nested Schema for `saml.sp_signing.key`

--- a/internal/service/sso/resource_identity_provider.go
+++ b/internal/service/sso/resource_identity_provider.go
@@ -113,17 +113,34 @@ type IdentityProviderOIDCResourceModel struct {
 }
 
 type IdentityProviderSAMLResourceModel struct {
-	AuthenticationRequestSigned   types.Bool                   `tfsdk:"authentication_request_signed"`
-	IdpEntityId                   types.String                 `tfsdk:"idp_entity_id"`
-	SpEntityId                    types.String                 `tfsdk:"sp_entity_id"`
-	IdpVerificationCertificateIds types.Set                    `tfsdk:"idp_verification_certificate_ids"`
-	SpSigningKeyId                pingonetypes.ResourceIDValue `tfsdk:"sp_signing_key_id"`
-	SsoBinding                    types.String                 `tfsdk:"sso_binding"`
-	SsoEndpoint                   types.String                 `tfsdk:"sso_endpoint"`
-	SloBinding                    types.String                 `tfsdk:"slo_binding"`
-	SloEndpoint                   types.String                 `tfsdk:"slo_endpoint"`
-	SloResponseEndpoint           types.String                 `tfsdk:"slo_response_endpoint"`
-	SloWindow                     types.Int64                  `tfsdk:"slo_window"`
+	AuthenticationRequestSigned types.Bool   `tfsdk:"authentication_request_signed"`
+	IdpEntityId                 types.String `tfsdk:"idp_entity_id"`
+	SpEntityId                  types.String `tfsdk:"sp_entity_id"`
+	IdpVerification             types.Object `tfsdk:"idp_verification"`
+	SpSigning                   types.Object `tfsdk:"sp_signing"`
+	SsoBinding                  types.String `tfsdk:"sso_binding"`
+	SsoEndpoint                 types.String `tfsdk:"sso_endpoint"`
+	SloBinding                  types.String `tfsdk:"slo_binding"`
+	SloEndpoint                 types.String `tfsdk:"slo_endpoint"`
+	SloResponseEndpoint         types.String `tfsdk:"slo_response_endpoint"`
+	SloWindow                   types.Int64  `tfsdk:"slo_window"`
+}
+
+type IdentityProviderSAMLResourceIdPVerificationModel struct {
+	Certificates types.Set `tfsdk:"certificates"`
+}
+
+type IdentityProviderSAMLResourceIdPVerificationCertificatesModel struct {
+	Id pingonetypes.ResourceIDValue `tfsdk:"id"`
+}
+
+type IdentityProviderSAMLResourceSpSigningModel struct {
+	Key       types.Object `tfsdk:"key"`
+	Algorithm types.String `tfsdk:"algorithm"`
+}
+
+type IdentityProviderSAMLResourceSpSigningKeyModel struct {
+	Id pingonetypes.ResourceIDValue `tfsdk:"id"`
 }
 
 var (
@@ -165,17 +182,34 @@ var (
 	}
 
 	identityProviderSAMLTFObjectTypes = map[string]attr.Type{
-		"authentication_request_signed":    types.BoolType,
-		"idp_entity_id":                    types.StringType,
-		"sp_entity_id":                     types.StringType,
-		"idp_verification_certificate_ids": types.SetType{ElemType: pingonetypes.ResourceIDType{}},
-		"sp_signing_key_id":                pingonetypes.ResourceIDType{},
-		"sso_binding":                      types.StringType,
-		"sso_endpoint":                     types.StringType,
-		"slo_binding":                      types.StringType,
-		"slo_endpoint":                     types.StringType,
-		"slo_response_endpoint":            types.StringType,
-		"slo_window":                       types.Int64Type,
+		"authentication_request_signed": types.BoolType,
+		"idp_entity_id":                 types.StringType,
+		"sp_entity_id":                  types.StringType,
+		"idp_verification":              types.ObjectType{AttrTypes: identityProviderSAMLIdPVerificationTFObjectTypes},
+		"sp_signing":                    types.ObjectType{AttrTypes: identityProviderSAMLSpSigningTFObjectTypes},
+		"sso_binding":                   types.StringType,
+		"sso_endpoint":                  types.StringType,
+		"slo_binding":                   types.StringType,
+		"slo_endpoint":                  types.StringType,
+		"slo_response_endpoint":         types.StringType,
+		"slo_window":                    types.Int64Type,
+	}
+
+	identityProviderSAMLIdPVerificationTFObjectTypes = map[string]attr.Type{
+		"certificates": types.SetType{ElemType: pingonetypes.ResourceIDType{}},
+	}
+
+	identityProviderSAMLIdPVerificationCertificateTFObjectTypes = map[string]attr.Type{
+		"id": pingonetypes.ResourceIDType{},
+	}
+
+	identityProviderSAMLSpSigningTFObjectTypes = map[string]attr.Type{
+		"key":       types.ObjectType{AttrTypes: identityProviderSAMLSpSigningKeyTFObjectTypes},
+		"algorithm": types.StringType,
+	}
+
+	identityProviderSAMLSpSigningKeyTFObjectTypes = map[string]attr.Type{
+		"id": pingonetypes.ResourceIDType{},
 	}
 )
 
@@ -250,6 +284,10 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 	samlIdpEntityIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the entity ID URI that is checked against the `issuerId` tag in the incoming response.",
 	)
+
+	samlSpSigningAlgorithmDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The signing key algorithm used by PingOne. The value will depend on which key algorithm and signature algorithm you chose when creating your signing key.",
+	).AllowedValuesEnum(management.AllowedEnumIdentityProviderSAMLSigningAlgorithmEnumValues)
 
 	samlSSOBindingDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the binding for the authentication request.",
@@ -678,22 +716,63 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 						},
 					},
 
-					"idp_verification_certificate_ids": schema.SetAttribute{
-						Description: framework.SchemaAttributeDescriptionFromMarkdown("An unordered list that specifies the identity provider's certificate IDs used to verify the signature on the signed assertion from the identity provider. Signing is done with a private key and verified with a public key.  Items must be valid PingOne resource IDs.").Description,
+					"idp_verification": schema.SingleNestedAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that specifies settings for SAML IdP verification, including the list of IdP certificates used to verify the signature on the signed assertion of the identity provider.").Description,
 						Required:    true,
 
-						ElementType: pingonetypes.ResourceIDType{},
+						Attributes: map[string]schema.Attribute{
+							"certificates": schema.SetNestedAttribute{
+								Description: framework.SchemaAttributeDescriptionFromMarkdown("An unordered list that specifies the identity provider's certificate IDs used to verify the signature on the signed assertion from the identity provider. Signing is done with a private key and verified with a public key.").Description,
+								Required:    true,
 
-						Validators: []validator.Set{
-							setvalidator.SizeAtLeast(attrMinLength),
+								NestedObject: schema.NestedAttributeObject{
+
+									Attributes: map[string]schema.Attribute{
+										"id": schema.StringAttribute{
+											Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the identity provider's certificate ID used to verify the signature on the signed assertion from the identity provider.  Must be a valid PingOne resource ID.").Description,
+											Required:    true,
+
+											CustomType: pingonetypes.ResourceIDType{},
+										},
+									},
+								},
+
+								Validators: []validator.Set{
+									setvalidator.SizeAtLeast(attrMinLength),
+								},
+							},
 						},
 					},
 
-					"sp_signing_key_id": schema.StringAttribute{
-						Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the service provider's signing key ID.  Must be a valid PingOne resource ID.").Description,
+					"sp_signing": schema.SingleNestedAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that specifies settings for SAML assertion signing, including the key and the signature algorithm.").Description,
 						Optional:    true,
 
-						CustomType: pingonetypes.ResourceIDType{},
+						Attributes: map[string]schema.Attribute{
+							"algorithm": schema.StringAttribute{
+								Description:         samlSpSigningAlgorithmDescription.Description,
+								MarkdownDescription: samlSpSigningAlgorithmDescription.MarkdownDescription,
+								Optional:            true,
+
+								Validators: []validator.String{
+									stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumIdentityProviderSAMLSigningAlgorithmEnumValues)...),
+								},
+							},
+
+							"key": schema.SingleNestedAttribute{
+								Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that specifies settings for the SAML Sp Signing key.").Description,
+								Optional:    true,
+
+								Attributes: map[string]schema.Attribute{
+									"id": schema.StringAttribute{
+										Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the service provider's signing key ID.  Must be a valid PingOne resource ID.").Description,
+										Required:    true,
+
+										CustomType: pingonetypes.ResourceIDType{},
+									},
+								},
+							},
+						},
 					},
 
 					"sso_binding": schema.StringAttribute{
@@ -1501,25 +1580,41 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 			idpData.SetSpEntityId(plan.SpEntityId.ValueString())
 		}
 
-		if !plan.IdpVerificationCertificateIds.IsNull() && !plan.IdpVerificationCertificateIds.IsUnknown() {
-			var certificateIdsPlan []string
-			diags.Append(plan.IdpVerificationCertificateIds.ElementsAs(ctx, &certificateIdsPlan, false)...)
+		if !plan.IdpVerification.IsNull() && !plan.IdpVerification.IsUnknown() {
+			var idpVerificationPlan IdentityProviderSAMLResourceIdPVerificationModel
+			diags.Append(plan.IdpVerification.As(ctx, &idpVerificationPlan, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    false,
+				UnhandledUnknownAsEmpty: false,
+			})...)
 			if diags.HasError() {
 				return nil, diags
 			}
 
-			idpVerificationCertificates := make([]management.IdentityProviderSAMLAllOfIdpVerificationCertificates, 0)
-			for _, v := range certificateIdsPlan {
-				idpVerificationCertificates = append(idpVerificationCertificates, *management.NewIdentityProviderSAMLAllOfIdpVerificationCertificates(v))
+			idpVerification, d := idpVerificationPlan.expand(ctx)
+			diags.Append(d...)
+			if diags.HasError() {
+				return nil, diags
 			}
 
-			idpVerifcation := management.NewIdentityProviderSAMLAllOfIdpVerification(idpVerificationCertificates)
-			idpData.SetIdpVerification(*idpVerifcation)
+			idpData.SetIdpVerification(*idpVerification)
 		}
 
-		if !plan.SpSigningKeyId.IsNull() && !plan.SpSigningKeyId.IsUnknown() {
-			spSigningKey := management.NewIdentityProviderSAMLAllOfSpSigningKey(plan.SpSigningKeyId.ValueString())
-			spSigning := management.NewIdentityProviderSAMLAllOfSpSigning(*spSigningKey)
+		if !plan.SpSigning.IsNull() && !plan.SpSigning.IsUnknown() {
+			var spSigningPlan IdentityProviderSAMLResourceSpSigningModel
+			diags.Append(plan.SpSigning.As(ctx, &spSigningPlan, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    false,
+				UnhandledUnknownAsEmpty: false,
+			})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			spSigning, d := spSigningPlan.expand(ctx)
+			diags.Append(d...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
 			idpData.SetSpSigning(*spSigning)
 		}
 
@@ -1565,6 +1660,53 @@ func (p *IdentityProviderResourceModel) expand(ctx context.Context) (*management
 		)
 
 		return nil, diags
+	}
+
+	return data, diags
+}
+
+func (p *IdentityProviderSAMLResourceIdPVerificationModel) expand(ctx context.Context) (*management.IdentityProviderSAMLAllOfIdpVerification, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var certificatesPlan []IdentityProviderSAMLResourceIdPVerificationCertificatesModel
+	diags.Append(p.Certificates.ElementsAs(ctx, &certificatesPlan, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	certificates := make([]management.IdentityProviderSAMLAllOfIdpVerificationCertificates, 0)
+	for _, certificatePlan := range certificatesPlan {
+		certificate := management.NewIdentityProviderSAMLAllOfIdpVerificationCertificates(certificatePlan.Id.ValueString())
+		certificates = append(certificates, *certificate)
+	}
+
+	data := management.NewIdentityProviderSAMLAllOfIdpVerification(
+		certificates,
+	)
+
+	return data, diags
+}
+
+func (p *IdentityProviderSAMLResourceSpSigningModel) expand(ctx context.Context) (*management.IdentityProviderSAMLAllOfSpSigning, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var keyPlan IdentityProviderSAMLResourceSpSigningKeyModel
+	diags.Append(p.Key.As(ctx, &keyPlan, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    false,
+		UnhandledUnknownAsEmpty: false,
+	})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	key := management.NewIdentityProviderSAMLAllOfSpSigningKey(keyPlan.Id.ValueString())
+
+	data := management.NewIdentityProviderSAMLAllOfSpSigning(
+		*key,
+	)
+
+	if !p.Algorithm.IsNull() && !p.Algorithm.IsUnknown() {
+		data.SetAlgorithm(management.EnumIdentityProviderSAMLSigningAlgorithm(p.Algorithm.ValueString()))
 	}
 
 	return data, diags
@@ -1771,10 +1913,24 @@ func identityProviderSAMLToTF(idpApiObject *management.IdentityProviderSAML) (ty
 		return types.ObjectNull(identityProviderSAMLTFObjectTypes), diags
 	}
 
+	idpVerification, d := identityProviderSAMLIdPVerificationOkToTF(idpApiObject.GetIdpVerificationOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(identityProviderSAMLTFObjectTypes), diags
+	}
+
+	spSigning, d := identityProviderSAMLSpSigningOkToTF(idpApiObject.GetSpSigningOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(identityProviderSAMLTFObjectTypes), diags
+	}
+
 	attributesMap := map[string]attr.Value{
 		"authentication_request_signed": framework.BoolOkToTF(idpApiObject.GetAuthnRequestSignedOk()),
 		"idp_entity_id":                 framework.StringOkToTF(idpApiObject.GetIdpEntityIdOk()),
 		"sp_entity_id":                  framework.StringOkToTF(idpApiObject.GetSpEntityIdOk()),
+		"idp_verification":              idpVerification,
+		"sp_signing":                    spSigning,
 		"sso_binding":                   framework.EnumOkToTF(idpApiObject.GetSsoBindingOk()),
 		"sso_endpoint":                  framework.StringOkToTF(idpApiObject.GetSsoEndpointOk()),
 		"slo_binding":                   framework.EnumOkToTF(idpApiObject.GetSloBindingOk()),
@@ -1783,26 +1939,99 @@ func identityProviderSAMLToTF(idpApiObject *management.IdentityProviderSAML) (ty
 		"slo_window":                    framework.Int32OkToTF(idpApiObject.GetSloWindowOk()),
 	}
 
-	attributesMap["idp_verification_certificate_ids"] = types.SetNull(pingonetypes.ResourceIDType{})
-	if v, ok := idpApiObject.GetIdpVerificationOk(); ok {
-		if c, ok := v.GetCertificatesOk(); ok {
-			ids := make([]string, 0)
-			for _, certificate := range c {
-				ids = append(ids, certificate.GetId())
-			}
-
-			attributesMap["idp_verification_certificate_ids"] = framework.PingOneResourceIDSetToTF(ids)
-		}
-	}
-
-	attributesMap["sp_signing_key_id"] = pingonetypes.NewResourceIDNull()
-	if v, ok := idpApiObject.GetSpSigningOk(); ok {
-		if c, ok := v.GetKeyOk(); ok {
-			attributesMap["sp_signing_key_id"] = framework.PingOneResourceIDOkToTF(c.GetIdOk())
-		}
-	}
-
 	returnVar, d := types.ObjectValue(identityProviderSAMLTFObjectTypes, attributesMap)
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func identityProviderSAMLIdPVerificationOkToTF(apiObject *management.IdentityProviderSAMLAllOfIdpVerification, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(identityProviderSAMLIdPVerificationTFObjectTypes), diags
+	}
+
+	certificates, d := identityProviderSAMLIdPVerificationCertificatesOkToTF(apiObject.GetCertificatesOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(identityProviderSAMLIdPVerificationTFObjectTypes), diags
+	}
+
+	attributesMap := map[string]attr.Value{
+		"certificates": certificates,
+	}
+
+	returnVar, d := types.ObjectValue(identityProviderSAMLIdPVerificationTFObjectTypes, attributesMap)
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func identityProviderSAMLIdPVerificationCertificatesOkToTF(apiObject []management.IdentityProviderSAMLAllOfIdpVerificationCertificates, ok bool) (types.Set, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: identityProviderSAMLIdPVerificationCertificateTFObjectTypes}
+
+	if !ok || len(apiObject) == 0 {
+		return types.SetNull(tfObjType), diags
+	}
+
+	flattenedList := []attr.Value{}
+	for _, v := range apiObject {
+
+		objMap := map[string]attr.Value{
+			"id": framework.PingOneResourceIDOkToTF(v.GetIdOk()),
+		}
+
+		flattenedObj, d := types.ObjectValue(identityProviderSAMLIdPVerificationCertificateTFObjectTypes, objMap)
+		diags.Append(d...)
+
+		flattenedList = append(flattenedList, flattenedObj)
+	}
+
+	returnVar, d := types.SetValue(tfObjType, flattenedList)
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func identityProviderSAMLSpSigningOkToTF(apiObject *management.IdentityProviderSAMLAllOfSpSigning, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(identityProviderSAMLSpSigningTFObjectTypes), diags
+	}
+
+	key, d := identityProviderSAMLSpSigningKeyOkToTF(apiObject.GetKeyOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(identityProviderSAMLSpSigningTFObjectTypes), diags
+	}
+
+	attributesMap := map[string]attr.Value{
+		"key":       key,
+		"algorithm": framework.EnumOkToTF(apiObject.GetAlgorithmOk()),
+	}
+
+	returnVar, d := types.ObjectValue(identityProviderSAMLSpSigningTFObjectTypes, attributesMap)
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func identityProviderSAMLSpSigningKeyOkToTF(apiObject *management.IdentityProviderSAMLAllOfSpSigningKey, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(identityProviderSAMLSpSigningKeyTFObjectTypes), diags
+	}
+
+	attributesMap := map[string]attr.Value{
+		"id": framework.PingOneResourceIDOkToTF(apiObject.GetIdOk()),
+	}
+
+	returnVar, d := types.ObjectValue(identityProviderSAMLSpSigningKeyTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags

--- a/internal/service/sso/resource_identity_provider.go
+++ b/internal/service/sso/resource_identity_provider.go
@@ -196,7 +196,7 @@ var (
 	}
 
 	identityProviderSAMLIdPVerificationTFObjectTypes = map[string]attr.Type{
-		"certificates": types.SetType{ElemType: pingonetypes.ResourceIDType{}},
+		"certificates": types.SetType{ElemType: types.ObjectType{AttrTypes: identityProviderSAMLIdPVerificationCertificateTFObjectTypes}},
 	}
 
 	identityProviderSAMLIdPVerificationCertificateTFObjectTypes = map[string]attr.Type{
@@ -283,6 +283,10 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 
 	samlIdpEntityIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the entity ID URI that is checked against the `issuerId` tag in the incoming response.",
+	)
+
+	samlSpSigningDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that specifies settings for SAML assertion signing, including the key and the signature algorithm.  Required when `authentication_request_signed` is set to `true`.",
 	)
 
 	samlSpSigningAlgorithmDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -745,8 +749,9 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 					},
 
 					"sp_signing": schema.SingleNestedAttribute{
-						Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that specifies settings for SAML assertion signing, including the key and the signature algorithm.").Description,
-						Optional:    true,
+						Description:         samlSpSigningDescription.Description,
+						MarkdownDescription: samlSpSigningDescription.MarkdownDescription,
+						Optional:            true,
 
 						Attributes: map[string]schema.Attribute{
 							"algorithm": schema.StringAttribute{
@@ -761,7 +766,7 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 
 							"key": schema.SingleNestedAttribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that specifies settings for the SAML Sp Signing key.").Description,
-								Optional:    true,
+								Required:    true,
 
 								Attributes: map[string]schema.Attribute{
 									"id": schema.StringAttribute{

--- a/internal/service/sso/resource_identity_provider_test.go
+++ b/internal/service/sso/resource_identity_provider_test.go
@@ -1081,9 +1081,10 @@ func TestAccIdentityProvider_SAML(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "saml.authentication_request_signed", "true"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_entity_id", fmt.Sprintf("idp:%s", name)),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sp_entity_id", fmt.Sprintf("sp:%s", name)),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_verification_certificate_ids.#", "1"),
-			resource.TestMatchResourceAttr(resourceFullName, "saml.idp_verification_certificate_ids.0", verify.P1ResourceIDRegexpFullString),
-			resource.TestMatchResourceAttr(resourceFullName, "saml.sp_signing_key_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_verification.certificates.#", "1"),
+			resource.TestMatchResourceAttr(resourceFullName, "saml.idp_verification.certificates.0.id", verify.P1ResourceIDRegexpFullString),
+			resource.TestMatchResourceAttr(resourceFullName, "saml.sp_signing.key.id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sp_signing.algorithm", "RSA_SHA512"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_binding", "HTTP_POST"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_endpoint", "https://www.pingidentity.com/sso"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_binding", "HTTP_REDIRECT"),
@@ -1110,8 +1111,9 @@ func TestAccIdentityProvider_SAML(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "saml.authentication_request_signed", "false"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_entity_id", fmt.Sprintf("idp:%s-1", name)),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sp_entity_id", fmt.Sprintf("sp:%s-1", name)),
-			resource.TestMatchResourceAttr(resourceFullName, "saml.idp_verification_certificate_ids.0", verify.P1ResourceIDRegexpFullString),
-			resource.TestCheckNoResourceAttr(resourceFullName, "saml.sp_signing_key_id"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_verification.certificates.#", "1"),
+			resource.TestMatchResourceAttr(resourceFullName, "saml.idp_verification.certificates.0.id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckNoResourceAttr(resourceFullName, "saml.sp_signing"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_binding", "HTTP_REDIRECT"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_endpoint", "https://www.pingidentity.com/sso1"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_binding", "HTTP_POST"),
@@ -1740,17 +1742,28 @@ resource "pingone_identity_provider" "%[2]s" {
   name           = "%[3]s"
 
   saml = {
-    authentication_request_signed    = true
-    idp_entity_id                    = "idp:%[3]s"
-    sp_entity_id                     = "sp:%[3]s"
-    idp_verification_certificate_ids = [pingone_certificate.%[2]s.id]
-    sp_signing_key_id                = pingone_key.%[2]s.id
-    sso_binding                      = "HTTP_POST"
-    sso_endpoint                     = "https://www.pingidentity.com/sso"
-    slo_binding                      = "HTTP_REDIRECT"
-    slo_endpoint                     = "https://dummy-slo-endpoint.pingidentity.com"
-    slo_response_endpoint            = "https://dummy-slo-response-endpoint.pingidentity.com"
-    slo_window                       = 1
+    authentication_request_signed = true
+    idp_entity_id                 = "idp:%[3]s"
+    sp_entity_id                  = "sp:%[3]s"
+    idp_verification = {
+      certificates = [
+        {
+          id = pingone_certificate.%[2]s.id
+        }
+      ]
+    }
+    sp_signing = {
+      key = {
+        id = pingone_key.%[2]s.id
+      }
+      algorithm = "RSA_SHA512"
+    }
+    sso_binding           = "HTTP_POST"
+    sso_endpoint          = "https://www.pingidentity.com/sso"
+    slo_binding           = "HTTP_REDIRECT"
+    slo_endpoint          = "https://dummy-slo-endpoint.pingidentity.com"
+    slo_response_endpoint = "https://dummy-slo-response-endpoint.pingidentity.com"
+    slo_window            = 1
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name, pem)
@@ -1775,11 +1788,17 @@ resource "pingone_identity_provider" "%[2]s" {
   name           = "%[3]s1"
 
   saml = {
-    idp_entity_id                    = "idp:%[3]s-1"
-    sp_entity_id                     = "sp:%[3]s-1"
-    idp_verification_certificate_ids = [pingone_certificate.%[2]s.id]
-    sso_binding                      = "HTTP_REDIRECT"
-    sso_endpoint                     = "https://www.pingidentity.com/sso1"
+    idp_entity_id = "idp:%[3]s-1"
+    sp_entity_id  = "sp:%[3]s-1"
+    idp_verification = {
+      certificates = [
+        {
+          id = pingone_certificate.%[2]s.id
+        }
+      ]
+    }
+    sso_binding  = "HTTP_REDIRECT"
+    sso_endpoint = "https://www.pingidentity.com/sso1"
   }
 }
 		`, acctest.GenericSandboxEnvironment(), resourceName, name, pem)

--- a/internal/service/sso/resource_identity_provider_test.go
+++ b/internal/service/sso/resource_identity_provider_test.go
@@ -1084,7 +1084,7 @@ func TestAccIdentityProvider_SAML(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "saml.idp_verification.certificates.#", "1"),
 			resource.TestMatchResourceAttr(resourceFullName, "saml.idp_verification.certificates.0.id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "saml.sp_signing.key.id", verify.P1ResourceIDRegexpFullString),
-			resource.TestCheckResourceAttr(resourceFullName, "saml.sp_signing.algorithm", "RSA_SHA512"),
+			resource.TestCheckResourceAttr(resourceFullName, "saml.sp_signing.algorithm", "SHA512withRSA"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_binding", "HTTP_POST"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.sso_endpoint", "https://www.pingidentity.com/sso"),
 			resource.TestCheckResourceAttr(resourceFullName, "saml.slo_binding", "HTTP_REDIRECT"),
@@ -1756,7 +1756,7 @@ resource "pingone_identity_provider" "%[2]s" {
       key = {
         id = pingone_key.%[2]s.id
       }
-      algorithm = "RSA_SHA512"
+      algorithm = "SHA512withRSA"
     }
     sso_binding           = "HTTP_POST"
     sso_endpoint          = "https://www.pingidentity.com/sso"
@@ -1765,8 +1765,7 @@ resource "pingone_identity_provider" "%[2]s" {
     slo_response_endpoint = "https://dummy-slo-response-endpoint.pingidentity.com"
     slo_window            = 1
   }
-}
-		`, acctest.GenericSandboxEnvironment(), resourceName, name, pem)
+}`, acctest.GenericSandboxEnvironment(), resourceName, name, pem)
 }
 
 func testAccIdentityProviderConfig_SAMLMinimal(resourceName, name, pem string) string {

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -1895,6 +1895,78 @@ resource "pingone_identity_provider" "my_awesome_identity_provider" {
 }
 ```
 
+### `saml.idp_verification_certificate_ids` parameter moved
+
+The `saml.idp_verification_certificate_ids` parameter has been moved to `saml.idp_verification.certificates.*.id`
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml {
+    idp_verification_certificate_ids = [
+      var.saml_idp_verification_certificate_id_1,
+      var.saml_idp_verification_certificate_id_2,
+    ]
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml = {
+    idp_verification = {
+      certificates = [
+        {
+          id = var.saml_idp_verification_certificate_id_1
+        },
+        {
+          id = var.saml_idp_verification_certificate_id_2
+        }
+      ]
+    }
+  }
+}
+```
+
+### `saml.sp_signing_key_id` parameter moved
+
+The `saml.sp_signing_key_id` parameter has been moved to `saml.sp_signing.key.id`
+
+Previous configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml {
+    sp_signing_key_id = var.saml_sp_signing_key_id
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_identity_provider" "my_awesome_identity_provider" {
+  # ... other configuration parameters
+
+  saml = {
+    sp_signing = {
+      key = {
+        id = var.saml_sp_signing_key_id
+      }
+    }
+  }
+}
+```
+
 ### `twitter` parameter data type change
 
 The `twitter` parameter is now a nested object type and no longer a block type.


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- **Enhancement** - `resource/pingone_identity_provider`: Added ability to set the SP signing key algorithm.
- **Breaking change** - `resource/pingone_identity_provider`: Replaced `saml.sp_signing_key_id` with `saml.sp_signing.key.id`.
- **Breaking change** - `resource/pingone_identity_provider`: Replaced `saml.idp_verification_certificate_ids` with `saml.idp_verification.certificates.*.id`.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccIdentityProvider_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccIdentityProvider_RemovalDrift
=== PAUSE TestAccIdentityProvider_RemovalDrift
=== RUN   TestAccIdentityProvider_NewEnv
=== PAUSE TestAccIdentityProvider_NewEnv
=== RUN   TestAccIdentityProvider_Change
=== PAUSE TestAccIdentityProvider_Change
=== RUN   TestAccIdentityProvider_Facebook
=== PAUSE TestAccIdentityProvider_Facebook
=== RUN   TestAccIdentityProvider_Google
=== PAUSE TestAccIdentityProvider_Google
=== RUN   TestAccIdentityProvider_LinkedIn
=== PAUSE TestAccIdentityProvider_LinkedIn
=== RUN   TestAccIdentityProvider_Yahoo
=== PAUSE TestAccIdentityProvider_Yahoo
=== RUN   TestAccIdentityProvider_Amazon
=== PAUSE TestAccIdentityProvider_Amazon
=== RUN   TestAccIdentityProvider_Twitter
=== PAUSE TestAccIdentityProvider_Twitter
=== RUN   TestAccIdentityProvider_Apple
=== PAUSE TestAccIdentityProvider_Apple
=== RUN   TestAccIdentityProvider_Paypal
=== PAUSE TestAccIdentityProvider_Paypal
=== RUN   TestAccIdentityProvider_Microsoft
=== PAUSE TestAccIdentityProvider_Microsoft
=== RUN   TestAccIdentityProvider_Github
=== PAUSE TestAccIdentityProvider_Github
=== RUN   TestAccIdentityProvider_OIDC
=== PAUSE TestAccIdentityProvider_OIDC
=== RUN   TestAccIdentityProvider_SAML
=== PAUSE TestAccIdentityProvider_SAML
=== RUN   TestAccIdentityProvider_ChangeProvider
=== PAUSE TestAccIdentityProvider_ChangeProvider
=== RUN   TestAccIdentityProvider_BadParameters
=== PAUSE TestAccIdentityProvider_BadParameters
=== CONT  TestAccIdentityProvider_RemovalDrift
=== CONT  TestAccIdentityProvider_Apple
=== CONT  TestAccIdentityProvider_OIDC
=== CONT  TestAccIdentityProvider_LinkedIn
=== CONT  TestAccIdentityProvider_Facebook
=== CONT  TestAccIdentityProvider_Amazon
=== CONT  TestAccIdentityProvider_Github
=== CONT  TestAccIdentityProvider_Change
=== CONT  TestAccIdentityProvider_ChangeProvider
=== CONT  TestAccIdentityProvider_SAML
=== CONT  TestAccIdentityProvider_NewEnv
=== CONT  TestAccIdentityProvider_Google
=== CONT  TestAccIdentityProvider_BadParameters
=== CONT  TestAccIdentityProvider_Paypal
=== CONT  TestAccIdentityProvider_Microsoft
=== CONT  TestAccIdentityProvider_Twitter
--- PASS: TestAccIdentityProvider_BadParameters (16.75s)
=== CONT  TestAccIdentityProvider_Yahoo
--- PASS: TestAccIdentityProvider_ChangeProvider (17.49s)
--- PASS: TestAccIdentityProvider_Microsoft (19.42s)
--- PASS: TestAccIdentityProvider_Paypal (19.60s)
--- PASS: TestAccIdentityProvider_Amazon (19.93s)
--- PASS: TestAccIdentityProvider_Google (20.80s)
--- PASS: TestAccIdentityProvider_Twitter (21.17s)
--- PASS: TestAccIdentityProvider_LinkedIn (21.29s)
--- PASS: TestAccIdentityProvider_Github (21.38s)
--- PASS: TestAccIdentityProvider_Facebook (21.83s)
--- PASS: TestAccIdentityProvider_Apple (22.44s)
--- PASS: TestAccIdentityProvider_Yahoo (13.11s)
--- PASS: TestAccIdentityProvider_Change (38.95s)
--- PASS: TestAccIdentityProvider_OIDC (39.16s)
--- PASS: TestAccIdentityProvider_SAML (39.54s)
--- PASS: TestAccIdentityProvider_NewEnv (42.63s)
--- PASS: TestAccIdentityProvider_RemovalDrift (53.41s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 55.630s
```

</details>