### PR TITLE
Migrate `pingone_notification_template_content` to plugin framework

### DIFF
--- a/.changelog/837.txt
+++ b/.changelog/837.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_notification_template_content`: Migrated to plugin framework.
+```

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -3387,6 +3387,222 @@ resource "pingone_notification_settings_email" "my_awesome_email_settings" {
 }
 ```
 
+## Resource: pingone_notification_template_content
+
+### `email` parameter data type change
+
+The `email` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email = {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from = {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+### `email.from` parameter data type change
+
+The `email.from` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email = {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from = {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+### `email.reply_to` parameter data type change
+
+The `email.reply_to` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email {
+    # ... other configuration parameters
+
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    reply_to {
+      name    = "BX Retail"
+      address = "reply@bxretail.org"
+    }
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email = {
+    # ... other configuration parameters
+
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    reply_to = {
+      name    = "BX Retail"
+      address = "reply@bxretail.org"
+    }
+  }
+}
+```
+
+### `push` parameter data type change
+
+The `push` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  push {
+    body  = "Please approve this transaction."
+    title = "BX Retail Transaction Request"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  push = {
+    body  = "Please approve this transaction."
+    title = "BX Retail Transaction Request"
+  }
+}
+```
+
+### `sms` parameter data type change
+
+The `sms` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  sms {
+    content = "Please approve this transaction with passcode $${otp}."
+    sender  = "BX Retail"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  sms = {
+    content = "Please approve this transaction with passcode $${otp}."
+    sender  = "BX Retail"
+  }
+}
+```
+
+### `voice` parameter data type change
+
+The `voice` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  voice {
+    content = "Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
+    type    = "Alice"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  voice = {
+    content = "Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
+    type    = "Alice"
+  }
+}
+```
+
 ## Resource: pingone_password_policy
 
 ### `account_lockout` parameter rename and data type change

--- a/docs/resources/notification_template_content.md
+++ b/docs/resources/notification_template_content.md
@@ -2,12 +2,12 @@
 page_title: "pingone_notification_template_content Resource - terraform-provider-pingone"
 subcategory: "Platform"
 description: |-
-  Resource to create and manage PingOne notification template contents for push, SMS, email and voice notifications.
+  Resource to create and manage PingOne notification template contents for push, SMS, email and voice notifications in an environment.
 ---
 
 # pingone_notification_template_content (Resource)
 
-Resource to create and manage PingOne notification template contents for push, SMS, email and voice notifications.
+Resource to create and manage PingOne notification template contents for push, SMS, email and voice notifications in an environment.
 
 ~> Only one notification method can be configured per resource, so (for example) a template that requires push, email and SMS will require three `pingone_notification_template_content` resource definitions, one for each method type.
 
@@ -25,11 +25,11 @@ resource "pingone_notification_template_content" "email" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  email {
+  email = {
     body    = "Please approve this transaction with passcode $${otp}."
     subject = "BX Retail Transaction Request"
 
-    from {
+    from = {
       name    = "BX Retail"
       address = "noreply@bxretail.org"
     }
@@ -41,7 +41,7 @@ resource "pingone_notification_template_content" "push" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  push {
+  push = {
     body  = "Please approve this transaction."
     title = "BX Retail Transaction Request"
   }
@@ -52,7 +52,7 @@ resource "pingone_notification_template_content" "sms" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  sms {
+  sms = {
     content = "Please approve this transaction with passcode $${otp}."
     sender  = "BX Retail"
   }
@@ -63,7 +63,7 @@ resource "pingone_notification_template_content" "voice" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  voice {
+  voice = {
     content = "Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
     type    = "Alice"
   }
@@ -75,92 +75,92 @@ resource "pingone_notification_template_content" "voice" {
 
 ### Required
 
-- `environment_id` (String) The ID of the environment to manage notification template contents in.
-- `locale` (String) An ISO standard language code. For more information about standard language codes, see [ISO Language Code Table](http://www.lingoes.net/en/translator/langcode.htm).
-- `template_name` (String) The ID of the template to manage localised contents for.  Options are `credential_issued`, `credential_revoked`, `credential_updated`, `credential_verification`, `device_pairing`, `digital_wallet_pairing`, `email_verification_admin`, `email_verification_user`, `email_phone_verification`, `general`, `id_verification`, `new_device_paired`, `recovery_code_template`, `strong_authentication`, `transaction`, `verification_code_template`.
+- `environment_id` (String) The ID of the environment to manage notification template contents in.  Must be a valid PingOne resource ID.  This field is immutable and will trigger a replace plan if changed.
+- `locale` (String) A string that specifies an ISO standard language code. For more information about standard language codes, see [ISO Language Code Table](http://www.lingoes.net/en/translator/langcode.htm).  Options are `af`, `af-ZA`, `ar`, `ar-AE`, `ar-BH`, `ar-DZ`, `ar-EG`, `ar-IQ`, `ar-JO`, `ar-KW`, `ar-LB`, `ar-LY`, `ar-MA`, `ar-OM`, `ar-QA`, `ar-SA`, `ar-SY`, `ar-TN`, `ar-YE`, `az`, `az-AZ`, `be`, `be-BY`, `bg`, `bg-BG`, `bs-BA`, `ca`, `ca-ES`, `cs`, `cs-CZ`, `cy`, `cy-GB`, `da`, `da-DK`, `de`, `de-AT`, `de-CH`, `de-DE`, `de-LI`, `de-LU`, `dv`, `dv-MV`, `el`, `el-GR`, `en`, `en-AU`, `en-BZ`, `en-CA`, `en-CB`, `en-GB`, `en-IE`, `en-JM`, `en-NZ`, `en-PH`, `en-TT`, `en-US`, `en-ZA`, `en-ZW`, `eo`, `es`, `es-AR`, `es-BO`, `es-CL`, `es-CO`, `es-CR`, `es-DO`, `es-EC`, `es-ES`, `es-GT`, `es-HN`, `es-MX`, `es-NI`, `es-PA`, `es-PE`, `es-PR`, `es-PY`, `es-SV`, `es-UY`, `es-VE`, `et`, `et-EE`, `eu`, `eu-ES`, `fa`, `fa-IR`, `fi`, `fi-FI`, `fo`, `fo-FO`, `fr`, `fr-BE`, `fr-CA`, `fr-CH`, `fr-FR`, `fr-LU`, `fr-MC`, `gl`, `gl-ES`, `gu`, `gu-IN`, `he`, `he-IL`, `hi`, `hi-IN`, `hr`, `hr-BA`, `hr-HR`, `hu`, `hu-HU`, `hy`, `hy-AM`, `id`, `id-ID`, `is`, `is-IS`, `it`, `it-CH`, `it-IT`, `ja`, `ja-JP`, `ka`, `ka-GE`, `kk`, `kk-KZ`, `kn`, `kn-IN`, `ko`, `ko-KR`, `kok`, `kok-IN`, `ky`, `ky-KG`, `lt`, `lt-LT`, `lv`, `lv-LV`, `mi`, `mi-NZ`, `mk`, `mk-MK`, `mn`, `mn-MN`, `mr`, `mr-IN`, `ms`, `ms-BN`, `ms-MY`, `mt`, `mt-MT`, `nb`, `nb-NO`, `nl`, `nl-BE`, `nl-NL`, `nn-NO`, `ns`, `ns-ZA`, `pa`, `pa-IN`, `pl`, `pl-PL`, `ps`, `ps-AR`, `pt`, `pt-BR`, `pt-PT`, `qu`, `qu-BO`, `qu-EC`, `qu-PE`, `ro`, `ro-RO`, `ru`, `ru-RU`, `sa`, `sa-IN`, `se`, `se-FI`, `se-NO`, `se-SE`, `sk`, `sk-SK`, `sl`, `sl-SI`, `sq`, `sq-AL`, `sr-BA`, `sr-SP`, `sv`, `sv-FI`, `sv-SE`, `sw`, `sw-KE`, `syr`, `syr-SY`, `ta`, `ta-IN`, `te`, `te-IN`, `th`, `th-TH`, `tl`, `tl-PH`, `tn`, `tn-ZA`, `tr`, `tr-TR`, `ts`, `tt`, `tt-RU`, `uk`, `uk-UA`, `ur`, `ur-PK`, `uz`, `uz-UZ`, `vi`, `vi-VN`, `xh`, `xh-ZA`, `zh`, `zh-CN`, `zh-HK`, `zh-MO`, `zh-SG`, `zh-TW`, `zu`, `zu-ZA`.  This field is immutable and will trigger a replace plan if changed.
+- `template_name` (String) A string that specifies the ID of the template to manage localised contents for.  Options are `credential_issued`, `credential_revoked`, `credential_updated`, `credential_verification`, `device_pairing`, `digital_wallet_pairing`, `email_phone_verification`, `email_verification_admin`, `email_verification_user`, `general`, `id_verification`, `new_device_paired`, `recovery_code_template`, `strong_authentication`, `transaction`, `verification_code_template`.  This field is immutable and will trigger a replace plan if changed.
 
 ### Optional
 
-- `email` (Block List, Max: 1) A block that specifies the content settings for the `email` delivery method. (see [below for nested schema](#nestedblock--email))
-- `push` (Block List, Max: 1) A block that specifies the content settings for the mobile `push` delivery method. (see [below for nested schema](#nestedblock--push))
-- `sms` (Block List, Max: 1) A block that specifies the content settings for the `SMS` delivery method. (see [below for nested schema](#nestedblock--sms))
-- `variant` (String) Holds the unique user-defined name for each content variant that uses the same template + `deliveryMethod` + `locale` combination.  This property is case insensitive and has a limit of 100 characters.
-- `voice` (Block List, Max: 1) A block that specifies the content settings for the `voice` delivery method. (see [below for nested schema](#nestedblock--voice))
+- `email` (Attributes) A single object that specifies properties for the `email` delivery method.  Exactly one of `email`, `push`, `sms` or `voice` must be specified. (see [below for nested schema](#nestedatt--email))
+- `push` (Attributes) A single object that specifies properties for the `push` delivery method.  Exactly one of `email`, `push`, `sms` or `voice` must be specified. (see [below for nested schema](#nestedatt--push))
+- `sms` (Attributes) A single object that specifies properties for the `sms` delivery method.  Exactly one of `email`, `push`, `sms` or `voice` must be specified. (see [below for nested schema](#nestedatt--sms))
+- `variant` (String) A string that specifies the unique user-defined name for each content variant that uses the same template + `deliveryMethod` + `locale` combination.  This property is case insensitive and has a limit of 100 characters.
+- `voice` (Attributes) A single object that specifies properties for the `voice` delivery method.  Exactly one of `email`, `push`, `sms` or `voice` must be specified. (see [below for nested schema](#nestedatt--voice))
 
 ### Read-Only
 
-- `default` (Boolean) Specifies whether the template is a predefined default template.
+- `default` (Boolean) A boolean that specifies whether the template is a predefined default template.
 - `id` (String) The ID of this resource.
 
-<a id="nestedblock--email"></a>
+<a id="nestedatt--email"></a>
 ### Nested Schema for `email`
 
 Required:
 
 - `body` (String) A string representing the email body. Email text can contain HTML but cannot be larger than 100 kB.  Use of variables is supported.
-- `subject` (String) The email's subject line. Cannot exceed 256 characters. Can include variables.
+- `subject` (String) A string representing the email's subject line. Cannot exceed 256 characters. Can include variables.
 
 Optional:
 
-- `character_set` (String) The email's character set. Defaults to `UTF-8`.
-- `content_type` (String) The email's content-type. Defaults to `text/html`.
-- `from` (Block List, Max: 1) A block that specifies the sender settings for the `email` delivery method. (see [below for nested schema](#nestedblock--email--from))
-- `reply_to` (Block List, Max: 1) A block that specifies the reply-to settings for the `email` delivery method. (see [below for nested schema](#nestedblock--email--reply_to))
+- `character_set` (String) A string that specifies the email's character set.  Defaults to `UTF-8`.
+- `content_type` (String) A string that specifies the email's content-type.  Defaults to `text/html`.
+- `from` (Attributes) A single object that specifies properties for the email sender. (see [below for nested schema](#nestedatt--email--from))
+- `reply_to` (Attributes) A single object that specifies properties for the email "reply to" address. (see [below for nested schema](#nestedatt--email--reply_to))
 
-<a id="nestedblock--email--from"></a>
+<a id="nestedatt--email--from"></a>
 ### Nested Schema for `email.from`
 
 Optional:
 
-- `address` (String) The sender email address. If the environment uses the Ping Identity email sender, or if the address field is empty, the address `noreply@pingidentity.com` is used.  You can configure other email sender addresses per environment. Defaults to `noreply@pingidentity.com`.
-- `name` (String) The email's sender name.  If the environment uses the Ping Identity email sender, the name `PingOne` is used. You can configure other email sender names per environment. Defaults to `PingOne`.
+- `address` (String) A string that specifies the sender email address. If the environment uses the Ping Identity email sender, or if the address field is empty, the address `noreply@pingidentity.com` is used.  You can configure other email sender addresses per environment.
+- `name` (String) A string that specifies the email's sender name.  If the environment uses the Ping Identity email sender, the name `PingOne` is used. You can configure other email sender names per environment.
 
 
-<a id="nestedblock--email--reply_to"></a>
+<a id="nestedatt--email--reply_to"></a>
 ### Nested Schema for `email.reply_to`
 
 Optional:
 
-- `address` (String) The "reply to" email address.  If the environment uses the Ping Identity email sender, or if the address field is empty, the address `noreply@pingidentity.com` is used.  You can configure other email "reply to" addresses per environment.
-- `name` (String) The email's "reply to" name.  If the environment uses the Ping Identity email sender, the name `PingOne` is used.  You can configure other email "reply to" names per environment.
+- `address` (String) A string that specifies the "reply to" email address.  If the environment uses the Ping Identity email sender, or if the address field is empty, the address `noreply@pingidentity.com` is used.  You can configure other email "reply to" addresses per environment.
+- `name` (String) A string that specifies the email's "reply to" name.  If the environment uses the Ping Identity email sender, the name `PingOne` is used.  You can configure other email "reply to" names per environment.
 
 
 
-<a id="nestedblock--push"></a>
+<a id="nestedatt--push"></a>
 ### Nested Schema for `push`
 
 Required:
 
-- `body` (String) The push notification text. This can include variables.
-- `title` (String) The push notification title. This can include variables.
+- `body` (String) A string that specifies the push notification text. This can include variables.
+- `title` (String) A string that specifies the push notification title. This can include variables.
 
 Optional:
 
-- `category` (String) For Push content, you can specify what type of banner should be displayed to the user. The available options are `BANNER_BUTTONS` (the banner contains both Approve and Deny buttons), `WITHOUT_BANNER_BUTTONS` (when the user clicks the banner, they are taken to an application that contains the necessary approval controls), `APPROVE_AND_OPEN_APP` (when the Approve button is clicked, authentication is completed and the user is taken to the relevant application).  If this parameter is not provided, the default is `BANNER_BUTTONS`. Note that to use the non-default push banners, you must implement them in your application code, using the PingOne SDK. For details, see the [README for iOS](https://github.com/pingidentity/pingone-mobile-sdk-ios/#171-push-notifications-categories) and the [README for Android](https://github.com/pingidentity/pingone-mobile-sdk-android). Defaults to `BANNER_BUTTONS`.
+- `category` (String) A string that specifies what type of banner should be displayed to the user.  Options are `APPROVE_AND_OPEN_APP` (when the Approve button is clicked, authentication is completed and the user is taken to the relevant application), `BANNER_BUTTONS` (the banner contains both Approve and Deny buttons), `WITHOUT_BANNER_BUTTONS` (when the user clicks the banner, they are taken to an application that contains the necessary approval controls).  Defaults to `DOC ERROR: Unknown default data type`.  Note that to use the non-default push banners, you must implement them in your application code, using the PingOne SDK. For details, see the [README for iOS](https://github.com/pingidentity/pingone-mobile-sdk-ios/#171-push-notifications-categories) and the [README for Android](https://github.com/pingidentity/pingone-mobile-sdk-android).
 
 
-<a id="nestedblock--sms"></a>
+<a id="nestedatt--sms"></a>
 ### Nested Schema for `sms`
 
 Required:
 
-- `content` (String) The SMS text. UC-2 encoding is used for text that contains non GSM-7 characters. UC-2 encoded text cannot exceed 67 characters. GSM-7 encoded text cannot exceed 153 characters. This can include variables.
+- `content` (String) A string that specifies the SMS text. UC-2 encoding is used for text that contains non GSM-7 characters. UC-2 encoded text cannot exceed 67 characters. GSM-7 encoded text cannot exceed 153 characters. This can include variables.
 
 Optional:
 
-- `sender` (String) The SMS sender ID. This property can contain only alphanumeric characters and spaces, and its length cannot exceed 11 characters. In some countries, it is impossible to send an SMS with an alphanumeric sender ID. For those countries, the sender ID must be empty. For SMS recipients in specific countries, refer to Twilio's documentation on [International support for Alphanumeric Sender ID](https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID).
+- `sender` (String) A string that specifies the SMS sender ID. This property can contain only alphanumeric characters and spaces, and its length cannot exceed 11 characters. In some countries, it is impossible to send an SMS with an alphanumeric sender ID. For those countries, the sender ID must be empty. For SMS recipients in specific countries, refer to Twilio's documentation on [International support for Alphanumeric Sender ID](https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID).
 
 
-<a id="nestedblock--voice"></a>
+<a id="nestedatt--voice"></a>
 ### Nested Schema for `voice`
 
 Required:
 
-- `content` (String) The voice text to read.  This can include variables.
+- `content` (String) A string that specifies the voice text to read. This can include variables.
 
 Optional:
 
-- `type` (String) The voice type desired for the message. Out of the box options include `Man`, `Woman`, `Alice` (Twilio only), `Amazon Polly`, or your own user-defined custom string. In the case that the selected voice type is not supported by the provider in the desired locale, another voice type will be automatically selected. Additional charges may be incurred for these selections, as determined by the sender. Defaults to `Alice`.
+- `type` (String) A string that specifies the voice type desired for the message. Out of the box options include `Man`, `Woman`, `Alice` (Twilio only), `Amazon Polly`, or your own user-defined custom string. In the case that the selected voice type is not supported by the provider in the desired locale, another voice type will be automatically selected. Additional charges may be incurred for these selections, as determined by the sender.
 
 ## Import
 

--- a/docs/resources/notification_template_content.md
+++ b/docs/resources/notification_template_content.md
@@ -136,7 +136,7 @@ Required:
 
 Optional:
 
-- `category` (String) A string that specifies what type of banner should be displayed to the user.  Options are `APPROVE_AND_OPEN_APP` (when the Approve button is clicked, authentication is completed and the user is taken to the relevant application), `BANNER_BUTTONS` (the banner contains both Approve and Deny buttons), `WITHOUT_BANNER_BUTTONS` (when the user clicks the banner, they are taken to an application that contains the necessary approval controls).  Defaults to `DOC ERROR: Unknown default data type`.  Note that to use the non-default push banners, you must implement them in your application code, using the PingOne SDK. For details, see the [README for iOS](https://github.com/pingidentity/pingone-mobile-sdk-ios/#171-push-notifications-categories) and the [README for Android](https://github.com/pingidentity/pingone-mobile-sdk-android).
+- `category` (String) A string that specifies what type of banner should be displayed to the user.  Options are `APPROVE_AND_OPEN_APP` (when the Approve button is clicked, authentication is completed and the user is taken to the relevant application), `BANNER_BUTTONS` (the banner contains both Approve and Deny buttons), `WITHOUT_BANNER_BUTTONS` (when the user clicks the banner, they are taken to an application that contains the necessary approval controls).  Defaults to `BANNER_BUTTONS`.  Note that to use the non-default push banners, you must implement them in your application code, using the PingOne SDK. For details, see the [README for iOS](https://github.com/pingidentity/pingone-mobile-sdk-ios/#171-push-notifications-categories) and the [README for Android](https://github.com/pingidentity/pingone-mobile-sdk-android).
 
 
 <a id="nestedatt--sms"></a>

--- a/examples/resources/pingone_notification_template_content/resource.tf
+++ b/examples/resources/pingone_notification_template_content/resource.tf
@@ -7,11 +7,11 @@ resource "pingone_notification_template_content" "email" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  email {
+  email = {
     body    = "Please approve this transaction with passcode $${otp}."
     subject = "BX Retail Transaction Request"
 
-    from {
+    from = {
       name    = "BX Retail"
       address = "noreply@bxretail.org"
     }
@@ -23,7 +23,7 @@ resource "pingone_notification_template_content" "push" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  push {
+  push = {
     body  = "Please approve this transaction."
     title = "BX Retail Transaction Request"
   }
@@ -34,7 +34,7 @@ resource "pingone_notification_template_content" "sms" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  sms {
+  sms = {
     content = "Please approve this transaction with passcode $${otp}."
     sender  = "BX Retail"
   }
@@ -45,7 +45,7 @@ resource "pingone_notification_template_content" "voice" {
   template_name  = "strong_authentication"
   locale         = "en"
 
-  voice {
+  voice = {
     content = "Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
     type    = "Alice"
   }

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -126,12 +126,11 @@ func New(version string) func() *schema.Provider {
 			ResourcesMap: map[string]*schema.Resource{
 				"pingone_authorize_decision_endpoint": authorize.ResourceDecisionEndpoint(),
 
-				"pingone_certificate":                   base.ResourceCertificate(),
-				"pingone_certificate_signing_response":  base.ResourceCertificateSigningResponse(),
-				"pingone_gateway_credential":            base.ResourceGatewayCredential(),
-				"pingone_language":                      base.ResourceLanguage(),
-				"pingone_language_update":               base.ResourceLanguageUpdate(),
-				"pingone_notification_template_content": base.ResourceNotificationTemplateContent(),
+				"pingone_certificate":                  base.ResourceCertificate(),
+				"pingone_certificate_signing_response": base.ResourceCertificateSigningResponse(),
+				"pingone_gateway_credential":           base.ResourceGatewayCredential(),
+				"pingone_language":                     base.ResourceLanguage(),
+				"pingone_language_update":              base.ResourceLanguageUpdate(),
 
 				"pingone_application_sign_on_policy_assignment": sso.ResourceApplicationSignOnPolicyAssignment(),
 				"pingone_sign_on_policy_action":                 sso.ResourceSignOnPolicyAction(),

--- a/internal/service/base/resource_notification_template_content.go
+++ b/internal/service/base/resource_notification_template_content.go
@@ -199,7 +199,7 @@ func (r *NotificationTemplateContentResource) Schema(ctx context.Context, req re
 		string(management.ENUMTEMPLATECONTENTPUSHCATEGORY_BANNER_BUTTONS):         "the banner contains both Approve and Deny buttons",
 		string(management.ENUMTEMPLATECONTENTPUSHCATEGORY_WITHOUT_BANNER_BUTTONS): "when the user clicks the banner, they are taken to an application that contains the necessary approval controls",
 		string(management.ENUMTEMPLATECONTENTPUSHCATEGORY_APPROVE_AND_OPEN_APP):   "when the Approve button is clicked, authentication is completed and the user is taken to the relevant application",
-	}).DefaultValue(management.ENUMTEMPLATECONTENTPUSHCATEGORY_BANNER_BUTTONS).AppendMarkdownString("Note that to use the non-default push banners, you must implement them in your application code, using the PingOne SDK. For details, see the [README for iOS](https://github.com/pingidentity/pingone-mobile-sdk-ios/#171-push-notifications-categories) and the [README for Android](https://github.com/pingidentity/pingone-mobile-sdk-android).")
+	}).DefaultValue(string(management.ENUMTEMPLATECONTENTPUSHCATEGORY_BANNER_BUTTONS)).AppendMarkdownString("Note that to use the non-default push banners, you must implement them in your application code, using the PingOne SDK. For details, see the [README for iOS](https://github.com/pingidentity/pingone-mobile-sdk-ios/#171-push-notifications-categories) and the [README for Android](https://github.com/pingidentity/pingone-mobile-sdk-android).")
 
 	const pushBodyMinLength = 1
 	const pushBodyMaxLength = 400

--- a/internal/service/base/resource_notification_template_content_test.go
+++ b/internal/service/base/resource_notification_template_content_test.go
@@ -5,16 +5,13 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/pingidentity/terraform-provider-pingone/internal/acctest"
 	"github.com/pingidentity/terraform-provider-pingone/internal/acctest/service/base"
 	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
-	"github.com/pingidentity/terraform-provider-pingone/internal/utils"
 	"github.com/pingidentity/terraform-provider-pingone/internal/verify"
 )
 
@@ -95,11 +92,12 @@ func TestAccNotificationTemplateContent_OverrideDefaultLocale(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "template_name", name),
 		resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
-		resource.TestCheckResourceAttr(resourceFullName, "variant", ""),
-		resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-		resource.TestCheckResourceAttr(resourceFullName, "push.#", "1"),
-		resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-		resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "variant"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+		resource.TestCheckResourceAttrSet(resourceFullName, "push.body"),
+		resource.TestCheckResourceAttrSet(resourceFullName, "push.title"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -164,11 +162,12 @@ func TestAccNotificationTemplateContent_NewLocale(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "template_name", name),
 		resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
-		resource.TestCheckResourceAttr(resourceFullName, "variant", ""),
-		resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-		resource.TestCheckResourceAttr(resourceFullName, "push.#", "1"),
-		resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-		resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "variant"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+		resource.TestCheckResourceAttr(resourceFullName, "push.body", "Min - Please approve this transaction."),
+		resource.TestCheckResourceAttr(resourceFullName, "push.title", "Min - BX Retail Transaction Request"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -244,10 +243,11 @@ func TestAccNotificationTemplateContent_NewVariant(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
 		resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 		resource.TestCheckResourceAttr(resourceFullName, "variant", variant),
-		resource.TestCheckResourceAttr(resourceFullName, "email.#", "1"),
-		resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
-		resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-		resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+		resource.TestCheckResourceAttrSet(resourceFullName, "email.body"),
+		resource.TestCheckResourceAttrSet(resourceFullName, "email.subject"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "push"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -343,7 +343,7 @@ func TestAccNotificationTemplateContent_ChangeVariant(t *testing.T) {
 			{
 				Config: testAccNotificationTemplateContentConfig_NoVariant_Minimal(environmentName, licenseID, resourceName, name, locale),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "variant", ""),
+					resource.TestCheckNoResourceAttr(resourceFullName, "variant"),
 				),
 			},
 			{
@@ -383,11 +383,11 @@ func TestAccNotificationTemplateContent_InvalidData(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccNotificationTemplateContentConfig_DefaultVariant_Push_Minimal(environmentName, licenseID, resourceName, name.Invalid, locale.Valid),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`expected template_name to be one of \["%s"\], got strong_authentication_doesnotexist`, strings.Join(utils.EnumSliceToStringSlice(management.AllowedEnumTemplateNameEnumValues), "\" \""))),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Value Match`),
 			},
 			{
 				Config:      testAccNotificationTemplateContentConfig_DefaultVariant_Push_Minimal(environmentName, licenseID, resourceName, name.Valid, locale.Invalid),
-				ExpectError: regexp.MustCompile(`expected locale to be one of \["af" "af-ZA" "ar" "ar-AE" "ar-BH" "ar-DZ" "ar-EG" "ar-IQ" "ar-JO" "ar-KW" "ar-LB" "ar-LY" "ar-MA" "ar-OM" "ar-QA" "ar-SA" "ar-SY" "ar-TN" "ar-YE" "az" "az-AZ" "be" "be-BY" "bg" "bg-BG" "bs-BA" "ca" "ca-ES" "cs" "cs-CZ" "cy" "cy-GB" "da" "da-DK" "de" "de-AT" "de-CH" "de-DE" "de-LI" "de-LU" "dv" "dv-MV" "el" "el-GR" "en" "en-AU" "en-BZ" "en-CA" "en-CB" "en-GB" "en-IE" "en-JM" "en-NZ" "en-PH" "en-TT" "en-US" "en-ZA" "en-ZW" "eo" "es" "es-AR" "es-BO" "es-CL" "es-CO" "es-CR" "es-DO" "es-EC" "es-ES" "es-GT" "es-HN" "es-MX" "es-NI" "es-PA" "es-PE" "es-PR" "es-PY" "es-SV" "es-UY" "es-VE" "et" "et-EE" "eu" "eu-ES" "fa" "fa-IR" "fi" "fi-FI" "fo" "fo-FO" "fr" "fr-BE" "fr-CA" "fr-CH" "fr-FR" "fr-LU" "fr-MC" "gl" "gl-ES" "gu" "gu-IN" "he" "he-IL" "hi" "hi-IN" "hr" "hr-BA" "hr-HR" "hu" "hu-HU" "hy" "hy-AM" "id" "id-ID" "is" "is-IS" "it" "it-CH" "it-IT" "ja" "ja-JP" "ka" "ka-GE" "kk" "kk-KZ" "kn" "kn-IN" "ko" "ko-KR" "kok" "kok-IN" "ky" "ky-KG" "lt" "lt-LT" "lv" "lv-LV" "mi" "mi-NZ" "mk" "mk-MK" "mn" "mn-MN" "mr" "mr-IN" "ms" "ms-BN" "ms-MY" "mt" "mt-MT" "nb" "nb-NO" "nl" "nl-BE" "nl-NL" "nn-NO" "ns" "ns-ZA" "pa" "pa-IN" "pl" "pl-PL" "ps" "ps-AR" "pt" "pt-BR" "pt-PT" "qu" "qu-BO" "qu-EC" "qu-PE" "ro" "ro-RO" "ru" "ru-RU" "sa" "sa-IN" "se" "se-FI" "se-NO" "se-SE" "sk" "sk-SK" "sl" "sl-SI" "sq" "sq-AL" "sr-BA" "sr-SP" "sv" "sv-FI" "sv-SE" "sw" "sw-KE" "syr" "syr-SY" "ta" "ta-IN" "te" "te-IN" "th" "th-TH" "tl" "tl-PH" "tn" "tn-ZA" "tr" "tr-TR" "tt" "tt-RU" "ts" "uk" "uk-UA" "ur" "ur-PK" "uz" "uz-UZ" "vi" "vi-VN" "xh" "xh-ZA" "zh" "zh-CN" "zh-HK" "zh-MO" "zh-SG" "zh-TW" "zu" "zu-ZA"\], got en-ZZ`),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Value Match`),
 			},
 			{
 				Config:      testAccNotificationTemplateContentConfig_DuplicateLocale(environmentName, licenseID, resourceName, name.Valid, "en"),
@@ -418,34 +418,32 @@ func TestAccNotificationTemplateContent_Email(t *testing.T) {
 		Minimal: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.subject", "Min - Verify your email address"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.body", "Min - <p>\n\tUse the code provided to verify your email address with PingOne. If you think you received this email in error, contact your supervisor.\n\t</p>\n\t<p>\n\tTo verify your email address:\n\t<ol type=\"1\">\n\t  <li>Sign-on to the self-service portal. For instructions, see <a href=\"https://docs.pingidentity.com/bundle/pingone/page/snd1631892368614.html\">Managing your PingOne user profile</a>.</li>\n\t  <li>Enter your verification code in the <b>Contact</b> section: ${code}</li>\n\t  <li>Click <b>Verify</b>.</li>\n\t</ol>\n\t</p>\n"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.from.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.reply_to.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.character_set", "UTF-8"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.content_type", "text/html"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.subject", "Min - Verify your email address"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.body", "Min - <p>\n\tUse the code provided to verify your email address with PingOne. If you think you received this email in error, contact your supervisor.\n\t</p>\n\t<p>\n\tTo verify your email address:\n\t<ol type=\"1\">\n\t  <li>Sign-on to the self-service portal. For instructions, see <a href=\"https://docs.pingidentity.com/bundle/pingone/page/snd1631892368614.html\">Managing your PingOne user profile</a>.</li>\n\t  <li>Enter your verification code in the <b>Contact</b> section: ${code}</li>\n\t  <li>Click <b>Verify</b>.</li>\n\t</ol>\n\t</p>\n"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email.from"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email.reply_to"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.character_set", "UTF-8"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.content_type", "text/html"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "push"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 		),
 		Full: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.subject", "Full - Verify your email address"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.body", "Full - <p>\n\tUse the code provided to verify your email address with PingOne. If you think you received this email in error, contact your supervisor.\n\t</p>\n\t<p>\n\tTo verify your email address:\n\t<ol type=\"1\">\n\t  <li>Sign-on to the self-service portal. For instructions, see <a href=\"https://docs.pingidentity.com/bundle/pingone/page/snd1631892368614.html\">Managing your PingOne user profile</a>.</li>\n\t  <li>Enter your verification code in the <b>Contact</b> section: ${code}</li>\n\t  <li>Click <b>Verify</b>.</li>\n\t</ol>\n\t</p>\n"),
-			// resource.TestCheckResourceAttr(resourceFullName, "email.0.from.#", "1"),
-			// resource.TestCheckResourceAttr(resourceFullName, "email.0.from.0.name", "BX Retail"),
-			// resource.TestCheckResourceAttr(resourceFullName, "email.0.from.0.address", "noreply@bxretail.org"),
-			// resource.TestCheckResourceAttr(resourceFullName, "email.0.reply_to.#", "1"),
-			// resource.TestCheckResourceAttr(resourceFullName, "email.0.reply_to.0.name", "BX Retail Reply"),
-			// resource.TestCheckResourceAttr(resourceFullName, "email.0.reply_to.0.address", "reply@bxretail.org"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.character_set", "iso-8859-5"),
-			resource.TestCheckResourceAttr(resourceFullName, "email.0.content_type", "text/plain"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.subject", "Full - Verify your email address"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.body", "Full - <p>\n\tUse the code provided to verify your email address with PingOne. If you think you received this email in error, contact your supervisor.\n\t</p>\n\t<p>\n\tTo verify your email address:\n\t<ol type=\"1\">\n\t  <li>Sign-on to the self-service portal. For instructions, see <a href=\"https://docs.pingidentity.com/bundle/pingone/page/snd1631892368614.html\">Managing your PingOne user profile</a>.</li>\n\t  <li>Enter your verification code in the <b>Contact</b> section: ${code}</li>\n\t  <li>Click <b>Verify</b>.</li>\n\t</ol>\n\t</p>\n"),
+			// resource.TestCheckResourceAttr(resourceFullName, "email.from.#", "1"),
+			// resource.TestCheckResourceAttr(resourceFullName, "email.from.name", "BX Retail"),
+			// resource.TestCheckResourceAttr(resourceFullName, "email.from.address", "noreply@bxretail.org"),
+			// resource.TestCheckResourceAttr(resourceFullName, "email.reply_to.#", "1"),
+			// resource.TestCheckResourceAttr(resourceFullName, "email.reply_to.name", "BX Retail Reply"),
+			// resource.TestCheckResourceAttr(resourceFullName, "email.reply_to.address", "reply@bxretail.org"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.character_set", "iso-8859-5"),
+			resource.TestCheckResourceAttr(resourceFullName, "email.content_type", "text/plain"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "push"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 		),
 	}
 
@@ -515,24 +513,22 @@ func TestAccNotificationTemplateContent_Push(t *testing.T) {
 		Minimal: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.0.body", "Min - Please approve this transaction."),
-			resource.TestCheckResourceAttr(resourceFullName, "push.0.title", "Min - BX Retail Transaction Request"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.0.category", "BANNER_BUTTONS"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+			resource.TestCheckResourceAttr(resourceFullName, "push.body", "Min - Please approve this transaction."),
+			resource.TestCheckResourceAttr(resourceFullName, "push.title", "Min - BX Retail Transaction Request"),
+			resource.TestCheckResourceAttr(resourceFullName, "push.category", "BANNER_BUTTONS"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 		),
 		Full: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.0.body", "Full - Please approve this transaction."),
-			resource.TestCheckResourceAttr(resourceFullName, "push.0.title", "Full - BX Retail Transaction Request"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.0.category", "WITHOUT_BANNER_BUTTONS"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+			resource.TestCheckResourceAttr(resourceFullName, "push.body", "Full - Please approve this transaction."),
+			resource.TestCheckResourceAttr(resourceFullName, "push.title", "Full - BX Retail Transaction Request"),
+			resource.TestCheckResourceAttr(resourceFullName, "push.category", "WITHOUT_BANNER_BUTTONS"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 		),
 	}
 
@@ -611,22 +607,20 @@ func TestAccNotificationTemplateContent_SMS(t *testing.T) {
 		Minimal: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.0.content", "Min - Please approve this transaction with passcode ${otp}."),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.0.sender", ""),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "push"),
+			resource.TestCheckResourceAttr(resourceFullName, "sms.content", "Min - Please approve this transaction with passcode ${otp}."),
+			resource.TestCheckNoResourceAttr(resourceFullName, "sms.sender"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 		),
 		Full: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.0.content", "Full - Please approve this transaction with passcode ${otp}."),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.0.sender", "BX Retail"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "0"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "push"),
+			resource.TestCheckResourceAttr(resourceFullName, "sms.content", "Full - Please approve this transaction with passcode ${otp}."),
+			resource.TestCheckResourceAttr(resourceFullName, "sms.sender", "BX Retail"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "voice"),
 		),
 	}
 
@@ -705,22 +699,20 @@ func TestAccNotificationTemplateContent_Voice(t *testing.T) {
 		Minimal: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.0.content", "Min - Hello <pause1sec> your authentication code is <sayCharValue>${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>${otp}</sayCharValue></repeatMessage>"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.0.type", "Alice"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "push"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+			resource.TestCheckResourceAttr(resourceFullName, "voice.content", "Min - Hello <pause1sec> your authentication code is <sayCharValue>${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>${otp}</sayCharValue></repeatMessage>"),
+			resource.TestCheckResourceAttr(resourceFullName, "voice.type", "Alice"),
 		),
 		Full: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "template_name", template.Valid),
 			resource.TestCheckResourceAttr(resourceFullName, "locale", locale),
-			resource.TestCheckResourceAttr(resourceFullName, "email.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "push.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "sms.#", "0"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.#", "1"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.0.content", "Full - Hello <pause1sec> your authentication code is <sayCharValue>${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>${otp}</sayCharValue></repeatMessage>"),
-			resource.TestCheckResourceAttr(resourceFullName, "voice.0.type", "Man"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "email"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "push"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "sms"),
+			resource.TestCheckResourceAttr(resourceFullName, "voice.content", "Full - Hello <pause1sec> your authentication code is <sayCharValue>${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>${otp}</sayCharValue></repeatMessage>"),
+			resource.TestCheckResourceAttr(resourceFullName, "voice.type", "Man"),
 		),
 	}
 
@@ -809,19 +801,19 @@ func TestAccNotificationTemplateContent_BadParameters(t *testing.T) {
 			{
 				ResourceName: resourceFullName,
 				ImportState:  true,
-				ExpectError:  regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/template_name/notification_template_content_id" and must match regex: .*`),
+				ExpectError:  regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 			{
 				ResourceName:  resourceFullName,
 				ImportStateId: "/",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/template_name/notification_template_content_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 			{
 				ResourceName:  resourceFullName,
 				ImportStateId: "badformat/badformat/badformat",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile(`Invalid import ID specified \(".*"\).  The ID should be in the format "environment_id/template_name/notification_template_content_id" and must match regex: .*`),
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 		},
 	})
