### PR TITLE
Add mutex to avoid parallel destroy of resource scopes

### DIFF
--- a/.changelog/852.txt
+++ b/.changelog/852.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_resource_scope`: Fixed blocking errors that result from removing multiple resource scopes that are already assigned to an application.
+```

--- a/internal/service/sso/resource_application_resource_grant_test.go
+++ b/internal/service/sso/resource_application_resource_grant_test.go
@@ -205,6 +205,47 @@ func TestAccApplicationResourceGrant_CustomResource(t *testing.T) {
 	})
 }
 
+func TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_application_resource_grant.%s", resourceName)
+
+	name := resourceName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoFeatureFlag(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             sso.ApplicationResourceGrant_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationResourceGrantConfig_CustomResource_SimultaneousGrantRemoval(resourceName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
+				),
+			},
+			{
+				Config: testAccApplicationResourceGrantConfig_CustomResource_SimultaneousGrantRemoval(resourceName, name),
+				Taint: []string{
+					fmt.Sprintf("pingone_resource_scope.%[1]s-1", name),
+					fmt.Sprintf("pingone_resource_scope.%[1]s-2", name),
+					fmt.Sprintf("pingone_resource_scope.%[1]s-3", name),
+					fmt.Sprintf("pingone_resource_scope.%[1]s-4", name),
+					fmt.Sprintf("pingone_resource_scope.%[1]s-5", name),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccApplicationResourceGrant_SystemApplication(t *testing.T) {
 	t.Parallel()
 
@@ -529,6 +570,81 @@ resource "pingone_application_resource_grant" "%[2]s" {
     pingone_resource_scope.%[2]s-1.name,
     pingone_resource_scope.%[2]s-2.name,
     pingone_resource_scope.%[2]s-3.name
+  ]
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccApplicationResourceGrantConfig_CustomResource_SimultaneousGrantRemoval(resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options = {
+    type                        = "SINGLE_PAGE_APP"
+    grant_types                 = ["AUTHORIZATION_CODE"]
+    response_types              = ["CODE"]
+    pkce_enforcement            = "S256_REQUIRED"
+    token_endpoint_authn_method = "NONE"
+    redirect_uris               = ["https://www.pingidentity.com"]
+  }
+}
+
+resource "pingone_resource" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+}
+
+resource "pingone_resource_scope" "%[2]s-1" {
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = pingone_resource.%[2]s.id
+
+  name = "%[3]s-1"
+}
+
+resource "pingone_resource_scope" "%[2]s-2" {
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = pingone_resource.%[2]s.id
+
+  name = "%[3]s-2"
+}
+
+resource "pingone_resource_scope" "%[2]s-3" {
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = pingone_resource.%[2]s.id
+
+  name = "%[3]s-3"
+}
+
+resource "pingone_resource_scope" "%[2]s-4" {
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = pingone_resource.%[2]s.id
+
+  name = "%[3]s-4"
+}
+
+resource "pingone_resource_scope" "%[2]s-5" {
+  environment_id = data.pingone_environment.general_test.id
+  resource_id    = pingone_resource.%[2]s.id
+
+  name = "%[3]s-5"
+}
+
+resource "pingone_application_resource_grant" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  application_id = pingone_application.%[2]s.id
+
+  resource_name = pingone_resource.%[2]s.name
+  scope_names = [
+    pingone_resource_scope.%[2]s-1.name,
+    pingone_resource_scope.%[2]s-2.name,
+    pingone_resource_scope.%[2]s-3.name,
+    pingone_resource_scope.%[2]s-4.name,
+    pingone_resource_scope.%[2]s-5.name,
   ]
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }

--- a/internal/service/sso/resource_resource_scope.go
+++ b/internal/service/sso/resource_resource_scope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -21,6 +22,8 @@ import (
 
 // Types
 type ResourceScopeResource serviceClientType
+
+var requestMutex sync.Mutex
 
 type ResourceScopeResourceModel struct {
 	Id            pingonetypes.ResourceIDValue `tfsdk:"id"`
@@ -296,6 +299,9 @@ func (r *ResourceScopeResource) Delete(ctx context.Context, req resource.DeleteR
 			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
 		return
 	}
+
+	requestMutex.Lock()
+	defer requestMutex.Unlock()
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_resource_scope`: Fixed blocking errors that result from removing multiple resource scopes that are already assigned to an application.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccApplicationResourceGrant_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccApplicationResourceGrant_RemovalDrift
=== PAUSE TestAccApplicationResourceGrant_RemovalDrift
=== RUN   TestAccApplicationResourceGrant_OpenIDResource
=== PAUSE TestAccApplicationResourceGrant_OpenIDResource
=== RUN   TestAccApplicationResourceGrant_CustomResource
=== PAUSE TestAccApplicationResourceGrant_CustomResource
=== RUN   TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval
=== PAUSE TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval
=== RUN   TestAccApplicationResourceGrant_SystemApplication
=== PAUSE TestAccApplicationResourceGrant_SystemApplication
=== RUN   TestAccApplicationResourceGrant_Change
=== PAUSE TestAccApplicationResourceGrant_Change
=== RUN   TestAccApplicationResourceGrant_BadParameters
=== PAUSE TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_RemovalDrift
=== CONT  TestAccApplicationResourceGrant_SystemApplication
=== CONT  TestAccApplicationResourceGrant_CustomResource
=== CONT  TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval
=== CONT  TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_OpenIDResource
=== CONT  TestAccApplicationResourceGrant_Change
--- PASS: TestAccApplicationResourceGrant_CustomResource (9.85s)
--- PASS: TestAccApplicationResourceGrant_BadParameters (11.79s)
--- PASS: TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval (14.53s)
--- PASS: TestAccApplicationResourceGrant_OpenIDResource (15.46s)
--- PASS: TestAccApplicationResourceGrant_Change (17.11s)
--- PASS: TestAccApplicationResourceGrant_RemovalDrift (54.93s)
--- PASS: TestAccApplicationResourceGrant_SystemApplication (59.42s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 60.678s
```

</details>