### PR TITLE
`resource/pingone_application` v0 to v1 state upgrader

### DIFF
--- a/internal/service/sso/data_source_application.go
+++ b/internal/service/sso/data_source_application.go
@@ -841,7 +841,7 @@ func (p *applicationDataSourceModel) toState(ctx context.Context, apiObject *man
 		// Service specific attributes
 		p.Tags = framework.EnumSetOkToTF(v.GetTagsOk())
 
-		var oidcOptionsState ApplicationOIDCOptionsResourceModel
+		var oidcOptionsState applicationOIDCOptionsResourceModelV1
 		if !p.OIDCOptions.IsNull() && !p.OIDCOptions.IsUnknown() {
 			d := p.OIDCOptions.As(ctx, &oidcOptionsState, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -39,7 +39,7 @@ import (
 // Types
 type ApplicationResource serviceClientType
 
-type ApplicationResourceModel struct {
+type applicationResourceModelV1 struct {
 	Id                        pingonetypes.ResourceIDValue `tfsdk:"id"`
 	EnvironmentId             pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
 	Name                      types.String                 `tfsdk:"name"`
@@ -56,16 +56,16 @@ type ApplicationResourceModel struct {
 	SAMLOptions               types.Object                 `tfsdk:"saml_options"`
 }
 
-type ApplicationAccessControlGroupOptionsResourceModel struct {
+type applicationAccessControlGroupOptionsResourceModelV1 struct {
 	Type   types.String `tfsdk:"type"`
 	Groups types.Set    `tfsdk:"groups"`
 }
 
-type ApplicationExternalLinkOptionsResourceModel struct {
+type applicationExternalLinkOptionsResourceModelV1 struct {
 	HomePageUrl types.String `tfsdk:"home_page_url"`
 }
 
-type ApplicationOIDCOptionsResourceModel struct {
+type applicationOIDCOptionsResourceModelV1 struct {
 	AdditionalRefreshTokenReplayProtectionEnabled types.Bool   `tfsdk:"additional_refresh_token_replay_protection_enabled"`
 	AllowWildcardsInRedirectUris                  types.Bool   `tfsdk:"allow_wildcards_in_redirect_uris"`
 	CertificateBasedAuthentication                types.Object `tfsdk:"certificate_based_authentication"`
@@ -96,16 +96,16 @@ type ApplicationOIDCOptionsResourceModel struct {
 	Type                                          types.String `tfsdk:"type"`
 }
 
-type ApplicationCorsSettingsResourceModel struct {
+type applicationCorsSettingsResourceModelV1 struct {
 	Behavior types.String `tfsdk:"behavior"`
 	Origins  types.Set    `tfsdk:"origins"`
 }
 
-type ApplicationOIDCCertificateBasedAuthenticationResourceModel struct {
+type applicationOIDCCertificateBasedAuthenticationResourceModelV1 struct {
 	KeyId pingonetypes.ResourceIDValue `tfsdk:"key_id"`
 }
 
-type ApplicationOIDCMobileAppResourceModel struct {
+type applicationOIDCMobileAppResourceModelV1 struct {
 	BundleId               types.String `tfsdk:"bundle_id"`
 	HuaweiAppId            types.String `tfsdk:"huawei_app_id"`
 	HuaweiPackageName      types.String `tfsdk:"huawei_package_name"`
@@ -115,26 +115,26 @@ type ApplicationOIDCMobileAppResourceModel struct {
 	UniversalAppLink       types.String `tfsdk:"universal_app_link"`
 }
 
-type ApplicationOIDCMobileAppIntegrityDetectionResourceModel struct {
+type applicationOIDCMobileAppIntegrityDetectionResourceModelV1 struct {
 	CacheDuration     types.Object `tfsdk:"cache_duration"`
 	Enabled           types.Bool   `tfsdk:"enabled"`
 	ExcludedPlatforms types.Set    `tfsdk:"excluded_platforms"`
 	GooglePlay        types.Object `tfsdk:"google_play"`
 }
 
-type ApplicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModel struct {
+type applicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModelV1 struct {
 	Amount types.Int64  `tfsdk:"amount"`
 	Units  types.String `tfsdk:"units"`
 }
 
-type ApplicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModel struct {
+type applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV1 struct {
 	DecryptionKey                 types.String         `tfsdk:"decryption_key"`
 	ServiceAccountCredentialsJson jsontypes.Normalized `tfsdk:"service_account_credentials_json"`
 	VerificationKey               types.String         `tfsdk:"verification_key"`
 	VerificationType              types.String         `tfsdk:"verification_type"`
 }
 
-type ApplicationSAMLOptionsResourceModel struct {
+type applicationSAMLOptionsResourceModelV1 struct {
 	AcsUrls                     types.Set    `tfsdk:"acs_urls"`
 	AssertionDuration           types.Int64  `tfsdk:"assertion_duration"`
 	AssertionSignedEnabled      types.Bool   `tfsdk:"assertion_signed_enabled"`
@@ -155,21 +155,21 @@ type ApplicationSAMLOptionsResourceModel struct {
 	Type                        types.String `tfsdk:"type"`
 }
 
-type ApplicationSAMLOptionsIdpSigningKeyResourceModel struct {
+type applicationSAMLOptionsIdpSigningKeyResourceModelV1 struct {
 	Algorithm types.String                 `tfsdk:"algorithm"`
 	KeyId     pingonetypes.ResourceIDValue `tfsdk:"key_id"`
 }
 
-type ApplicationSAMLOptionsSpEncryptionResourceModel struct {
+type applicationSAMLOptionsSpEncryptionResourceModelV1 struct {
 	Algorithm   types.String `tfsdk:"algorithm"`
 	Certificate types.Object `tfsdk:"certificate"`
 }
 
-type ApplicationSAMLOptionsSpEncryptionCertificateResourceModel struct {
+type applicationSAMLOptionsSpEncryptionCertificateResourceModelV1 struct {
 	Id pingonetypes.ResourceIDValue `tfsdk:"id"`
 }
 
-type ApplicationSAMLOptionsSpVerificationResourceModel struct {
+type applicationSAMLOptionsSpVerificationResourceModelV1 struct {
 	CertificateIds     types.Set  `tfsdk:"certificate_ids"`
 	AuthnRequestSigned types.Bool `tfsdk:"authn_request_signed"`
 }
@@ -300,6 +300,7 @@ var (
 	_ resource.ResourceWithConfigure      = &ApplicationResource{}
 	_ resource.ResourceWithImportState    = &ApplicationResource{}
 	_ resource.ResourceWithValidateConfig = &ApplicationResource{}
+	_ resource.ResourceWithUpgradeState   = &ApplicationResource{}
 )
 
 // New Object
@@ -630,6 +631,9 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 	).DefaultValue(false)
 
 	resp.Schema = schema.Schema{
+
+		Version: 1,
+
 		// This description is used by the documentation generator and the language server.
 		Description: "Resource to create and manage a PingOne application (SAML, OpenID Connect, External Link) in an environment.",
 
@@ -1657,12 +1661,12 @@ func (r *ApplicationResource) Configure(ctx context.Context, req resource.Config
 }
 
 func (r *ApplicationResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var data ApplicationResourceModel
+	var data applicationResourceModelV1
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	if !data.OIDCOptions.IsNull() && !data.OIDCOptions.IsUnknown() {
-		var plan ApplicationOIDCOptionsResourceModel
+		var plan applicationOIDCOptionsResourceModelV1
 		resp.Diagnostics.Append(data.OIDCOptions.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -1709,7 +1713,7 @@ func (r *ApplicationResource) ValidateConfig(ctx context.Context, req resource.V
 }
 
 func (r *ApplicationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan, state ApplicationResourceModel
+	var plan, state applicationResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -1789,7 +1793,7 @@ func (r *ApplicationResource) Create(ctx context.Context, req resource.CreateReq
 }
 
 func (r *ApplicationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *ApplicationResourceModel
+	var data *applicationResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -1834,7 +1838,7 @@ func (r *ApplicationResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *ApplicationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state ApplicationResourceModel
+	var plan, state applicationResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -1883,7 +1887,7 @@ func (r *ApplicationResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 func (r *ApplicationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data *ApplicationResourceModel
+	var data *applicationResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -1969,7 +1973,7 @@ func applicationWriteCustomError(error model.P1Error) diag.Diagnostics {
 	return framework.DefaultCustomError(error)
 }
 
-func (p *ApplicationResourceModel) expandCreate(ctx context.Context) (*management.CreateApplicationRequest, diag.Diagnostics) {
+func (p *applicationResourceModelV1) expandCreate(ctx context.Context) (*management.CreateApplicationRequest, diag.Diagnostics) {
 	var d, diags diag.Diagnostics
 
 	data := &management.CreateApplicationRequest{}
@@ -1992,7 +1996,7 @@ func (p *ApplicationResourceModel) expandCreate(ctx context.Context) (*managemen
 	return data, diags
 }
 
-func (p *ApplicationResourceModel) expandUpdate(ctx context.Context) (*management.UpdateApplicationRequest, diag.Diagnostics) {
+func (p *applicationResourceModelV1) expandUpdate(ctx context.Context) (*management.UpdateApplicationRequest, diag.Diagnostics) {
 	var d, diags diag.Diagnostics
 
 	data := &management.UpdateApplicationRequest{}
@@ -2015,7 +2019,7 @@ func (p *ApplicationResourceModel) expandUpdate(ctx context.Context) (*managemen
 	return data, diags
 }
 
-func (p *ApplicationCorsSettingsResourceModel) expand() (*management.ApplicationCorsSettings, diag.Diagnostics) {
+func (p *applicationCorsSettingsResourceModelV1) expand() (*management.ApplicationCorsSettings, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	data := management.NewApplicationCorsSettings(management.EnumApplicationCorsSettingsBehavior(p.Behavior.ValueString()))
@@ -2033,13 +2037,13 @@ func (p *ApplicationCorsSettingsResourceModel) expand() (*management.Application
 	return data, diags
 }
 
-func (p *ApplicationResourceModel) expandApplicationOIDC(ctx context.Context) (*management.ApplicationOIDC, diag.Diagnostics) {
+func (p *applicationResourceModelV1) expandApplicationOIDC(ctx context.Context) (*management.ApplicationOIDC, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var data *management.ApplicationOIDC
 
 	if !p.OIDCOptions.IsNull() && !p.OIDCOptions.IsUnknown() {
-		var plan ApplicationOIDCOptionsResourceModel
+		var plan applicationOIDCOptionsResourceModelV1
 		d := p.OIDCOptions.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -2084,7 +2088,7 @@ func (p *ApplicationResourceModel) expandApplicationOIDC(ctx context.Context) (*
 		data.HiddenFromAppPortal = applicationCommon.HiddenFromAppPortal
 
 		if !plan.CorsSettings.IsNull() && !plan.CorsSettings.IsUnknown() {
-			var corsPlan ApplicationCorsSettingsResourceModel
+			var corsPlan applicationCorsSettingsResourceModelV1
 
 			diags.Append(plan.CorsSettings.As(ctx, &corsPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2238,7 +2242,7 @@ func (p *ApplicationResourceModel) expandApplicationOIDC(ctx context.Context) (*
 				return nil, diags
 			}
 
-			var kerberosPlan ApplicationOIDCCertificateBasedAuthenticationResourceModel
+			var kerberosPlan applicationOIDCCertificateBasedAuthenticationResourceModelV1
 
 			diags.Append(plan.CertificateBasedAuthentication.As(ctx, &kerberosPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2260,7 +2264,7 @@ func (p *ApplicationResourceModel) expandApplicationOIDC(ctx context.Context) (*
 		}
 
 		if !plan.MobileApp.IsNull() && !plan.MobileApp.IsUnknown() {
-			var mobileAppPlan ApplicationOIDCMobileAppResourceModel
+			var mobileAppPlan applicationOIDCMobileAppResourceModelV1
 
 			diags.Append(plan.MobileApp.As(ctx, &mobileAppPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2283,7 +2287,7 @@ func (p *ApplicationResourceModel) expandApplicationOIDC(ctx context.Context) (*
 	return data, diags
 }
 
-func (p *ApplicationOIDCMobileAppResourceModel) expand(ctx context.Context) (*management.ApplicationOIDCAllOfMobile, diag.Diagnostics) {
+func (p *applicationOIDCMobileAppResourceModelV1) expand(ctx context.Context) (*management.ApplicationOIDCAllOfMobile, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	data := management.NewApplicationOIDCAllOfMobile()
@@ -2302,7 +2306,7 @@ func (p *ApplicationOIDCMobileAppResourceModel) expand(ctx context.Context) (*ma
 
 	if !p.IntegrityDetection.IsNull() && !p.IntegrityDetection.IsUnknown() {
 
-		var integrityDetectionPlan ApplicationOIDCMobileAppIntegrityDetectionResourceModel
+		var integrityDetectionPlan applicationOIDCMobileAppIntegrityDetectionResourceModelV1
 		diags.Append(p.IntegrityDetection.As(ctx, &integrityDetectionPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -2338,7 +2342,7 @@ func (p *ApplicationOIDCMobileAppResourceModel) expand(ctx context.Context) (*ma
 	return data, diags
 }
 
-func (p *ApplicationOIDCMobileAppIntegrityDetectionResourceModel) expand(ctx context.Context) (*management.ApplicationOIDCAllOfMobileIntegrityDetection, diag.Diagnostics) {
+func (p *applicationOIDCMobileAppIntegrityDetectionResourceModelV1) expand(ctx context.Context) (*management.ApplicationOIDCAllOfMobileIntegrityDetection, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	data := management.NewApplicationOIDCAllOfMobileIntegrityDetection()
@@ -2377,7 +2381,7 @@ func (p *ApplicationOIDCMobileAppIntegrityDetectionResourceModel) expand(ctx con
 
 	if !p.GooglePlay.IsNull() && !p.GooglePlay.IsUnknown() {
 
-		var googlePlayPlan ApplicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModel
+		var googlePlayPlan applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV1
 		diags.Append(p.GooglePlay.As(ctx, &googlePlayPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -2417,7 +2421,7 @@ func (p *ApplicationOIDCMobileAppIntegrityDetectionResourceModel) expand(ctx con
 
 	if !p.CacheDuration.IsNull() && !p.CacheDuration.IsUnknown() {
 
-		var cacheDurationPlan ApplicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModel
+		var cacheDurationPlan applicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModelV1
 		diags.Append(p.CacheDuration.As(ctx, &cacheDurationPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -2442,13 +2446,13 @@ func (p *ApplicationOIDCMobileAppIntegrityDetectionResourceModel) expand(ctx con
 	return data, diags
 }
 
-func (p *ApplicationResourceModel) expandApplicationSAML(ctx context.Context) (*management.ApplicationSAML, diag.Diagnostics) {
+func (p *applicationResourceModelV1) expandApplicationSAML(ctx context.Context) (*management.ApplicationSAML, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var data *management.ApplicationSAML
 
 	if !p.SAMLOptions.IsNull() && !p.SAMLOptions.IsUnknown() {
-		var plan ApplicationSAMLOptionsResourceModel
+		var plan applicationSAMLOptionsResourceModelV1
 		d := p.SAMLOptions.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -2489,7 +2493,7 @@ func (p *ApplicationResourceModel) expandApplicationSAML(ctx context.Context) (*
 
 		// SAML specific options
 		if !plan.CorsSettings.IsNull() && !plan.CorsSettings.IsUnknown() {
-			var corsPlan ApplicationCorsSettingsResourceModel
+			var corsPlan applicationCorsSettingsResourceModelV1
 
 			diags.Append(plan.CorsSettings.As(ctx, &corsPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2517,7 +2521,7 @@ func (p *ApplicationResourceModel) expandApplicationSAML(ctx context.Context) (*
 
 		if !plan.IdpSigningKey.IsNull() && !plan.IdpSigningKey.IsUnknown() {
 
-			var idpSigningOptionsPlan ApplicationSAMLOptionsIdpSigningKeyResourceModel
+			var idpSigningOptionsPlan applicationSAMLOptionsIdpSigningKeyResourceModelV1
 
 			diags.Append(plan.IdpSigningKey.As(ctx, &idpSigningOptionsPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2566,7 +2570,7 @@ func (p *ApplicationResourceModel) expandApplicationSAML(ctx context.Context) (*
 		}
 
 		if !plan.SpEncryption.IsNull() && !plan.SpEncryption.IsUnknown() {
-			var spEncryptionPlan ApplicationSAMLOptionsSpEncryptionResourceModel
+			var spEncryptionPlan applicationSAMLOptionsSpEncryptionResourceModelV1
 
 			diags.Append(plan.SpEncryption.As(ctx, &spEncryptionPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2576,7 +2580,7 @@ func (p *ApplicationResourceModel) expandApplicationSAML(ctx context.Context) (*
 				return nil, diags
 			}
 
-			var spEncryptionCertificatePlan ApplicationSAMLOptionsSpEncryptionCertificateResourceModel
+			var spEncryptionCertificatePlan applicationSAMLOptionsSpEncryptionCertificateResourceModelV1
 
 			diags.Append(spEncryptionPlan.Certificate.As(ctx, &spEncryptionCertificatePlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2595,7 +2599,7 @@ func (p *ApplicationResourceModel) expandApplicationSAML(ctx context.Context) (*
 		}
 
 		if !plan.SpVerification.IsNull() && !plan.SpVerification.IsUnknown() {
-			var spVerificationPlan ApplicationSAMLOptionsSpVerificationResourceModel
+			var spVerificationPlan applicationSAMLOptionsSpVerificationResourceModelV1
 
 			diags.Append(plan.SpVerification.As(ctx, &spVerificationPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
@@ -2632,13 +2636,13 @@ func (p *ApplicationResourceModel) expandApplicationSAML(ctx context.Context) (*
 	return data, diags
 }
 
-func (p *ApplicationResourceModel) expandApplicationExternalLink(ctx context.Context) (*management.ApplicationExternalLink, diag.Diagnostics) {
+func (p *applicationResourceModelV1) expandApplicationExternalLink(ctx context.Context) (*management.ApplicationExternalLink, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var data *management.ApplicationExternalLink
 
 	if !p.ExternalLinkOptions.IsNull() && !p.ExternalLinkOptions.IsUnknown() {
-		var plan ApplicationExternalLinkOptionsResourceModel
+		var plan applicationExternalLinkOptionsResourceModelV1
 		d := p.ExternalLinkOptions.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -2673,7 +2677,7 @@ func (p *ApplicationResourceModel) expandApplicationExternalLink(ctx context.Con
 	return data, diags
 }
 
-func (p *ApplicationResourceModel) expandApplicationCommon(ctx context.Context) (*management.Application, diag.Diagnostics) {
+func (p *applicationResourceModelV1) expandApplicationCommon(ctx context.Context) (*management.Application, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	data := management.Application{}
@@ -2714,7 +2718,7 @@ func (p *ApplicationResourceModel) expandApplicationCommon(ctx context.Context) 
 	}
 
 	if !p.AccessControlGroupOptions.IsNull() && !p.AccessControlGroupOptions.IsUnknown() {
-		var plan ApplicationAccessControlGroupOptionsResourceModel
+		var plan applicationAccessControlGroupOptionsResourceModelV1
 		d := p.AccessControlGroupOptions.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -2756,7 +2760,7 @@ func (p *ApplicationResourceModel) expandApplicationCommon(ctx context.Context) 
 	return &data, diags
 }
 
-func (p *ApplicationResourceModel) toState(ctx context.Context, apiObject *management.ReadOneApplication200Response) diag.Diagnostics {
+func (p *applicationResourceModelV1) toState(ctx context.Context, apiObject *management.ReadOneApplication200Response) diag.Diagnostics {
 	var diags, d diag.Diagnostics
 
 	if apiObject == nil {
@@ -2833,7 +2837,7 @@ func (p *ApplicationResourceModel) toState(ctx context.Context, apiObject *manag
 		// Service specific attributes
 		p.Tags = framework.EnumSetOkToTF(v.GetTagsOk())
 
-		var oidcOptionsState ApplicationOIDCOptionsResourceModel
+		var oidcOptionsState applicationOIDCOptionsResourceModelV1
 		if !p.OIDCOptions.IsNull() && !p.OIDCOptions.IsUnknown() {
 			d := p.OIDCOptions.As(ctx, &oidcOptionsState, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,

--- a/internal/service/sso/resource_application_schema_upgrade_0_to_1.go
+++ b/internal/service/sso/resource_application_schema_upgrade_0_to_1.go
@@ -1,0 +1,1331 @@
+package sso
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/patrickcping/pingone-go-sdk-v2/management"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
+	"github.com/pingidentity/terraform-provider-pingone/internal/service"
+)
+
+type applicationResourceModelV0 struct {
+	Id                        pingonetypes.ResourceIDValue `tfsdk:"id"`
+	EnvironmentId             pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
+	Name                      types.String                 `tfsdk:"name"`
+	Description               types.String                 `tfsdk:"description"`
+	Enabled                   types.Bool                   `tfsdk:"enabled"`
+	Tags                      types.Set                    `tfsdk:"tags"`
+	LoginPageUrl              types.String                 `tfsdk:"login_page_url"`
+	Icon                      types.List                   `tfsdk:"icon"`
+	AccessControlRoleType     types.String                 `tfsdk:"access_control_role_type"`
+	AccessControlGroupOptions types.List                   `tfsdk:"access_control_group_options"`
+	HiddenFromAppPortal       types.Bool                   `tfsdk:"hidden_from_app_portal"`
+	ExternalLinkOptions       types.List                   `tfsdk:"external_link_options"`
+	OIDCOptions               types.List                   `tfsdk:"oidc_options"`
+	SAMLOptions               types.List                   `tfsdk:"saml_options"`
+}
+
+type applicationAccessControlGroupOptionsResourceModelV0 struct {
+	Type   types.String `tfsdk:"type"`
+	Groups types.Set    `tfsdk:"groups"`
+}
+
+type applicationExternalLinkOptionsResourceModelV0 struct {
+	HomePageUrl types.String `tfsdk:"home_page_url"`
+}
+
+type applicationOIDCOptionsResourceModelV0 struct {
+	AdditionalRefreshTokenReplayProtectionEnabled types.Bool                   `tfsdk:"additional_refresh_token_replay_protection_enabled"`
+	AllowWildcardsInRedirectUris                  types.Bool                   `tfsdk:"allow_wildcards_in_redirect_uris"`
+	CertificateBasedAuthentication                types.List                   `tfsdk:"certificate_based_authentication"`
+	CorsSettings                                  types.List                   `tfsdk:"cors_settings"`
+	GrantTypes                                    types.Set                    `tfsdk:"grant_types"`
+	HomePageUrl                                   types.String                 `tfsdk:"home_page_url"`
+	InitiateLoginUri                              types.String                 `tfsdk:"initiate_login_uri"`
+	Jwks                                          types.String                 `tfsdk:"jwks"`
+	JwksUrl                                       types.String                 `tfsdk:"jwks_url"`
+	MobileApp                                     types.List                   `tfsdk:"mobile_app"`
+	ParRequirement                                types.String                 `tfsdk:"par_requirement"`
+	ParTimeout                                    types.Int64                  `tfsdk:"par_timeout"`
+	PKCEEnforcement                               types.String                 `tfsdk:"pkce_enforcement"`
+	PostLogoutRedirectUris                        types.Set                    `tfsdk:"post_logout_redirect_uris"`
+	RedirectUris                                  types.Set                    `tfsdk:"redirect_uris"`
+	RefreshTokenDuration                          types.Int64                  `tfsdk:"refresh_token_duration"`
+	RefreshTokenRollingDuration                   types.Int64                  `tfsdk:"refresh_token_rolling_duration"`
+	RefreshTokenRollingGracePeriodDuration        types.Int64                  `tfsdk:"refresh_token_rolling_grace_period_duration"`
+	RequireSignedRequestObject                    types.Bool                   `tfsdk:"require_signed_request_object"`
+	ResponseTypes                                 types.Set                    `tfsdk:"response_types"`
+	SupportUnsignedRequestObject                  types.Bool                   `tfsdk:"support_unsigned_request_object"`
+	TargetLinkUri                                 types.String                 `tfsdk:"target_link_uri"`
+	TokenEndpointAuthnMethod                      types.String                 `tfsdk:"token_endpoint_authn_method"`
+	Type                                          types.String                 `tfsdk:"type"`
+	ClientId                                      pingonetypes.ResourceIDValue `tfsdk:"client_id"`
+	ClientSecret                                  types.String                 `tfsdk:"client_secret"`
+	BundleId                                      types.String                 `tfsdk:"bundle_id"`
+	PackageName                                   types.String                 `tfsdk:"package_name"`
+}
+
+type applicationCorsSettingsResourceModelV0 struct {
+	Behavior types.String `tfsdk:"behavior"`
+	Origins  types.Set    `tfsdk:"origins"`
+}
+
+type applicationOIDCCertificateBasedAuthenticationResourceModelV0 struct {
+	KeyId pingonetypes.ResourceIDValue `tfsdk:"key_id"`
+}
+
+type applicationOIDCMobileAppResourceModelV0 struct {
+	BundleId               types.String `tfsdk:"bundle_id"`
+	HuaweiAppId            types.String `tfsdk:"huawei_app_id"`
+	HuaweiPackageName      types.String `tfsdk:"huawei_package_name"`
+	IntegrityDetection     types.List   `tfsdk:"integrity_detection"`
+	PackageName            types.String `tfsdk:"package_name"`
+	PasscodeRefreshSeconds types.Int64  `tfsdk:"passcode_refresh_seconds"`
+	UniversalAppLink       types.String `tfsdk:"universal_app_link"`
+}
+
+type applicationOIDCMobileAppIntegrityDetectionResourceModelV0 struct {
+	CacheDuration     types.List `tfsdk:"cache_duration"`
+	Enabled           types.Bool `tfsdk:"enabled"`
+	ExcludedPlatforms types.Set  `tfsdk:"excluded_platforms"`
+	GooglePlay        types.List `tfsdk:"google_play"`
+}
+
+type applicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModelV0 struct {
+	Amount types.Int64  `tfsdk:"amount"`
+	Units  types.String `tfsdk:"units"`
+}
+
+type applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV0 struct {
+	DecryptionKey                 types.String `tfsdk:"decryption_key"`
+	ServiceAccountCredentialsJson types.String `tfsdk:"service_account_credentials_json"`
+	VerificationKey               types.String `tfsdk:"verification_key"`
+	VerificationType              types.String `tfsdk:"verification_type"`
+}
+
+type applicationSAMLOptionsResourceModelV0 struct {
+	AcsUrls                      types.Set    `tfsdk:"acs_urls"`
+	AssertionDuration            types.Int64  `tfsdk:"assertion_duration"`
+	AssertionSignedEnabled       types.Bool   `tfsdk:"assertion_signed_enabled"`
+	CorsSettings                 types.List   `tfsdk:"cors_settings"`
+	EnableRequestedAuthnContext  types.Bool   `tfsdk:"enable_requested_authn_context"`
+	HomePageUrl                  types.String `tfsdk:"home_page_url"`
+	IdpSigningKeyId              types.String `tfsdk:"idp_signing_key_id"`
+	IdpSigningKey                types.List   `tfsdk:"idp_signing_key"`
+	DefaultTargetUrl             types.String `tfsdk:"default_target_url"`
+	NameIdFormat                 types.String `tfsdk:"nameid_format"`
+	ResponseIsSigned             types.Bool   `tfsdk:"response_is_signed"`
+	SloBinding                   types.String `tfsdk:"slo_binding"`
+	SloEndpoint                  types.String `tfsdk:"slo_endpoint"`
+	SloResponseEndpoint          types.String `tfsdk:"slo_response_endpoint"`
+	SloWindow                    types.Int64  `tfsdk:"slo_window"`
+	SpEncryption                 types.List   `tfsdk:"sp_encryption"`
+	SpEntityId                   types.String `tfsdk:"sp_entity_id"`
+	SpVerificationCertificateIds types.Set    `tfsdk:"sp_verification_certificate_ids"`
+	SpVerification               types.List   `tfsdk:"sp_verification"`
+	Type                         types.String `tfsdk:"type"`
+}
+
+type applicationSAMLOptionsIdpSigningKeyResourceModelV0 struct {
+	Algorithm types.String                 `tfsdk:"algorithm"`
+	KeyId     pingonetypes.ResourceIDValue `tfsdk:"key_id"`
+}
+
+type applicationSAMLOptionsSpEncryptionResourceModelV0 struct {
+	Algorithm   types.String `tfsdk:"algorithm"`
+	Certificate types.List   `tfsdk:"certificate"`
+}
+
+type applicationSAMLOptionsSpEncryptionCertificateResourceModelV0 struct {
+	Id pingonetypes.ResourceIDValue `tfsdk:"id"`
+}
+
+type applicationSAMLOptionsSpVerificationResourceModelV0 struct {
+	CertificateIds     types.Set  `tfsdk:"certificate_ids"`
+	AuthnRequestSigned types.Bool `tfsdk:"authn_request_signed"`
+}
+
+func (r *ApplicationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+
+	const oidcOptionsParTimeoutDefault = 60
+	const oidcOptionsRefreshTokenDurationDefault = 2592000
+	const oidcOptionsRefreshTokenRollingDurationDefault = 15552000
+	const oidcOptionsMobileAppPasscodeRefreshSecondsDefault = 30
+
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": framework.Attr_ID(),
+
+					"environment_id": framework.Attr_LinkID(
+						framework.SchemaAttributeDescriptionFromMarkdown(""),
+					),
+
+					"name": schema.StringAttribute{
+						Required: true,
+					},
+
+					"description": schema.StringAttribute{
+						Optional: true,
+					},
+
+					"enabled": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+
+						Default: booldefault.StaticBool(true),
+					},
+
+					"tags": schema.SetAttribute{
+						Optional: true,
+
+						ElementType: types.StringType,
+					},
+
+					"login_page_url": schema.StringAttribute{
+						Optional: true,
+					},
+
+					"access_control_role_type": schema.StringAttribute{
+						Optional: true,
+						Computed: true,
+					},
+
+					"hidden_from_app_portal": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+
+						Default: booldefault.StaticBool(false),
+					},
+				},
+
+				Blocks: map[string]schema.Block{
+					"icon": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									Required: true,
+
+									CustomType: pingonetypes.ResourceIDType{},
+								},
+								"href": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+
+					"access_control_group_options": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"type": schema.StringAttribute{
+									Required: true,
+								},
+
+								"groups": schema.SetAttribute{
+									Required: true,
+
+									ElementType: types.StringType,
+								},
+							},
+						},
+					},
+
+					"external_link_options": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"home_page_url": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+
+					"oidc_options": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"type": schema.StringAttribute{
+									Required: true,
+								},
+
+								"home_page_url": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"initiate_login_uri": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"jwks": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"jwks_url": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"target_link_uri": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"grant_types": schema.SetAttribute{
+									Required: true,
+
+									ElementType: types.StringType,
+								},
+
+								"response_types": schema.SetAttribute{
+									Optional: true,
+
+									ElementType: types.StringType,
+								},
+
+								"token_endpoint_authn_method": schema.StringAttribute{
+									Required: true,
+								},
+
+								"par_requirement": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString(string(management.ENUMAPPLICATIONOIDCPARREQUIREMENT_OPTIONAL)),
+								},
+
+								"par_timeout": schema.Int64Attribute{
+									Optional: true,
+									Computed: true,
+
+									Default: int64default.StaticInt64(oidcOptionsParTimeoutDefault),
+								},
+
+								"pkce_enforcement": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString(string(management.ENUMAPPLICATIONOIDCPKCEOPTION_OPTIONAL)),
+								},
+
+								"redirect_uris": schema.SetAttribute{
+									Optional: true,
+
+									ElementType: types.StringType,
+								},
+
+								"allow_wildcards_in_redirect_uris": schema.BoolAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: booldefault.StaticBool(false),
+								},
+
+								"post_logout_redirect_uris": schema.SetAttribute{
+									Optional: true,
+
+									ElementType: types.StringType,
+								},
+
+								"refresh_token_duration": schema.Int64Attribute{
+									Optional: true,
+									Computed: true,
+
+									Default: int64default.StaticInt64(oidcOptionsRefreshTokenDurationDefault),
+								},
+
+								"refresh_token_rolling_duration": schema.Int64Attribute{
+									Optional: true,
+									Computed: true,
+
+									Default: int64default.StaticInt64(oidcOptionsRefreshTokenRollingDurationDefault),
+								},
+
+								"refresh_token_rolling_grace_period_duration": schema.Int64Attribute{
+									Optional: true,
+								},
+
+								"additional_refresh_token_replay_protection_enabled": schema.BoolAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: booldefault.StaticBool(true),
+								},
+
+								"client_id": schema.StringAttribute{
+									Computed: true,
+
+									CustomType: pingonetypes.ResourceIDType{},
+								},
+
+								"client_secret": schema.StringAttribute{
+									Computed:  true,
+									Sensitive: true,
+								},
+
+								"support_unsigned_request_object": schema.BoolAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: booldefault.StaticBool(false),
+								},
+
+								"require_signed_request_object": schema.BoolAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: booldefault.StaticBool(false),
+								},
+
+								"bundle_id": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+								},
+
+								"package_name": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+								},
+							},
+
+							Blocks: map[string]schema.Block{
+								"certificate_based_authentication": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"key_id": schema.StringAttribute{
+												Required: true,
+
+												CustomType: pingonetypes.ResourceIDType{},
+											},
+										},
+									},
+								},
+
+								"cors_settings": r.resourceApplicationSchemaCorsSettingsV0(),
+
+								"mobile_app": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"bundle_id": schema.StringAttribute{
+												Optional: true,
+											},
+
+											"package_name": schema.StringAttribute{
+												Optional: true,
+											},
+
+											"huawei_app_id": schema.StringAttribute{
+												Optional: true,
+											},
+
+											"huawei_package_name": schema.StringAttribute{
+												Optional: true,
+											},
+
+											"passcode_refresh_seconds": schema.Int64Attribute{
+												Optional: true,
+												Computed: true,
+
+												Default: int64default.StaticInt64(oidcOptionsMobileAppPasscodeRefreshSecondsDefault),
+											},
+
+											"universal_app_link": schema.StringAttribute{
+												Optional: true,
+											},
+										},
+
+										Blocks: map[string]schema.Block{
+											"integrity_detection": schema.ListNestedBlock{
+												NestedObject: schema.NestedBlockObject{
+													Attributes: map[string]schema.Attribute{
+														"enabled": schema.BoolAttribute{
+															Optional: true,
+															Computed: true,
+
+															Default: booldefault.StaticBool(false),
+														},
+
+														"excluded_platforms": schema.SetAttribute{
+															Optional: true,
+
+															ElementType: types.StringType,
+														},
+													},
+
+													Blocks: map[string]schema.Block{
+														"cache_duration": schema.ListNestedBlock{
+															NestedObject: schema.NestedBlockObject{
+																Attributes: map[string]schema.Attribute{
+																	"amount": schema.Int64Attribute{
+																		Required: true,
+																	},
+
+																	"units": schema.StringAttribute{
+																		Optional: true,
+																		Computed: true,
+
+																		Default: stringdefault.StaticString(string(management.ENUMDURATIONUNITMINSHOURS_MINUTES)),
+																	},
+																},
+															},
+														},
+
+														"google_play": schema.ListNestedBlock{
+															NestedObject: schema.NestedBlockObject{
+																Attributes: map[string]schema.Attribute{
+																	"decryption_key": schema.StringAttribute{
+																		Optional:  true,
+																		Sensitive: true,
+																	},
+
+																	"service_account_credentials_json": schema.StringAttribute{
+																		Optional:  true,
+																		Sensitive: true,
+																	},
+
+																	"verification_key": schema.StringAttribute{
+																		Optional:  true,
+																		Sensitive: true,
+																	},
+
+																	"verification_type": schema.StringAttribute{
+																		Required: true,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+
+					"saml_options": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"home_page_url": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"type": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString(string(management.ENUMAPPLICATIONTYPE_WEB_APP)),
+								},
+
+								"acs_urls": schema.SetAttribute{
+									Required: true,
+
+									ElementType: types.StringType,
+								},
+
+								"assertion_duration": schema.Int64Attribute{
+									Required: true,
+								},
+
+								"assertion_signed_enabled": schema.BoolAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: booldefault.StaticBool(true),
+								},
+
+								"default_target_url": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"idp_signing_key_id": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+								},
+
+								"enable_requested_authn_context": schema.BoolAttribute{
+									Optional: true,
+								},
+
+								"nameid_format": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"response_is_signed": schema.BoolAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: booldefault.StaticBool(false),
+								},
+
+								"slo_binding": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString(string(management.ENUMAPPLICATIONSAMLSLOBINDING_POST)),
+								},
+
+								"slo_endpoint": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"slo_response_endpoint": schema.StringAttribute{
+									Optional: true,
+								},
+
+								"slo_window": schema.Int64Attribute{
+									Optional: true,
+								},
+
+								"sp_entity_id": schema.StringAttribute{
+									Required: true,
+								},
+
+								"sp_verification_certificate_ids": schema.SetAttribute{
+									Optional: true,
+									Computed: true,
+
+									ElementType: types.StringType,
+								},
+							},
+
+							Blocks: map[string]schema.Block{
+								"idp_signing_key": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"algorithm": schema.StringAttribute{
+												Required: true,
+											},
+
+											"key_id": schema.StringAttribute{
+												Required: true,
+
+												CustomType: pingonetypes.ResourceIDType{},
+											},
+										},
+									},
+								},
+
+								"sp_encryption": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"algorithm": schema.StringAttribute{
+												Required: true,
+											},
+										},
+
+										Blocks: map[string]schema.Block{
+											"certificate": schema.ListNestedBlock{
+												NestedObject: schema.NestedBlockObject{
+													Attributes: map[string]schema.Attribute{
+														"id": schema.StringAttribute{
+															Required: true,
+
+															CustomType: pingonetypes.ResourceIDType{},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+
+								"sp_verification": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"authn_request_signed": schema.BoolAttribute{
+												Optional: true,
+												Computed: true,
+
+												Default: booldefault.StaticBool(false),
+											},
+
+											"certificate_ids": schema.SetAttribute{
+												Required: true,
+
+												ElementType: pingonetypes.ResourceIDType{},
+											},
+										},
+									},
+								},
+
+								"cors_settings": r.resourceApplicationSchemaCorsSettingsV0(),
+							},
+						},
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var d diag.Diagnostics
+				var priorStateData applicationResourceModelV0
+
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorStateData)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				icon, d := priorStateData.schemaUpgradeIconV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				accessControlGroupOptions, d := priorStateData.schemaUpgradeAccessControlGroupOptionsV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				externalLinkOptions, d := priorStateData.schemaUpgradeExternalLinkOptionsV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				oIDCOptions, d := priorStateData.schemaUpgradeOIDCOptionsV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				sAMLOptions, d := priorStateData.schemaUpgradeSAMLOptionsV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				upgradedStateData := applicationResourceModelV1{
+					Id:                        priorStateData.Id,
+					EnvironmentId:             priorStateData.EnvironmentId,
+					Name:                      priorStateData.Name,
+					Description:               priorStateData.Description,
+					Enabled:                   priorStateData.Enabled,
+					Tags:                      priorStateData.Tags,
+					LoginPageUrl:              priorStateData.LoginPageUrl,
+					Icon:                      icon,
+					AccessControlRoleType:     priorStateData.AccessControlRoleType,
+					AccessControlGroupOptions: accessControlGroupOptions,
+					HiddenFromAppPortal:       priorStateData.HiddenFromAppPortal,
+					ExternalLinkOptions:       externalLinkOptions,
+					OIDCOptions:               oIDCOptions,
+					SAMLOptions:               sAMLOptions,
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
+			},
+		},
+	}
+}
+
+func (r *ApplicationResource) resourceApplicationSchemaCorsSettingsV0() schema.Block {
+	return schema.ListNestedBlock{
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"behavior": schema.StringAttribute{
+					Required: true,
+				},
+
+				"origins": schema.SetAttribute{
+					Optional: true,
+
+					ElementType: types.StringType,
+				},
+			},
+		},
+	}
+}
+
+func (p *applicationResourceModelV0) schemaUpgradeIconV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := service.ImageTFObjectTypes
+	planAttribute := p.Icon
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []service.ImageResourceModel
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationResourceModelV0) schemaUpgradeAccessControlGroupOptionsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationAccessControlGroupOptionsTFObjectTypes
+	planAttribute := p.AccessControlGroupOptions
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationAccessControlGroupOptionsResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationAccessControlGroupOptionsResourceModelV1{
+			Type:   priorStateData[0].Type,
+			Groups: priorStateData[0].Groups,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationResourceModelV0) schemaUpgradeExternalLinkOptionsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationExternalLinkOptionsTFObjectTypes
+	planAttribute := p.ExternalLinkOptions
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationExternalLinkOptionsResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationExternalLinkOptionsResourceModelV1{
+			HomePageUrl: priorStateData[0].HomePageUrl,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationResourceModelV0) schemaUpgradeOIDCOptionsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationOidcOptionsTFObjectTypes
+	planAttribute := p.OIDCOptions
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationOIDCOptionsResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		certificateBasedAuthentication, d := priorStateData[0].schemaUpgradeCertificateBasedAuthenticationV0toV1(ctx)
+		diags.Append(d...)
+
+		corsSettings, d := priorStateData[0].schemaUpgradeCorsSettingsV0toV1(ctx)
+		diags.Append(d...)
+
+		mobileApp, d := priorStateData[0].schemaUpgradeMobileAppV0toV1(ctx)
+		diags.Append(d...)
+
+		const deviceTimeoutDefault = 600
+		const devicePollingIntervalDefault = 5
+
+		upgradedStateData := applicationOIDCOptionsResourceModelV1{
+			AdditionalRefreshTokenReplayProtectionEnabled: priorStateData[0].AdditionalRefreshTokenReplayProtectionEnabled,
+			AllowWildcardsInRedirectUris:                  priorStateData[0].AllowWildcardsInRedirectUris,
+			CertificateBasedAuthentication:                certificateBasedAuthentication,
+			CorsSettings:                                  corsSettings,
+			DevicePathId:                                  types.StringNull(),
+			DeviceCustomVerificationUri:                   types.StringNull(),
+			DeviceTimeout:                                 types.Int64Value(deviceTimeoutDefault),
+			DevicePollingInterval:                         types.Int64Value(devicePollingIntervalDefault),
+			GrantTypes:                                    priorStateData[0].GrantTypes,
+			HomePageUrl:                                   priorStateData[0].HomePageUrl,
+			InitiateLoginUri:                              priorStateData[0].InitiateLoginUri,
+			Jwks:                                          priorStateData[0].Jwks,
+			JwksUrl:                                       priorStateData[0].JwksUrl,
+			MobileApp:                                     mobileApp,
+			ParRequirement:                                priorStateData[0].ParRequirement,
+			ParTimeout:                                    priorStateData[0].ParTimeout,
+			PKCEEnforcement:                               priorStateData[0].PKCEEnforcement,
+			PostLogoutRedirectUris:                        priorStateData[0].PostLogoutRedirectUris,
+			RedirectUris:                                  priorStateData[0].RedirectUris,
+			RefreshTokenDuration:                          priorStateData[0].RefreshTokenDuration,
+			RefreshTokenRollingDuration:                   priorStateData[0].RefreshTokenRollingDuration,
+			RefreshTokenRollingGracePeriodDuration:        priorStateData[0].RefreshTokenRollingGracePeriodDuration,
+			RequireSignedRequestObject:                    priorStateData[0].RequireSignedRequestObject,
+			ResponseTypes:                                 priorStateData[0].ResponseTypes,
+			SupportUnsignedRequestObject:                  priorStateData[0].SupportUnsignedRequestObject,
+			TargetLinkUri:                                 priorStateData[0].TargetLinkUri,
+			TokenEndpointAuthnMethod:                      priorStateData[0].TokenEndpointAuthnMethod,
+			Type:                                          priorStateData[0].Type,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationOIDCOptionsResourceModelV0) schemaUpgradeCertificateBasedAuthenticationV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationOidcOptionsCertificateAuthenticationTFObjectTypes
+	planAttribute := p.CertificateBasedAuthentication
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationOIDCCertificateBasedAuthenticationResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationOIDCCertificateBasedAuthenticationResourceModelV1{
+			KeyId: priorStateData[0].KeyId,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationOIDCOptionsResourceModelV0) schemaUpgradeCorsSettingsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	planAttribute := p.CorsSettings
+	return applicationSchemaUpgradeCorsSettingsV0toV1(ctx, planAttribute)
+}
+
+func applicationSchemaUpgradeCorsSettingsV0toV1(ctx context.Context, planAttribute types.List) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationCorsSettingsTFObjectTypes
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationCorsSettingsResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationCorsSettingsResourceModelV1{
+			Behavior: priorStateData[0].Behavior,
+			Origins:  priorStateData[0].Origins,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationOIDCOptionsResourceModelV0) schemaUpgradeMobileAppV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationOidcMobileAppTFObjectTypes
+	planAttribute := p.MobileApp
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationOIDCMobileAppResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		integrityDetection, d := priorStateData[0].schemaUpgradeIntegrityDetectionV0toV1(ctx)
+		diags.Append(d...)
+
+		upgradedStateData := applicationOIDCMobileAppResourceModelV1{
+			BundleId:               priorStateData[0].BundleId,
+			HuaweiAppId:            priorStateData[0].HuaweiAppId,
+			HuaweiPackageName:      priorStateData[0].HuaweiPackageName,
+			IntegrityDetection:     integrityDetection,
+			PackageName:            priorStateData[0].PackageName,
+			PasscodeRefreshSeconds: priorStateData[0].PasscodeRefreshSeconds,
+			UniversalAppLink:       priorStateData[0].UniversalAppLink,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationOIDCMobileAppResourceModelV0) schemaUpgradeIntegrityDetectionV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationOidcMobileAppIntegrityDetectionTFObjectTypes
+	planAttribute := p.IntegrityDetection
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationOIDCMobileAppIntegrityDetectionResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		cacheDuration, d := priorStateData[0].schemaUpgradeCacheDurationV0toV1(ctx)
+		diags.Append(d...)
+
+		googlePlay, d := priorStateData[0].schemaUpgradeGooglePlayV0toV1(ctx)
+		diags.Append(d...)
+
+		upgradedStateData := applicationOIDCMobileAppIntegrityDetectionResourceModelV1{
+			CacheDuration:     cacheDuration,
+			Enabled:           priorStateData[0].Enabled,
+			ExcludedPlatforms: priorStateData[0].ExcludedPlatforms,
+			GooglePlay:        googlePlay,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationOIDCMobileAppIntegrityDetectionResourceModelV0) schemaUpgradeCacheDurationV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationOidcMobileAppIntegrityDetectionCacheDurationTFObjectTypes
+	planAttribute := p.CacheDuration
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModelV1{
+			Amount: priorStateData[0].Amount,
+			Units:  priorStateData[0].Units,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationOIDCMobileAppIntegrityDetectionResourceModelV0) schemaUpgradeGooglePlayV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationOidcMobileAppIntegrityDetectionGooglePlayTFObjectTypes
+	planAttribute := p.GooglePlay
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV1{
+			DecryptionKey:                 types.StringNull(),
+			ServiceAccountCredentialsJson: jsontypes.NewNormalizedNull(),
+			VerificationKey:               types.StringNull(),
+			VerificationType:              priorStateData[0].VerificationType,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationResourceModelV0) schemaUpgradeSAMLOptionsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationSamlOptionsTFObjectTypes
+	planAttribute := p.SAMLOptions
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationSAMLOptionsResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		corsSettings, d := priorStateData[0].schemaUpgradeCorsSettingsV0toV1(ctx)
+		diags.Append(d...)
+
+		idpSigningKey, d := priorStateData[0].schemaUpgradeIdPSigningKeyV0toV1(ctx)
+		diags.Append(d...)
+
+		spEncryption, d := priorStateData[0].schemaUpgradeSpEncryptionV0toV1(ctx)
+		diags.Append(d...)
+
+		spVerification, d := priorStateData[0].schemaUpgradeSpVerificationV0toV1(ctx)
+		diags.Append(d...)
+
+		upgradedStateData := applicationSAMLOptionsResourceModelV1{
+			AcsUrls:                     priorStateData[0].AcsUrls,
+			AssertionDuration:           priorStateData[0].AssertionDuration,
+			AssertionSignedEnabled:      priorStateData[0].AssertionSignedEnabled,
+			CorsSettings:                corsSettings,
+			EnableRequestedAuthnContext: priorStateData[0].EnableRequestedAuthnContext,
+			HomePageUrl:                 priorStateData[0].HomePageUrl,
+			IdpSigningKey:               idpSigningKey,
+			DefaultTargetUrl:            priorStateData[0].DefaultTargetUrl,
+			NameIdFormat:                priorStateData[0].NameIdFormat,
+			ResponseIsSigned:            priorStateData[0].ResponseIsSigned,
+			SloBinding:                  priorStateData[0].SloBinding,
+			SloEndpoint:                 priorStateData[0].SloEndpoint,
+			SloResponseEndpoint:         priorStateData[0].SloResponseEndpoint,
+			SloWindow:                   priorStateData[0].SloWindow,
+			SpEncryption:                spEncryption,
+			SpEntityId:                  priorStateData[0].SpEntityId,
+			SpVerification:              spVerification,
+			Type:                        priorStateData[0].Type,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationSAMLOptionsResourceModelV0) schemaUpgradeCorsSettingsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	planAttribute := p.CorsSettings
+	return applicationSchemaUpgradeCorsSettingsV0toV1(ctx, planAttribute)
+}
+
+func (p *applicationSAMLOptionsResourceModelV0) schemaUpgradeIdPSigningKeyV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationSamlOptionsIdpSigningKeyTFObjectTypes
+	planAttribute := p.IdpSigningKey
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationSAMLOptionsIdpSigningKeyResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationSAMLOptionsIdpSigningKeyResourceModelV1{
+			Algorithm: priorStateData[0].Algorithm,
+			KeyId:     priorStateData[0].KeyId,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationSAMLOptionsResourceModelV0) schemaUpgradeSpEncryptionV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationSamlOptionsSpEncryptionTFObjectTypes
+	planAttribute := p.SpEncryption
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationSAMLOptionsSpEncryptionResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		certificate, d := priorStateData[0].schemaUpgradeCertificateV0toV1(ctx)
+		diags.Append(d...)
+
+		upgradedStateData := applicationSAMLOptionsSpEncryptionResourceModelV1{
+			Algorithm:   priorStateData[0].Algorithm,
+			Certificate: certificate,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationSAMLOptionsSpEncryptionResourceModelV0) schemaUpgradeCertificateV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationSamlOptionsSpEncryptionCertificateTFObjectTypes
+	planAttribute := p.Certificate
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationSAMLOptionsSpEncryptionCertificateResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationSAMLOptionsSpEncryptionCertificateResourceModelV1{
+			Id: priorStateData[0].Id,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *applicationSAMLOptionsResourceModelV0) schemaUpgradeSpVerificationV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := applicationSamlOptionsSpVerificationTFObjectTypes
+	planAttribute := p.SpVerification
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []applicationSAMLOptionsSpVerificationResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := applicationSAMLOptionsSpVerificationResourceModelV1{
+			CertificateIds:     priorStateData[0].CertificateIds,
+			AuthnRequestSigned: priorStateData[0].AuthnRequestSigned,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}

--- a/internal/service/sso/utils_application.go
+++ b/internal/service/sso/utils_application.go
@@ -75,7 +75,7 @@ func applicationCorsSettingsOkToTF(apiObject *management.ApplicationCorsSettings
 	return returnVar, diags
 }
 
-func applicationOidcOptionsToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue ApplicationOIDCOptionsResourceModel) (types.Object, diag.Diagnostics) {
+func applicationOidcOptionsToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsResourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if apiObject == nil || apiObject.GetId() == "" {
@@ -89,7 +89,7 @@ func applicationOidcOptionsToTF(ctx context.Context, apiObject *management.Appli
 	diags.Append(d...)
 
 	mobileAppObject, ok := apiObject.GetMobileOk()
-	var mobileAppState ApplicationOIDCMobileAppResourceModel
+	var mobileAppState applicationOIDCMobileAppResourceModelV1
 	if !stateValue.MobileApp.IsNull() && !stateValue.MobileApp.IsUnknown() {
 		d := stateValue.MobileApp.As(ctx, &mobileAppState, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
@@ -161,7 +161,7 @@ func applicationOidcOptionsCertificateBasedAuthenticationToTF(apiObject *managem
 	return returnVar, diags
 }
 
-func applicationMobileAppOkToTF(ctx context.Context, apiObject *management.ApplicationOIDCAllOfMobile, ok bool, stateValue ApplicationOIDCMobileAppResourceModel) (types.Object, diag.Diagnostics) {
+func applicationMobileAppOkToTF(ctx context.Context, apiObject *management.ApplicationOIDCAllOfMobile, ok bool, stateValue applicationOIDCMobileAppResourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if !ok || apiObject == nil {
@@ -169,7 +169,7 @@ func applicationMobileAppOkToTF(ctx context.Context, apiObject *management.Appli
 	}
 
 	integrityDetectionObj, ok := apiObject.GetIntegrityDetectionOk()
-	var integrityDetectionState ApplicationOIDCMobileAppIntegrityDetectionResourceModel
+	var integrityDetectionState applicationOIDCMobileAppIntegrityDetectionResourceModelV1
 	if !stateValue.IntegrityDetection.IsNull() && !stateValue.IntegrityDetection.IsUnknown() {
 		d := stateValue.IntegrityDetection.As(ctx, &integrityDetectionState, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
@@ -213,7 +213,7 @@ func applicationMobileAppOkToTF(ctx context.Context, apiObject *management.Appli
 	return returnVar, diags
 }
 
-func applicationMobileAppIntegrityDetectionOkToTF(ctx context.Context, apiObject *management.ApplicationOIDCAllOfMobileIntegrityDetection, ok bool, stateValue ApplicationOIDCMobileAppIntegrityDetectionResourceModel) (types.Object, diag.Diagnostics) {
+func applicationMobileAppIntegrityDetectionOkToTF(ctx context.Context, apiObject *management.ApplicationOIDCAllOfMobileIntegrityDetection, ok bool, stateValue applicationOIDCMobileAppIntegrityDetectionResourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if !ok || apiObject == nil {
@@ -224,7 +224,7 @@ func applicationMobileAppIntegrityDetectionOkToTF(ctx context.Context, apiObject
 	diags.Append(d...)
 
 	googlePlayObject, ok := apiObject.GetGooglePlayOk()
-	var googlePlayState ApplicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModel
+	var googlePlayState applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV1
 	if !stateValue.GooglePlay.IsNull() && !stateValue.GooglePlay.IsUnknown() {
 		d := stateValue.GooglePlay.As(ctx, &googlePlayState, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
@@ -277,7 +277,7 @@ func applicationMobileAppIntegrityDetectionCacheDurationOkToTF(apiObject *manage
 	return returnVar, diags
 }
 
-func applicationMobileAppIntegrityDetectionGooglePlayOkToTF(apiObject *management.ApplicationOIDCAllOfMobileIntegrityDetectionGooglePlay, ok bool, stateValue ApplicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModel) (types.Object, diag.Diagnostics) {
+func applicationMobileAppIntegrityDetectionGooglePlayOkToTF(apiObject *management.ApplicationOIDCAllOfMobileIntegrityDetectionGooglePlay, ok bool, stateValue applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if !ok || apiObject == nil {


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_application` v0 to v1 state upgrader

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccApplication_RemovalDrift
=== PAUSE TestAccApplication_RemovalDrift
=== RUN   TestAccApplication_NewEnv
=== PAUSE TestAccApplication_NewEnv
=== RUN   TestAccApplication_OIDCFullWeb
=== PAUSE TestAccApplication_OIDCFullWeb
=== RUN   TestAccApplication_OIDCMinimalWeb
=== PAUSE TestAccApplication_OIDCMinimalWeb
=== RUN   TestAccApplication_OIDCWebUpdate
=== PAUSE TestAccApplication_OIDCWebUpdate
=== RUN   TestAccApplication_OIDCFullNative
=== PAUSE TestAccApplication_OIDCFullNative
=== RUN   TestAccApplication_OIDCMinimalNative
=== PAUSE TestAccApplication_OIDCMinimalNative
=== RUN   TestAccApplication_OIDCNativeUpdate
=== PAUSE TestAccApplication_OIDCNativeUpdate
=== RUN   TestAccApplication_NativeKerberos
=== PAUSE TestAccApplication_NativeKerberos
=== RUN   TestAccApplication_NativeMobile
=== PAUSE TestAccApplication_NativeMobile
=== RUN   TestAccApplication_NativeMobile_IntegrityDetection
=== PAUSE TestAccApplication_NativeMobile_IntegrityDetection
=== RUN   TestAccApplication_OIDCFullCustom
=== PAUSE TestAccApplication_OIDCFullCustom
=== RUN   TestAccApplication_OIDCMinimalCustom
=== PAUSE TestAccApplication_OIDCMinimalCustom
=== RUN   TestAccApplication_OIDCCustomUpdate
=== PAUSE TestAccApplication_OIDCCustomUpdate
=== RUN   TestAccApplication_OIDCCustom_Device
=== PAUSE TestAccApplication_OIDCCustom_Device
=== RUN   TestAccApplication_OIDCFullService
=== PAUSE TestAccApplication_OIDCFullService
=== RUN   TestAccApplication_OIDCMinimalService
=== PAUSE TestAccApplication_OIDCMinimalService
=== RUN   TestAccApplication_OIDCServiceUpdate
=== PAUSE TestAccApplication_OIDCServiceUpdate
=== RUN   TestAccApplication_OIDCFullSPA
=== PAUSE TestAccApplication_OIDCFullSPA
=== RUN   TestAccApplication_OIDCMinimalSPA
=== PAUSE TestAccApplication_OIDCMinimalSPA
=== RUN   TestAccApplication_OIDCSPAUpdate
=== PAUSE TestAccApplication_OIDCSPAUpdate
=== RUN   TestAccApplication_OIDCFullWorker
=== PAUSE TestAccApplication_OIDCFullWorker
=== RUN   TestAccApplication_OIDCMinimalWorker
=== PAUSE TestAccApplication_OIDCMinimalWorker
=== RUN   TestAccApplication_OIDCWorkerUpdate
=== PAUSE TestAccApplication_OIDCWorkerUpdate
=== RUN   TestAccApplication_OIDC_WildcardInRedirectURI
=== PAUSE TestAccApplication_OIDC_WildcardInRedirectURI
=== RUN   TestAccApplication_OIDC_LocalhostAddresses
=== PAUSE TestAccApplication_OIDC_LocalhostAddresses
=== RUN   TestAccApplication_OIDC_NativeAppAddresses
=== PAUSE TestAccApplication_OIDC_NativeAppAddresses
=== RUN   TestAccApplication_OIDC_JwtTokenAuth
=== PAUSE TestAccApplication_OIDC_JwtTokenAuth
=== RUN   TestAccApplication_SAMLFull
=== PAUSE TestAccApplication_SAMLFull
=== RUN   TestAccApplication_SAMLMinimal
=== PAUSE TestAccApplication_SAMLMinimal
=== RUN   TestAccApplication_ExternalLinkFull
=== PAUSE TestAccApplication_ExternalLinkFull
=== RUN   TestAccApplication_ExternalLinkMinimal
=== PAUSE TestAccApplication_ExternalLinkMinimal
=== RUN   TestAccApplication_Enabled
=== PAUSE TestAccApplication_Enabled
=== RUN   TestAccApplication_BadParameters
=== PAUSE TestAccApplication_BadParameters
=== CONT  TestAccApplication_RemovalDrift
=== CONT  TestAccApplication_OIDCServiceUpdate
=== CONT  TestAccApplication_OIDC_NativeAppAddresses
=== CONT  TestAccApplication_NativeMobile
=== CONT  TestAccApplication_OIDCMinimalWorker
=== CONT  TestAccApplication_ExternalLinkFull
=== CONT  TestAccApplication_SAMLMinimal
=== CONT  TestAccApplication_OIDCFullSPA
=== CONT  TestAccApplication_ExternalLinkMinimal
=== CONT  TestAccApplication_OIDC_LocalhostAddresses
=== CONT  TestAccApplication_OIDCSPAUpdate
=== CONT  TestAccApplication_OIDCMinimalSPA
=== CONT  TestAccApplication_OIDC_WildcardInRedirectURI
=== CONT  TestAccApplication_OIDCWorkerUpdate
=== CONT  TestAccApplication_OIDCFullWorker
=== CONT  TestAccApplication_OIDCCustomUpdate
--- PASS: TestAccApplication_OIDC_NativeAppAddresses (11.46s)
=== CONT  TestAccApplication_OIDCFullCustom
--- PASS: TestAccApplication_ExternalLinkMinimal (12.53s)
=== CONT  TestAccApplication_OIDCMinimalCustom
--- PASS: TestAccApplication_OIDCMinimalSPA (12.67s)
=== CONT  TestAccApplication_SAMLFull
=== CONT  TestAccApplication_OIDCFullNative
--- PASS: TestAccApplication_OIDCMinimalWorker (13.43s)
--- PASS: TestAccApplication_OIDC_WildcardInRedirectURI (14.00s)
=== CONT  TestAccApplication_NativeKerberos
--- PASS: TestAccApplication_OIDCFullWorker (16.75s)
=== CONT  TestAccApplication_OIDCNativeUpdate
--- PASS: TestAccApplication_ExternalLinkFull (18.29s)
=== CONT  TestAccApplication_OIDCMinimalNative
--- PASS: TestAccApplication_OIDCFullSPA (19.85s)
=== CONT  TestAccApplication_OIDCMinimalWeb
--- PASS: TestAccApplication_OIDCMinimalCustom (11.52s)
=== CONT  TestAccApplication_OIDCWebUpdate
--- PASS: TestAccApplication_OIDCFullCustom (14.94s)
=== CONT  TestAccApplication_NativeMobile_IntegrityDetection
--- PASS: TestAccApplication_OIDCFullNative (13.47s)
=== CONT  TestAccApplication_OIDC_JwtTokenAuth
--- PASS: TestAccApplication_OIDCWorkerUpdate (27.44s)
=== CONT  TestAccApplication_OIDCFullWeb
--- PASS: TestAccApplication_OIDC_LocalhostAddresses (28.56s)
=== CONT  TestAccApplication_OIDCFullService
--- PASS: TestAccApplication_OIDCMinimalWeb (8.75s)
=== CONT  TestAccApplication_OIDCMinimalService
--- PASS: TestAccApplication_OIDCServiceUpdate (28.71s)
=== CONT  TestAccApplication_BadParameters
--- PASS: TestAccApplication_OIDCSPAUpdate (29.18s)
=== CONT  TestAccApplication_NewEnv
--- PASS: TestAccApplication_OIDCCustomUpdate (29.83s)
=== CONT  TestAccApplication_OIDCCustom_Device
--- PASS: TestAccApplication_OIDCMinimalNative (14.21s)
=== CONT  TestAccApplication_Enabled
--- PASS: TestAccApplication_OIDCMinimalService (11.77s)
--- PASS: TestAccApplication_OIDCNativeUpdate (25.24s)
--- PASS: TestAccApplication_OIDCFullService (14.27s)
--- PASS: TestAccApplication_OIDCFullWeb (15.63s)
--- PASS: TestAccApplication_BadParameters (17.68s)
--- PASS: TestAccApplication_OIDCWebUpdate (23.54s)
--- PASS: TestAccApplication_SAMLMinimal (48.15s)
--- PASS: TestAccApplication_Enabled (19.68s)
--- PASS: TestAccApplication_RemovalDrift (57.26s)
--- PASS: TestAccApplication_SAMLFull (47.46s)
--- PASS: TestAccApplication_NativeMobile (62.19s)
--- PASS: TestAccApplication_NativeKerberos (49.87s)
--- PASS: TestAccApplication_OIDCCustom_Device (36.32s)
--- PASS: TestAccApplication_NewEnv (44.03s)
--- PASS: TestAccApplication_OIDC_JwtTokenAuth (53.88s)
--- PASS: TestAccApplication_NativeMobile_IntegrityDetection (65.30s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 93.786s
```

</details>