### PR TITLE
Add `RequiresReplaceIfExistenceChanges` custom plan modifier

### DIFF
--- a/.changelog/838.txt
+++ b/.changelog/838.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_risk_predictor`: Fixed issue that forced replacement of a resource if a mutable field changed within a "resource type" object.
+```

--- a/internal/framework/objectplanmodifier/replace_if_existence_changes.go
+++ b/internal/framework/objectplanmodifier/replace_if_existence_changes.go
@@ -1,0 +1,51 @@
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func RequiresReplaceIfExistenceChanges() planmodifier.Object {
+	return requiresReplaceIfExistenceChangesModifier{}
+}
+
+type requiresReplaceIfExistenceChangesModifier struct {
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m requiresReplaceIfExistenceChangesModifier) Description(_ context.Context) string {
+	return "If the object is set and becomes unset, or is unset and becomes set, Terraform will destroy and recreate the resource."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m requiresReplaceIfExistenceChangesModifier) MarkdownDescription(_ context.Context) string {
+	return "If the object is set and becomes unset, or is unset and becomes set, Terraform will destroy and recreate the resource."
+}
+
+// PlanModifyString implements the plan modification logic.
+func (m requiresReplaceIfExistenceChangesModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Creation plan
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Destruction plan
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// If the state is not null and the plan value is null or unknown, replace the resource.
+	if !req.StateValue.IsNull() && (req.PlanValue.IsNull() || req.PlanValue.IsUnknown()) {
+		resp.RequiresReplace = true
+		return
+	}
+
+	// If the state is null and the plan value is not null, replace the resource.
+	if req.StateValue.IsNull() && !req.PlanValue.IsNull() {
+		resp.RequiresReplace = true
+		return
+	}
+
+	resp.RequiresReplace = false
+}

--- a/internal/service/risk/resource_risk_predictor.go
+++ b/internal/service/risk/resource_risk_predictor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	"github.com/patrickcping/pingone-go-sdk-v2/risk"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	objectplanmodifierinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/objectplanmodifier"
 	stringvalidatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/stringvalidator"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
 	riskservicehelpers "github.com/pingidentity/terraform-provider-pingone/internal/service/risk/helpers"
@@ -631,7 +632,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -645,7 +646,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -690,7 +691,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -783,7 +784,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -799,7 +800,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -815,7 +816,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -859,7 +860,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -907,7 +908,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -938,7 +939,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 
@@ -1152,7 +1153,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: predictorObjectValidators,
 
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
+					objectplanmodifierinternal.RequiresReplaceIfExistenceChanges(),
 				},
 			},
 		},


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