@@ -842,7 +834,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  push {
+  push = {
     body  = "Min - Please approve this transaction."
     title = "Min - BX Retail Transaction Request"
   }
@@ -863,7 +855,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   locale         = "%[5]s"
   variant        = "%[6]s"
 
-  email {
+  email = {
     body    = <<EOT
 Test $${code.value}
 EOT
@@ -881,7 +873,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  email {
+  email = {
     body    = <<EOT
 Test $${code.value}
 EOT
@@ -900,7 +892,7 @@ resource "pingone_notification_template_content" "%[3]s-1" {
   locale         = "%[5]s"
   variant        = "test-duplicate-locale"
 
-  push {
+  push = {
     body  = "1 - Please approve this transaction."
     title = "1 - BX Retail Transaction Request"
   }
@@ -912,7 +904,7 @@ resource "pingone_notification_template_content" "%[3]s-2" {
   locale         = "%[5]s"
   variant        = "test-duplicate-locale"
 
-  push {
+  push = {
     body  = "2 - Please approve this transaction."
     title = "2 - BX Retail Transaction Request"
   }
@@ -933,7 +925,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  email {
+  email = {
     body    = <<EOT
 Min - <p>
 	Use the code provided to verify your email address with PingOne. If you think you received this email in error, contact your supervisor.
@@ -961,7 +953,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  email {
+  email = {
     body    = <<EOT
 Full - <p>
 	Use the code provided to verify your email address with PingOne. If you think you received this email in error, contact your supervisor.
@@ -977,12 +969,12 @@ Full - <p>
 EOT
     subject = "Full - Verify your email address"
 
-    // from {
+    // from = {
     //   name    = "BX Retail"
     //   address = "noreply@bxretail.org"
     // }
 
-    // reply_to {
+    // reply_to = {
     //   name    = "BX Retail Reply"
     //   address = "reply@bxretail.org"
     // }
@@ -1002,7 +994,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  push {
+  push = {
     body  = "Min - Please approve this transaction."
     title = "Min - BX Retail Transaction Request"
   }
@@ -1018,7 +1010,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  push {
+  push = {
     body  = "Full - Please approve this transaction."
     title = "Full - BX Retail Transaction Request"
 
@@ -1036,7 +1028,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  sms {
+  sms = {
     content = "Min - Please approve this transaction with passcode $${otp}."
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, locale)
@@ -1051,7 +1043,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  sms {
+  sms = {
     content = "Full - Please approve this transaction with passcode $${otp}."
     sender  = "BX Retail"
   }
@@ -1067,7 +1059,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  voice {
+  voice = {
     content = "Min - Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
   }
 }`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, locale)
@@ -1082,7 +1074,7 @@ resource "pingone_notification_template_content" "%[3]s" {
   template_name  = "%[4]s"
   locale         = "%[5]s"
 
-  voice {
+  voice = {
     content = "Full - Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
     type    = "Man"
   }

--- a/internal/service/base/service.go
+++ b/internal/service/base/service.go
@@ -35,6 +35,7 @@ func Resources() []func() resource.Resource {
 		NewNotificationPolicyResource,
 		NewNotificationSettingsEmailResource,
 		NewNotificationSettingsResource,
+		NewNotificationTemplateContentResource,
 		NewPhoneDeliverySettingsResource,
 		NewSystemApplicationResource,
 		NewTrustedEmailAddressResource,

--- a/templates/guides/version-1-upgrade.md
+++ b/templates/guides/version-1-upgrade.md
@@ -3387,6 +3387,222 @@ resource "pingone_notification_settings_email" "my_awesome_email_settings" {
 }
 ```
 
+## Resource: pingone_notification_template_content
+
+### `email` parameter data type change
+
+The `email` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email = {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from = {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+### `email.from` parameter data type change
+
+The `email.from` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email = {
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    from = {
+      name    = "BX Retail"
+      address = "noreply@bxretail.org"
+    }
+  }
+}
+```
+
+### `email.reply_to` parameter data type change
+
+The `email.reply_to` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email {
+    # ... other configuration parameters
+
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    reply_to {
+      name    = "BX Retail"
+      address = "reply@bxretail.org"
+    }
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  email = {
+    # ... other configuration parameters
+
+    body    = "Please approve this transaction with passcode $${otp}."
+    subject = "BX Retail Transaction Request"
+
+    reply_to = {
+      name    = "BX Retail"
+      address = "reply@bxretail.org"
+    }
+  }
+}
+```
+
+### `push` parameter data type change
+
+The `push` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  push {
+    body  = "Please approve this transaction."
+    title = "BX Retail Transaction Request"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  push = {
+    body  = "Please approve this transaction."
+    title = "BX Retail Transaction Request"
+  }
+}
+```
+
+### `sms` parameter data type change
+
+The `sms` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  sms {
+    content = "Please approve this transaction with passcode $${otp}."
+    sender  = "BX Retail"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  sms = {
+    content = "Please approve this transaction with passcode $${otp}."
+    sender  = "BX Retail"
+  }
+}
+```
+
+### `voice` parameter data type change
+
+The `voice` parameter is now a nested object type and no longer a list type.
+
+Previous configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  voice {
+    content = "Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
+    type    = "Alice"
+  }
+}
+```
+
+New configuration example:
+
+```terraform
+resource "pingone_notification_template_content" "email" {
+  # ... other configuration parameters
+
+  voice = {
+    content = "Hello <pause1sec> your authentication code is <sayCharValue>$${otp}</sayCharValue><pause1sec><pause1sec><repeatMessage val=2>I repeat <pause1sec>your code is <sayCharValue>$${otp}</sayCharValue></repeatMessage>"
+    type    = "Alice"
+  }
+}
+```
+
 ## Resource: pingone_password_policy
 
 ### `account_lockout` parameter rename and data type change


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_resource`: Migrated to plugin framework.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccNotificationTemplateContent_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccNotificationTemplateContent_RemovalDrift
=== PAUSE TestAccNotificationTemplateContent_RemovalDrift
=== RUN   TestAccNotificationTemplateContent_OverrideDefaultLocale
=== PAUSE TestAccNotificationTemplateContent_OverrideDefaultLocale
=== RUN   TestAccNotificationTemplateContent_NewLocale
=== PAUSE TestAccNotificationTemplateContent_NewLocale
=== RUN   TestAccNotificationTemplateContent_NewVariant
=== PAUSE TestAccNotificationTemplateContent_NewVariant
=== RUN   TestAccNotificationTemplateContent_ChangeVariant
=== PAUSE TestAccNotificationTemplateContent_ChangeVariant
=== RUN   TestAccNotificationTemplateContent_InvalidData
=== PAUSE TestAccNotificationTemplateContent_InvalidData
=== RUN   TestAccNotificationTemplateContent_Email
=== PAUSE TestAccNotificationTemplateContent_Email
=== RUN   TestAccNotificationTemplateContent_Push
=== PAUSE TestAccNotificationTemplateContent_Push
=== RUN   TestAccNotificationTemplateContent_SMS
=== PAUSE TestAccNotificationTemplateContent_SMS
=== RUN   TestAccNotificationTemplateContent_Voice
=== PAUSE TestAccNotificationTemplateContent_Voice
=== RUN   TestAccNotificationTemplateContent_BadParameters
=== PAUSE TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_RemovalDrift
=== CONT  TestAccNotificationTemplateContent_Email
=== CONT  TestAccNotificationTemplateContent_Voice
=== CONT  TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_SMS
=== CONT  TestAccNotificationTemplateContent_NewVariant
=== CONT  TestAccNotificationTemplateContent_ChangeVariant
=== CONT  TestAccNotificationTemplateContent_Push
=== CONT  TestAccNotificationTemplateContent_NewLocale
=== CONT  TestAccNotificationTemplateContent_OverrideDefaultLocale
=== CONT  TestAccNotificationTemplateContent_InvalidData
--- PASS: TestAccNotificationTemplateContent_InvalidData (39.24s)
--- PASS: TestAccNotificationTemplateContent_BadParameters (45.07s)
--- PASS: TestAccNotificationTemplateContent_RemovalDrift (55.35s)
--- PASS: TestAccNotificationTemplateContent_OverrideDefaultLocale (87.60s)
--- PASS: TestAccNotificationTemplateContent_NewVariant (87.75s)
--- PASS: TestAccNotificationTemplateContent_ChangeVariant (100.94s)
--- PASS: TestAccNotificationTemplateContent_NewLocale (128.83s)
--- PASS: TestAccNotificationTemplateContent_Email (144.24s)
--- PASS: TestAccNotificationTemplateContent_SMS (182.47s)
--- PASS: TestAccNotificationTemplateContent_Voice (183.24s)
--- PASS: TestAccNotificationTemplateContent_Push (185.64s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        186.855s
```

</details>