### PR TITLE
Add mutex to avoid parallel destroy of resource scopes (0.29.1)

### DIFF
--- a/.changelog/854.txt
+++ b/.changelog/854.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_resource_scope`: Fixed blocking errors that result from removing multiple resource scopes that are already assigned to an application.
+```

--- a/internal/service/sso/resource_application_resource_grant_test.go
+++ b/internal/service/sso/resource_application_resource_grant_test.go
@@ -582,7 +582,7 @@ resource "pingone_application" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
   enabled        = true
-  
+
   oidc_options {
     type                        = "SINGLE_PAGE_APP"
     grant_types                 = ["AUTHORIZATION_CODE"]
@@ -637,7 +637,7 @@ resource "pingone_resource_scope" "%[2]s-5" {
 resource "pingone_application_resource_grant" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   application_id = pingone_application.%[2]s.id
-  resource_name = pingone_resource.%[2]s.name
+  resource_name  = pingone_resource.%[2]s.name
 
   scope_names = [
     pingone_resource_scope.%[2]s-1.name,

--- a/internal/service/sso/resource_resource_scope.go
+++ b/internal/service/sso/resource_resource_scope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -20,6 +21,8 @@ import (
 
 // Types
 type ResourceScopeResource serviceClientType
+
+var requestMutex sync.Mutex
 
 type ResourceScopeResourceModel struct {
 	Id            types.String `tfsdk:"id"`
@@ -295,6 +298,9 @@ func (r *ResourceScopeResource) Delete(ctx context.Context, req resource.DeleteR
 			"Expected the PingOne client, got nil.  Please report this issue to the provider maintainers.")
 		return
 	}
+
+	requestMutex.Lock()
+	defer requestMutex.Unlock()
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_resource_scope`: Fixed blocking errors that result from removing multiple resource scopes that are already assigned to an application.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccApplicationResourceGrant_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso && \
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccResourceScope_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccApplicationResourceGrant_RemovalDrift
=== PAUSE TestAccApplicationResourceGrant_RemovalDrift
=== RUN   TestAccApplicationResourceGrant_OpenIDResource
=== PAUSE TestAccApplicationResourceGrant_OpenIDResource
=== RUN   TestAccApplicationResourceGrant_CustomResource
=== PAUSE TestAccApplicationResourceGrant_CustomResource
=== RUN   TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval
=== PAUSE TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval
=== RUN   TestAccApplicationResourceGrant_SystemApplication
=== PAUSE TestAccApplicationResourceGrant_SystemApplication
=== RUN   TestAccApplicationResourceGrant_Change
=== PAUSE TestAccApplicationResourceGrant_Change
=== RUN   TestAccApplicationResourceGrant_BadParameters
=== PAUSE TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_RemovalDrift
=== CONT  TestAccApplicationResourceGrant_SystemApplication
=== CONT  TestAccApplicationResourceGrant_BadParameters
=== CONT  TestAccApplicationResourceGrant_Change
=== CONT  TestAccApplicationResourceGrant_CustomResource
=== CONT  TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval
=== CONT  TestAccApplicationResourceGrant_OpenIDResource
--- PASS: TestAccApplicationResourceGrant_CustomResource (8.72s)
--- PASS: TestAccApplicationResourceGrant_BadParameters (10.70s)
--- PASS: TestAccApplicationResourceGrant_CustomResource_SimultaneousGrantRemoval (13.19s)
--- PASS: TestAccApplicationResourceGrant_OpenIDResource (13.58s)
--- PASS: TestAccApplicationResourceGrant_Change (15.01s)
--- PASS: TestAccApplicationResourceGrant_RemovalDrift (28.63s)
--- PASS: TestAccApplicationResourceGrant_SystemApplication (31.67s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 34.584s
=== RUN   TestAccResourceScope_RemovalDrift
=== PAUSE TestAccResourceScope_RemovalDrift
=== RUN   TestAccResourceScope_NewEnv
=== PAUSE TestAccResourceScope_NewEnv
=== RUN   TestAccResourceScope_Full
=== PAUSE TestAccResourceScope_Full
=== RUN   TestAccResourceScope_Minimal
=== PAUSE TestAccResourceScope_Minimal
=== RUN   TestAccResourceScope_Change
=== PAUSE TestAccResourceScope_Change
=== RUN   TestAccResourceScope_InvalidParameters
=== PAUSE TestAccResourceScope_InvalidParameters
=== RUN   TestAccResourceScope_BadParameters
=== PAUSE TestAccResourceScope_BadParameters
=== CONT  TestAccResourceScope_RemovalDrift
=== CONT  TestAccResourceScope_Change
=== CONT  TestAccResourceScope_BadParameters
=== CONT  TestAccResourceScope_InvalidParameters
=== CONT  TestAccResourceScope_Full
=== CONT  TestAccResourceScope_NewEnv
=== CONT  TestAccResourceScope_Minimal
--- PASS: TestAccResourceScope_InvalidParameters (5.97s)
--- PASS: TestAccResourceScope_Minimal (6.08s)
--- PASS: TestAccResourceScope_Full (8.19s)
--- PASS: TestAccResourceScope_BadParameters (8.97s)
--- PASS: TestAccResourceScope_Change (12.66s)
--- PASS: TestAccResourceScope_NewEnv (13.51s)
--- PASS: TestAccResourceScope_RemovalDrift (21.98s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 22.928s
```

</details>