### PR TITLE
`resource/pingone_mfa_settings` state upgrader v0 to v1

### DIFF
--- a/internal/service/mfa/resource_mfa_settings.go
+++ b/internal/service/mfa/resource_mfa_settings.go
@@ -28,7 +28,7 @@ import (
 // Types
 type MFASettingsResource serviceClientType
 
-type MFASettingsResourceModel struct {
+type mFASettingsResourceModelV1 struct {
 	EnvironmentId   pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
 	Lockout         types.Object                 `tfsdk:"lockout"`
 	Pairing         types.Object                 `tfsdk:"pairing"`
@@ -36,21 +36,21 @@ type MFASettingsResourceModel struct {
 	Users           types.Object                 `tfsdk:"users"`
 }
 
-type MFASettingsLockoutResourceModel struct {
+type mFASettingsLockoutResourceModelV1 struct {
 	FailureCount    types.Int64 `tfsdk:"failure_count"`
 	DurationSeconds types.Int64 `tfsdk:"duration_seconds"`
 }
 
-type MFASettingsPairingResourceModel struct {
+type mFASettingsPairingResourceModelV1 struct {
 	MaxAllowedDevices types.Int64  `tfsdk:"max_allowed_devices"`
 	PairingKeyFormat  types.String `tfsdk:"pairing_key_format"`
 }
 
-type MFASettingsPhoneExtensionsResourceModel struct {
+type mFASettingsPhoneExtensionsResourceModelV1 struct {
 	Enabled types.Bool `tfsdk:"enabled"`
 }
 
-type MFASettingsUsersResourceModel struct {
+type mFASettingsUsersResourceModelV1 struct {
 	MFAEnabled types.Bool `tfsdk:"mfa_enabled"`
 }
 
@@ -76,9 +76,10 @@ var (
 
 // Framework interfaces
 var (
-	_ resource.Resource                = &MFASettingsResource{}
-	_ resource.ResourceWithConfigure   = &MFASettingsResource{}
-	_ resource.ResourceWithImportState = &MFASettingsResource{}
+	_ resource.Resource                 = &MFASettingsResource{}
+	_ resource.ResourceWithConfigure    = &MFASettingsResource{}
+	_ resource.ResourceWithImportState  = &MFASettingsResource{}
+	_ resource.ResourceWithUpgradeState = &MFASettingsResource{}
 )
 
 // New Object
@@ -118,6 +119,9 @@ func (r *MFASettingsResource) Schema(ctx context.Context, req resource.SchemaReq
 	)
 
 	resp.Schema = schema.Schema{
+
+		Version: 1,
+
 		// This description is used by the documentation generator and the language server.
 		Description: "Resource to manage the MFA settings for a PingOne environment.",
 
@@ -253,7 +257,7 @@ func (r *MFASettingsResource) Configure(ctx context.Context, req resource.Config
 }
 
 func (r *MFASettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan, state MFASettingsResourceModel
+	var plan, state mFASettingsResourceModelV1
 
 	if r.Client.MFAAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -302,7 +306,7 @@ func (r *MFASettingsResource) Create(ctx context.Context, req resource.CreateReq
 }
 
 func (r *MFASettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *MFASettingsResourceModel
+	var data *mFASettingsResourceModelV1
 
 	if r.Client.MFAAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -347,7 +351,7 @@ func (r *MFASettingsResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *MFASettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state MFASettingsResourceModel
+	var plan, state mFASettingsResourceModelV1
 
 	if r.Client.MFAAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -396,7 +400,7 @@ func (r *MFASettingsResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 func (r *MFASettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data *MFASettingsResourceModel
+	var data *mFASettingsResourceModelV1
 
 	if r.Client.MFAAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -459,11 +463,11 @@ func (r *MFASettingsResource) ImportState(ctx context.Context, req resource.Impo
 	}
 }
 
-func (p *MFASettingsResourceModel) expand(ctx context.Context) (*mfa.MFASettings, diag.Diagnostics) {
+func (p *mFASettingsResourceModelV1) expand(ctx context.Context) (*mfa.MFASettings, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	// Pairing
-	var pairingPlan MFASettingsPairingResourceModel
+	var pairingPlan mFASettingsPairingResourceModelV1
 	diags.Append(p.Pairing.As(ctx, &pairingPlan, basetypes.ObjectAsOptions{
 		UnhandledNullAsEmpty:    false,
 		UnhandledUnknownAsEmpty: false,
@@ -483,7 +487,7 @@ func (p *MFASettingsResourceModel) expand(ctx context.Context) (*mfa.MFASettings
 
 	// Lockout
 	if !p.Lockout.IsNull() && !p.Lockout.IsUnknown() {
-		var lockoutPlan MFASettingsLockoutResourceModel
+		var lockoutPlan mFASettingsLockoutResourceModelV1
 		diags.Append(p.Lockout.As(ctx, &lockoutPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -504,7 +508,7 @@ func (p *MFASettingsResourceModel) expand(ctx context.Context) (*mfa.MFASettings
 
 	// Phone Extensions
 	if !p.PhoneExtensions.IsNull() && !p.PhoneExtensions.IsUnknown() {
-		var phoneExtensionsPlan MFASettingsPhoneExtensionsResourceModel
+		var phoneExtensionsPlan mFASettingsPhoneExtensionsResourceModelV1
 		diags.Append(p.PhoneExtensions.As(ctx, &phoneExtensionsPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -523,7 +527,7 @@ func (p *MFASettingsResourceModel) expand(ctx context.Context) (*mfa.MFASettings
 
 	// Users
 	if !p.Users.IsNull() && !p.Users.IsUnknown() {
-		var usersPlan MFASettingsUsersResourceModel
+		var usersPlan mFASettingsUsersResourceModelV1
 		diags.Append(p.Users.As(ctx, &usersPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -543,7 +547,7 @@ func (p *MFASettingsResourceModel) expand(ctx context.Context) (*mfa.MFASettings
 	return data, diags
 }
 
-func (p *MFASettingsResourceModel) toState(apiObject *mfa.MFASettings) diag.Diagnostics {
+func (p *mFASettingsResourceModelV1) toState(apiObject *mfa.MFASettings) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if apiObject == nil {

--- a/internal/service/mfa/resource_mfa_settings_schema_upgrade_0_to_1.go
+++ b/internal/service/mfa/resource_mfa_settings_schema_upgrade_0_to_1.go
@@ -1,0 +1,208 @@
+package mfa
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
+)
+
+type mFASettingsResourceModelV0 struct {
+	Id                     pingonetypes.ResourceIDValue `tfsdk:"id"`
+	EnvironmentId          pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
+	PhoneExtensionsEnabled types.Bool                   `tfsdk:"phone_extensions_enabled"`
+	Pairing                types.List                   `tfsdk:"pairing"`
+	Lockout                types.List                   `tfsdk:"lockout"`
+	Authentication         types.List                   `tfsdk:"authentication"`
+}
+
+type mFASettingsLockoutResourceModelV0 mFASettingsLockoutResourceModelV1
+
+type mFASettingsPairingResourceModelV0 mFASettingsPairingResourceModelV1
+
+func (r *MFASettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": framework.Attr_ID(),
+
+					"environment_id": framework.Attr_LinkID(
+						framework.SchemaAttributeDescriptionFromMarkdown(""),
+					),
+
+					"phone_extensions_enabled": schema.BoolAttribute{
+						Optional: true,
+						Computed: true,
+
+						Default: booldefault.StaticBool(false),
+					},
+				},
+
+				Blocks: map[string]schema.Block{
+
+					"pairing": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"max_allowed_devices": schema.Int64Attribute{
+									Optional: true,
+									Computed: true,
+
+									Default: int64default.StaticInt64(5),
+								},
+
+								"pairing_key_format": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+
+					"lockout": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"failure_count": schema.Int64Attribute{
+									Required: true,
+								},
+
+								"duration_seconds": schema.Int64Attribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+
+					"authentication": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"device_selection": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var d diag.Diagnostics
+				var priorStateData mFASettingsResourceModelV0
+
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorStateData)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				lockout, d := priorStateData.schemaUpgradeLockoutV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				pairing, d := priorStateData.schemaUpgradePairingV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				phoneExtentions, d := priorStateData.schemaUpgradePhoneExtensionsV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				upgradedStateData := mFASettingsResourceModelV1{
+					EnvironmentId:   priorStateData.EnvironmentId,
+					Lockout:         lockout,
+					Pairing:         pairing,
+					PhoneExtensions: phoneExtentions,
+					Users:           types.ObjectNull(MFASettingsUsersTFObjectTypes),
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
+			},
+		},
+	}
+}
+
+func (p *mFASettingsResourceModelV0) schemaUpgradeLockoutV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := MFASettingsLockoutTFObjectTypes
+	planAttribute := p.Lockout
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []mFASettingsLockoutResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *mFASettingsResourceModelV0) schemaUpgradePairingV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := MFASettingsPairingTFObjectTypes
+	planAttribute := p.Pairing
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []mFASettingsPairingResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *mFASettingsResourceModelV0) schemaUpgradePhoneExtensionsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := MFASettingsPhoneExtensionsTFObjectTypes
+	planAttribute := p.PhoneExtensionsEnabled
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		upgradedStateData := mFASettingsPhoneExtensionsResourceModelV1{
+			Enabled: planAttribute,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}

--- a/internal/service/mfa/resource_mfa_settings_schema_upgrade_0_to_1.go
+++ b/internal/service/mfa/resource_mfa_settings_schema_upgrade_0_to_1.go
@@ -27,6 +27,8 @@ type mFASettingsLockoutResourceModelV0 mFASettingsLockoutResourceModelV1
 type mFASettingsPairingResourceModelV0 mFASettingsPairingResourceModelV1
 
 func (r *MFASettingsResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+
+	const pairingMaxAllowedDevicesDescription = 5
 	return map[int64]resource.StateUpgrader{
 		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
 		0: {
@@ -55,7 +57,7 @@ func (r *MFASettingsResource) UpgradeState(ctx context.Context) map[int64]resour
 									Optional: true,
 									Computed: true,
 
-									Default: int64default.StaticInt64(5),
+									Default: int64default.StaticInt64(pairingMaxAllowedDevicesDescription),
 								},
 
 								"pairing_key_format": schema.StringAttribute{


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_mfa_settings` state upgrader v0 to v1

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccMFASettings_ github.com/pingidentity/terraform-provider-pingone/internal/service/mfa
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccMFASettings_RemovalDrift
=== PAUSE TestAccMFASettings_RemovalDrift
=== RUN   TestAccMFASettings_Full
=== PAUSE TestAccMFASettings_Full
=== RUN   TestAccMFASettings_Minimal
=== PAUSE TestAccMFASettings_Minimal
=== RUN   TestAccMFASettings_Change
=== PAUSE TestAccMFASettings_Change
=== RUN   TestAccMFASettings_BadParameters
=== PAUSE TestAccMFASettings_BadParameters
=== CONT  TestAccMFASettings_RemovalDrift
=== CONT  TestAccMFASettings_Change
=== CONT  TestAccMFASettings_BadParameters
=== CONT  TestAccMFASettings_Minimal
=== CONT  TestAccMFASettings_Full
--- PASS: TestAccMFASettings_Full (42.55s)
--- PASS: TestAccMFASettings_BadParameters (42.56s)
--- PASS: TestAccMFASettings_Minimal (47.78s)
--- PASS: TestAccMFASettings_RemovalDrift (53.52s)
--- PASS: TestAccMFASettings_Change (55.05s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 56.728s
```

</details>