### PR TITLE
Changes to support import the default MFA device policy and Verify policy into state

### DIFF
--- a/.changelog/844.txt
+++ b/.changelog/844.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+`resource/pingone_verify_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
+```
+
+```release-note:bug
+`resource/pingone_mfa_device_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
+```
+
+```release-note:enhancement
+`resource/pingone_mfa_device_policy`: Added the `default` field to track (in state) whether the policy is the default for the environment.
+```

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -198,6 +198,7 @@ resource "pingone_mfa_device_policy" "my_awesome_mfa_device_policy" {
 
 ### Read-Only
 
+- `default` (Boolean) A boolean that specifies whether this MFA device policy is enforced as the default within the environment. When set to `true`, all other MFA device policies are `false`.  Defaults to `false`.
 - `id` (String) The ID of this resource.
 
 <a id="nestedatt--email"></a>

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -1381,6 +1381,7 @@ func TestAccMFADevicePolicy_DataModel(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "new_device_notification", "NONE"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 			{
@@ -1396,6 +1397,7 @@ func TestAccMFADevicePolicy_DataModel(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "PROMPT_TO_SELECT"),
 					resource.TestCheckResourceAttr(resourceFullName, "new_device_notification", "SMS_THEN_EMAIL"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 			{
@@ -1411,6 +1413,7 @@ func TestAccMFADevicePolicy_DataModel(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "PROMPT_TO_SELECT"),
 					resource.TestCheckResourceAttr(resourceFullName, "new_device_notification", "SMS_THEN_EMAIL"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 			{
@@ -1421,6 +1424,7 @@ func TestAccMFADevicePolicy_DataModel(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "new_device_notification", "NONE"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 			{
@@ -1431,6 +1435,7 @@ func TestAccMFADevicePolicy_DataModel(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "PROMPT_TO_SELECT"),
 					resource.TestCheckResourceAttr(resourceFullName, "new_device_notification", "SMS_THEN_EMAIL"),
+					resource.TestCheckResourceAttr(resourceFullName, "default", "false"),
 				),
 			},
 		},

--- a/internal/service/verify/resource_verify_policy.go
+++ b/internal/service/verify/resource_verify_policy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -442,6 +443,10 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 				Description:         defaultDescription.Description,
 				MarkdownDescription: defaultDescription.MarkdownDescription,
 				Computed:            true,
+
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 
 			"description": schema.StringAttribute{


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- **Bug**: `resource/pingone_verify_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
- **Bug**: `resource/pingone_mfa_device_policy`: Resource can now be modified with Terraform if the `default` property is modified to `true` in the console or by API directly.
- **Enhancement**: `resource/pingone_mfa_device_policy`: Added the `default` field to track (in state) whether the policy is the default for the environment.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccMFADevicePolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa && \
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccVerifyPolicy_ github.com/pingidentity/terraform-provider-pingone/internal/service/verify
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccMFADevicePolicy_RemovalDrift
=== PAUSE TestAccMFADevicePolicy_RemovalDrift
=== RUN   TestAccMFADevicePolicy_NewEnv
=== PAUSE TestAccMFADevicePolicy_NewEnv
=== RUN   TestAccMFADevicePolicy_SMS_Full
=== PAUSE TestAccMFADevicePolicy_SMS_Full
=== RUN   TestAccMFADevicePolicy_SMS_Minimal
=== PAUSE TestAccMFADevicePolicy_SMS_Minimal
=== RUN   TestAccMFADevicePolicy_SMS_Change
=== PAUSE TestAccMFADevicePolicy_SMS_Change
=== RUN   TestAccMFADevicePolicy_Voice_Full
=== PAUSE TestAccMFADevicePolicy_Voice_Full
=== RUN   TestAccMFADevicePolicy_Voice_Minimal
=== PAUSE TestAccMFADevicePolicy_Voice_Minimal
=== RUN   TestAccMFADevicePolicy_Voice_Change
=== PAUSE TestAccMFADevicePolicy_Voice_Change
=== RUN   TestAccMFADevicePolicy_Email_Full
=== PAUSE TestAccMFADevicePolicy_Email_Full
=== RUN   TestAccMFADevicePolicy_Email_Minimal
=== PAUSE TestAccMFADevicePolicy_Email_Minimal
=== RUN   TestAccMFADevicePolicy_Email_Change
=== PAUSE TestAccMFADevicePolicy_Email_Change
=== RUN   TestAccMFADevicePolicy_Mobile_Full
=== PAUSE TestAccMFADevicePolicy_Mobile_Full
=== RUN   TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== RUN   TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== RUN   TestAccMFADevicePolicy_Mobile_Minimal
=== PAUSE TestAccMFADevicePolicy_Mobile_Minimal
=== RUN   TestAccMFADevicePolicy_Mobile_Change
=== PAUSE TestAccMFADevicePolicy_Mobile_Change
=== RUN   TestAccMFADevicePolicy_Totp_Full
=== PAUSE TestAccMFADevicePolicy_Totp_Full
=== RUN   TestAccMFADevicePolicy_Totp_Minimal
=== PAUSE TestAccMFADevicePolicy_Totp_Minimal
=== RUN   TestAccMFADevicePolicy_Totp_Change
=== PAUSE TestAccMFADevicePolicy_Totp_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Full
=== PAUSE TestAccMFADevicePolicy_FIDO2_Full
=== RUN   TestAccMFADevicePolicy_FIDO2_Minimal
=== PAUSE TestAccMFADevicePolicy_FIDO2_Minimal
=== RUN   TestAccMFADevicePolicy_FIDO2_Change
=== PAUSE TestAccMFADevicePolicy_FIDO2_Change
=== RUN   TestAccMFADevicePolicy_DataModel
=== PAUSE TestAccMFADevicePolicy_DataModel
=== RUN   TestAccMFADevicePolicy_BadParameters
=== PAUSE TestAccMFADevicePolicy_BadParameters
=== RUN   TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== PAUSE TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicy_RemovalDrift
=== CONT  TestAccMFADevicePolicy_FIDO2_Full
=== CONT  TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== CONT  TestAccMFADevicePolicy_DataModel
=== CONT  TestAccMFADevicePolicy_Totp_Full
=== CONT  TestAccMFADevicePolicy_FIDO2_Change
=== CONT  TestAccMFADevicePolicy_Mobile_Minimal
=== CONT  TestAccMFADevicePolicy_Totp_Change
=== CONT  TestAccMFADevicePolicy_Voice_Change
=== CONT  TestAccMFADevicePolicy_Totp_Minimal
=== CONT  TestAccMFADevicePolicy_Mobile_Change
=== CONT  TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicy_SMS_Change
=== CONT  TestAccMFADevicePolicy_Voice_Minimal
=== CONT  TestAccMFADevicePolicy_Voice_Full
=== CONT  TestAccMFADevicePolicy_SMS_Full
--- PASS: TestAccMFADevicePolicy_Totp_Minimal (9.15s)
=== CONT  TestAccMFADevicePolicy_SMS_Minimal
--- PASS: TestAccMFADevicePolicy_Mobile_Minimal (9.89s)
=== CONT  TestAccMFADevicePolicy_BadParameters
--- PASS: TestAccMFADevicePolicy_Voice_Minimal (10.67s)
=== CONT  TestAccMFADevicePolicy_Email_Minimal
--- PASS: TestAccMFADevicePolicy_Voice_Full (12.12s)
=== CONT  TestAccMFADevicePolicy_Email_Full
--- PASS: TestAccMFADevicePolicy_Totp_Full (12.37s)
=== CONT  TestAccMFADevicePolicy_FIDO2_Minimal
--- PASS: TestAccMFADevicePolicy_SMS_Full (12.52s)
=== CONT  TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
--- PASS: TestAccMFADevicePolicy_FIDO2_Full (13.22s)
=== CONT  TestAccMFADevicePolicy_NewEnv
--- PASS: TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors (14.33s)
=== CONT  TestAccMFADevicePolicy_Mobile_Full
--- PASS: TestAccMFADevicePolicy_DeleteDependentSOPFinalAction (15.30s)
=== CONT  TestAccMFADevicePolicy_Email_Change
--- PASS: TestAccMFADevicePolicy_SMS_Minimal (8.53s)
--- PASS: TestAccMFADevicePolicy_Email_Minimal (8.77s)
--- PASS: TestAccMFADevicePolicy_Totp_Change (19.64s)
--- PASS: TestAccMFADevicePolicy_Voice_Change (19.79s)
--- PASS: TestAccMFADevicePolicy_FIDO2_Change (20.78s)
--- PASS: TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors (8.32s)
--- PASS: TestAccMFADevicePolicy_FIDO2_Minimal (8.50s)
--- PASS: TestAccMFADevicePolicy_Email_Full (9.54s)
--- PASS: TestAccMFADevicePolicy_SMS_Change (22.26s)
--- PASS: TestAccMFADevicePolicy_BadParameters (12.61s)
--- PASS: TestAccMFADevicePolicy_Mobile_Change (22.68s)
--- PASS: TestAccMFADevicePolicy_Mobile_Full (10.60s)
--- PASS: TestAccMFADevicePolicy_Email_Change (13.50s)
--- PASS: TestAccMFADevicePolicy_DataModel (31.84s)
--- PASS: TestAccMFADevicePolicy_RemovalDrift (49.75s)
--- PASS: TestAccMFADevicePolicy_NewEnv (42.16s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 56.327s
=== RUN   TestAccVerifyPolicy_RemovalDrift
=== PAUSE TestAccVerifyPolicy_RemovalDrift
=== RUN   TestAccVerifyPolicy_NewEnv
=== PAUSE TestAccVerifyPolicy_NewEnv
=== RUN   TestAccVerifyPolicy_Full
=== PAUSE TestAccVerifyPolicy_Full
=== RUN   TestAccVerifyPolicy_ValidationChecks
=== PAUSE TestAccVerifyPolicy_ValidationChecks
=== RUN   TestAccVerifyPolicy_BadParameters
=== PAUSE TestAccVerifyPolicy_BadParameters
=== CONT  TestAccVerifyPolicy_RemovalDrift
=== CONT  TestAccVerifyPolicy_ValidationChecks
=== CONT  TestAccVerifyPolicy_BadParameters
=== CONT  TestAccVerifyPolicy_Full
=== CONT  TestAccVerifyPolicy_NewEnv
--- PASS: TestAccVerifyPolicy_ValidationChecks (1.83s)
--- PASS: TestAccVerifyPolicy_BadParameters (8.29s)
--- PASS: TestAccVerifyPolicy_Full (27.52s)
--- PASS: TestAccVerifyPolicy_NewEnv (40.71s)
--- PASS: TestAccVerifyPolicy_RemovalDrift (44.93s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/verify      46.036s
```

</details>