`resource/pingone_risk_predictor`: Fixed issue that forced replacement of a resource if a mutable field changed within a "resource type" object.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccRiskPredictor_ github.com/pingidentity/terraform-provider-pingone/internal/service/risk
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccRiskPredictor_RemovalDrift
=== PAUSE TestAccRiskPredictor_RemovalDrift
=== RUN   TestAccRiskPredictor_NewEnv
=== PAUSE TestAccRiskPredictor_NewEnv
=== RUN   TestAccRiskPredictor_Full
=== PAUSE TestAccRiskPredictor_Full
=== RUN   TestAccRiskPredictor_Composite
=== PAUSE TestAccRiskPredictor_Composite
=== RUN   TestAccRiskPredictor_Anonymous_Network
=== PAUSE TestAccRiskPredictor_Anonymous_Network
=== RUN   TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Bot_Detection
=== PAUSE TestAccRiskPredictor_Bot_Detection
=== RUN   TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Geovelocity
=== PAUSE TestAccRiskPredictor_Geovelocity
=== RUN   TestAccRiskPredictor_Geovelocity_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Geovelocity_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_IP_Reputation
=== PAUSE TestAccRiskPredictor_IP_Reputation
=== RUN   TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_CustomMap_BetweenRanges
=== PAUSE TestAccRiskPredictor_CustomMap_BetweenRanges
=== RUN   TestAccRiskPredictor_CustomMap_IPRanges
=== PAUSE TestAccRiskPredictor_CustomMap_IPRanges
=== RUN   TestAccRiskPredictor_CustomMap_StringList
=== PAUSE TestAccRiskPredictor_CustomMap_StringList
=== RUN   TestAccRiskPredictor_NewDevice
=== PAUSE TestAccRiskPredictor_NewDevice
=== RUN   TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_SuspiciousDevice
=== PAUSE TestAccRiskPredictor_SuspiciousDevice
=== RUN   TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_UserLocationAnomaly
=== PAUSE TestAccRiskPredictor_UserLocationAnomaly
=== RUN   TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Velocity
=== PAUSE TestAccRiskPredictor_Velocity
=== RUN   TestAccRiskPredictor_Velocity_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Velocity_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_UserRiskBehavior
=== PAUSE TestAccRiskPredictor_UserRiskBehavior
=== RUN   TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_BadParameters
=== PAUSE TestAccRiskPredictor_BadParameters
=== CONT  TestAccRiskPredictor_RemovalDrift
=== CONT  TestAccRiskPredictor_CustomMap_IPRanges
=== CONT  TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_UserRiskBehavior
=== CONT  TestAccRiskPredictor_SuspiciousDevice
=== CONT  TestAccRiskPredictor_Velocity_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_Velocity
=== CONT  TestAccRiskPredictor_Full
=== CONT  TestAccRiskPredictor_Composite
=== CONT  TestAccRiskPredictor_Bot_Detection
=== CONT  TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_IP_Reputation
=== CONT  TestAccRiskPredictor_NewDevice
=== CONT  TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_Anonymous_Network
=== NAME  TestAccRiskPredictor_Velocity_OverwriteUndeletable
    resource_risk_predictor_test.go:1727: STAGING-21856
--- SKIP: TestAccRiskPredictor_Velocity_OverwriteUndeletable (0.25s)
=== CONT  TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== NAME  TestAccRiskPredictor_Velocity
    resource_risk_predictor_test.go:1595: STAGING-21856
--- SKIP: TestAccRiskPredictor_Velocity (0.37s)
=== CONT  TestAccRiskPredictor_UserLocationAnomaly
=== CONT  TestAccRiskPredictor_NewEnv
--- PASS: TestAccRiskPredictor_NewDevice_OverwriteUndeletable (11.46s)
--- PASS: TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable (11.72s)
=== CONT  TestAccRiskPredictor_CustomMap_StringList
--- PASS: TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable (12.02s)
=== CONT  TestAccRiskPredictor_BadParameters
--- PASS: TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable (12.40s)
=== CONT  TestAccRiskPredictor_Geovelocity_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable (15.09s)
=== CONT  TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_Geovelocity_OverwriteUndeletable (11.72s)
=== CONT  TestAccRiskPredictor_Geovelocity
--- PASS: TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable (11.33s)
=== CONT  TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_RemovalDrift (28.70s)
=== CONT  TestAccRiskPredictor_CustomMap_BetweenRanges
--- PASS: TestAccRiskPredictor_BadParameters (16.68s)
--- PASS: TestAccRiskPredictor_NewEnv (18.28s)
--- PASS: TestAccRiskPredictor_Full (41.29s)
--- PASS: TestAccRiskPredictor_UserLocationAnomaly (45.25s)
--- PASS: TestAccRiskPredictor_Bot_Detection (45.63s)
--- PASS: TestAccRiskPredictor_SuspiciousDevice (46.37s)
--- PASS: TestAccRiskPredictor_NewDevice (46.52s)
--- PASS: TestAccRiskPredictor_IP_Reputation (46.91s)
--- PASS: TestAccRiskPredictor_CustomMap_IPRanges (46.92s)
--- PASS: TestAccRiskPredictor_UserRiskBehavior (47.19s)
--- PASS: TestAccRiskPredictor_Composite (47.24s)
--- PASS: TestAccRiskPredictor_Anonymous_Network (47.79s)
--- PASS: TestAccRiskPredictor_CustomMap_StringList (39.73s)
--- PASS: TestAccRiskPredictor_Geovelocity (34.12s)
--- PASS: TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable (34.24s)
--- PASS: TestAccRiskPredictor_CustomMap_BetweenRanges (33.47s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/risk        63.190s
```

</details>