### PR TITLE
Add `custom_data` field to be able to append custom JSON data to a group

### DIFF
--- a/.changelog/850.txt
+++ b/.changelog/850.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+`resource/pingone_group`: Added `custom_data` field to be able to append custom JSON data to a group.
+```
+
+```release-note:enhancement
+`data-source/pingone_group`: Added `custom_data` field to be able to read custom JSON data attached to a group.
+```

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -39,6 +39,7 @@ data "pingone_group" "example_by_id" {
 
 ### Read-Only
 
+- `custom_data` (String) A JSON string that specifies user-defined custom data.
 - `description` (String) A string that specifies the description applied to the group.
 - `external_id` (String) A string that specifies a user defined ID that represents the counterpart group in an external system.
 - `id` (String) The ID of this resource.

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -24,6 +24,10 @@ resource "pingone_group" "my_awesome_group" {
   name        = "My awesome group"
   description = "My new awesome group for people who are awesome"
 
+  custom_data = jsonencode({
+    "hello" = "world"
+  })
+
   lifecycle {
     # change the `prevent_destroy` parameter value to `true` to prevent this data carrying resource from being destroyed
     prevent_destroy = false
@@ -41,6 +45,7 @@ resource "pingone_group" "my_awesome_group" {
 
 ### Optional
 
+- `custom_data` (String) A JSON string that specifies user-defined custom data.
 - `description` (String) A description to apply to the group.
 - `external_id` (String) A user defined ID that represents the counterpart group in an external system.
 - `population_id` (String) The ID of the population that the group should be assigned to.  This field is immutable and will trigger a replace plan if changed.

--- a/examples/resources/pingone_group/resource.tf
+++ b/examples/resources/pingone_group/resource.tf
@@ -8,6 +8,10 @@ resource "pingone_group" "my_awesome_group" {
   name        = "My awesome group"
   description = "My new awesome group for people who are awesome"
 
+  custom_data = jsonencode({
+    "hello" = "world"
+  })
+
   lifecycle {
     # change the `prevent_destroy` parameter value to `true` to prevent this data carrying resource from being destroyed
     prevent_destroy = false

--- a/internal/framework/resource.go
+++ b/internal/framework/resource.go
@@ -2,11 +2,13 @@ package framework
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -155,6 +157,29 @@ func DaVinciResourceIDListToTF(v []string) basetypes.ListValue {
 		}
 
 		return types.ListValueMust(pingonetypes.ResourceIDType{}, list)
+	}
+}
+
+func JSONNormalizedToTF(v map[string]interface{}) (jsontypes.Normalized, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if v == nil {
+		return jsontypes.NewNormalizedNull(), diags
+	} else {
+		jsonBytes, err := json.Marshal(v)
+		if err != nil {
+			diags.Append(diag.NewErrorDiagnostic("Normalized JSON Type Conversion Error", err.Error()))
+			return jsontypes.NewNormalizedNull(), diags
+		}
+		return jsontypes.NewNormalizedValue(string(jsonBytes[:])), diags
+	}
+}
+
+func JSONNormalizedOkToTF(v map[string]interface{}, ok bool) (jsontypes.Normalized, diag.Diagnostics) {
+	if !ok || v == nil {
+		return jsontypes.NewNormalizedNull(), nil
+	} else {
+		return JSONNormalizedToTF(v)
 	}
 }
 

--- a/internal/service/sso/data_source_group_test.go
+++ b/internal/service/sso/data_source_group_test.go
@@ -40,6 +40,7 @@ func TestAccGroupDataSource_ByNameFull(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceFullName, "population_id", resourceFullName, "population_id"),
 					resource.TestCheckResourceAttrPair(dataSourceFullName, "user_filter", resourceFullName, "user_filter"),
 					resource.TestCheckResourceAttrPair(dataSourceFullName, "external_id", resourceFullName, "external_id"),
+					resource.TestCheckResourceAttrPair(dataSourceFullName, "custom_data", resourceFullName, "custom_data"),
 				),
 			},
 		},
@@ -75,6 +76,7 @@ func TestAccGroupDataSource_ByIDFull(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceFullName, "population_id", resourceFullName, "population_id"),
 					resource.TestCheckResourceAttrPair(dataSourceFullName, "user_filter", resourceFullName, "user_filter"),
 					resource.TestCheckResourceAttrPair(dataSourceFullName, "external_id", resourceFullName, "external_id"),
+					resource.TestCheckResourceAttrPair(dataSourceFullName, "custom_data", resourceFullName, "custom_data"),
 				),
 			},
 		},
@@ -125,6 +127,8 @@ resource "pingone_group" "%[2]s" {
   population_id = pingone_population.%[2]s.id
   user_filter   = "email ew \"@test.com\""
   external_id   = "external_1234"
+
+  custom_data = jsonencode({ "hello" = "world" })
 }
 
 data "pingone_group" "%[2]s" {
@@ -153,6 +157,8 @@ resource "pingone_group" "%[2]s" {
   population_id = pingone_population.%[2]s.id
   user_filter   = "email ew \"@test.com\""
   external_id   = "external_1234"
+
+  custom_data = jsonencode({ "hello" = "world" })
 }
 
 data "pingone_group" "%[2]s" {

--- a/internal/service/sso/resource_group_test.go
+++ b/internal/service/sso/resource_group_test.go
@@ -121,6 +121,7 @@ func TestAccGroup_Full(t *testing.T) {
 		resource.TestMatchResourceAttr(resourceFullName, "population_id", verify.P1ResourceIDRegexpFullString),
 		resource.TestCheckResourceAttr(resourceFullName, "user_filter", `email ew "@test.com"`),
 		resource.TestCheckResourceAttr(resourceFullName, "external_id", "external_1234"),
+		resource.TestCheckResourceAttr(resourceFullName, "custom_data", "{\"hello\":\"world\"}"),
 	)
 
 	minimalCheck := resource.ComposeTestCheckFunc(
@@ -131,6 +132,7 @@ func TestAccGroup_Full(t *testing.T) {
 		resource.TestCheckNoResourceAttr(resourceFullName, "population_id"),
 		resource.TestCheckNoResourceAttr(resourceFullName, "user_filter"),
 		resource.TestCheckNoResourceAttr(resourceFullName, "external_id"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "custom_data"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -263,6 +265,8 @@ resource "pingone_group" "%[2]s" {
   population_id  = pingone_population.%[2]s.id
   user_filter    = "email ew \"@test.com\""
   external_id    = "external_1234"
+
+  custom_data = jsonencode({ "hello" = "world" })
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- **Enhancement**: `resource/pingone_group`: Added `custom_data` field to be able to append custom JSON data to a group.
- **Enhancement**: `data-source/pingone_group`: Added `custom_data` field to be able to read custom JSON data attached to a group.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccGroup_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso && \
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccGroupDataSource_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccGroup_RemovalDrift
=== PAUSE TestAccGroup_RemovalDrift
=== RUN   TestAccGroup_NewEnv
=== PAUSE TestAccGroup_NewEnv
=== RUN   TestAccGroup_Full
=== PAUSE TestAccGroup_Full
=== RUN   TestAccGroup_BadParameters
=== PAUSE TestAccGroup_BadParameters
=== CONT  TestAccGroup_RemovalDrift
=== CONT  TestAccGroup_Full
=== CONT  TestAccGroup_BadParameters
=== CONT  TestAccGroup_NewEnv
--- PASS: TestAccGroup_BadParameters (7.37s)
--- PASS: TestAccGroup_Full (27.71s)
--- PASS: TestAccGroup_NewEnv (40.39s)
--- PASS: TestAccGroup_RemovalDrift (44.98s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 46.097s
=== RUN   TestAccGroupDataSource_ByNameFull
=== PAUSE TestAccGroupDataSource_ByNameFull
=== RUN   TestAccGroupDataSource_ByIDFull
=== PAUSE TestAccGroupDataSource_ByIDFull
=== RUN   TestAccGroupDataSource_NotFound
=== PAUSE TestAccGroupDataSource_NotFound
=== CONT  TestAccGroupDataSource_ByNameFull
=== CONT  TestAccGroupDataSource_NotFound
=== CONT  TestAccGroupDataSource_ByIDFull
--- PASS: TestAccGroupDataSource_NotFound (1.98s)
--- PASS: TestAccGroupDataSource_ByIDFull (5.25s)
--- PASS: TestAccGroupDataSource_ByNameFull (7.27s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 8.467s
```

</details>