### PR TITLE
`resource/pingone_notification_settings_email` state upgrader v0 to v1

### DIFF
--- a/internal/service/base/resource_notification_settings.go
+++ b/internal/service/base/resource_notification_settings.go
@@ -493,7 +493,7 @@ func (p *NotificationSettingsResourceModel) expand(ctx context.Context) (*manage
 	}
 
 	if !p.From.IsNull() && !p.From.IsUnknown() {
-		var plan EmailSourceModel
+		var plan emailSourceModelV1
 		diags.Append(p.From.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -513,7 +513,7 @@ func (p *NotificationSettingsResourceModel) expand(ctx context.Context) (*manage
 	}
 
 	if !p.ReplyTo.IsNull() && !p.ReplyTo.IsUnknown() {
-		var plan EmailSourceModel
+		var plan emailSourceModelV1
 		diags.Append(p.ReplyTo.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,

--- a/internal/service/base/resource_notification_settings_email.go
+++ b/internal/service/base/resource_notification_settings_email.go
@@ -79,7 +79,7 @@ func (r *NotificationSettingsEmailResource) Schema(ctx context.Context, req reso
 	resp.Schema = schema.Schema{
 
 		Version: 1,
-		
+
 		// This description is used by the documentation generator and the language server.
 		Description: "Resource to manage the email sender settings in a PingOne environment.",
 

--- a/internal/service/base/resource_notification_settings_email.go
+++ b/internal/service/base/resource_notification_settings_email.go
@@ -25,7 +25,7 @@ import (
 // Types
 type NotificationSettingsEmailResource serviceClientType
 
-type NotificationSettingsEmailResourceModel struct {
+type notificationSettingsEmailResourceModelV1 struct {
 	Id            pingonetypes.ResourceIDValue `tfsdk:"id"`
 	EnvironmentId pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
 	Host          types.String                 `tfsdk:"host"`
@@ -37,7 +37,7 @@ type NotificationSettingsEmailResourceModel struct {
 	ReplyTo       types.Object                 `tfsdk:"reply_to"`
 }
 
-type EmailSourceModel struct {
+type emailSourceModelV1 struct {
 	Name         types.String `tfsdk:"name"`
 	EmailAddress types.String `tfsdk:"email_address"`
 }
@@ -77,6 +77,9 @@ func (r *NotificationSettingsEmailResource) Schema(ctx context.Context, req reso
 	)
 
 	resp.Schema = schema.Schema{
+
+		Version: 1,
+		
 		// This description is used by the documentation generator and the language server.
 		Description: "Resource to manage the email sender settings in a PingOne environment.",
 
@@ -194,7 +197,7 @@ func (r *NotificationSettingsEmailResource) Configure(ctx context.Context, req r
 }
 
 func (r *NotificationSettingsEmailResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan, state NotificationSettingsEmailResourceModel
+	var plan, state notificationSettingsEmailResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -243,7 +246,7 @@ func (r *NotificationSettingsEmailResource) Create(ctx context.Context, req reso
 }
 
 func (r *NotificationSettingsEmailResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *NotificationSettingsEmailResourceModel
+	var data *notificationSettingsEmailResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -288,7 +291,7 @@ func (r *NotificationSettingsEmailResource) Read(ctx context.Context, req resour
 }
 
 func (r *NotificationSettingsEmailResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state NotificationSettingsEmailResourceModel
+	var plan, state notificationSettingsEmailResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -337,7 +340,7 @@ func (r *NotificationSettingsEmailResource) Update(ctx context.Context, req reso
 }
 
 func (r *NotificationSettingsEmailResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data *NotificationSettingsEmailResourceModel
+	var data *notificationSettingsEmailResourceModelV1
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -393,7 +396,7 @@ func (r *NotificationSettingsEmailResource) ImportState(ctx context.Context, req
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), attributes["environment_id"])...)
 }
 
-func (p *NotificationSettingsEmailResourceModel) expand(ctx context.Context) (*management.NotificationsSettingsEmailDeliverySettings, diag.Diagnostics) {
+func (p *notificationSettingsEmailResourceModelV1) expand(ctx context.Context) (*management.NotificationsSettingsEmailDeliverySettings, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	data := management.NewNotificationsSettingsEmailDeliverySettings()
@@ -415,7 +418,7 @@ func (p *NotificationSettingsEmailResourceModel) expand(ctx context.Context) (*m
 	}
 
 	if !p.From.IsNull() && !p.From.IsUnknown() {
-		var plan EmailSourceModel
+		var plan emailSourceModelV1
 		d := p.From.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -432,7 +435,7 @@ func (p *NotificationSettingsEmailResourceModel) expand(ctx context.Context) (*m
 	}
 
 	if !p.ReplyTo.IsNull() && !p.ReplyTo.IsUnknown() {
-		var plan EmailSourceModel
+		var plan emailSourceModelV1
 		d := p.ReplyTo.As(ctx, &plan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -455,7 +458,7 @@ func (p *NotificationSettingsEmailResourceModel) expand(ctx context.Context) (*m
 	return data, diags
 }
 
-func (p *NotificationSettingsEmailResourceModel) toState(apiObject *management.NotificationsSettingsEmailDeliverySettings) diag.Diagnostics {
+func (p *notificationSettingsEmailResourceModelV1) toState(apiObject *management.NotificationsSettingsEmailDeliverySettings) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if apiObject == nil {

--- a/internal/service/base/resource_notification_settings_email_schema_upgrade_0_to_1.go
+++ b/internal/service/base/resource_notification_settings_email_schema_upgrade_0_to_1.go
@@ -1,0 +1,159 @@
+package base
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
+)
+
+type notificationSettingsEmailResourceModelV0 struct {
+	Id            pingonetypes.ResourceIDValue `tfsdk:"id"`
+	EnvironmentId pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
+	Host          types.String                 `tfsdk:"host"`
+	Port          types.Int64                  `tfsdk:"port"`
+	Protocol      types.String                 `tfsdk:"protocol"`
+	Username      types.String                 `tfsdk:"username"`
+	Password      types.String                 `tfsdk:"password"`
+	From          types.List                   `tfsdk:"from"`
+	ReplyTo       types.List                   `tfsdk:"reply_to"`
+}
+
+type emailSourceModelV0 emailSourceModelV1
+
+func (r *NotificationSettingsEmailResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": framework.Attr_ID(),
+
+					"environment_id": framework.Attr_LinkID(
+						framework.SchemaAttributeDescriptionFromMarkdown(""),
+					),
+
+					"host": schema.StringAttribute{
+						Required: true,
+					},
+
+					"port": schema.Int64Attribute{
+						Required: true,
+					},
+
+					"protocol": schema.StringAttribute{
+						Computed: true,
+					},
+
+					"username": schema.StringAttribute{
+						Required: true,
+					},
+
+					"password": schema.StringAttribute{
+						Required:  true,
+						Sensitive: true,
+					},
+				},
+
+				Blocks: map[string]schema.Block{
+					"from": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									Optional: true,
+								},
+								"email_address": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+					"reply_to": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"name": schema.StringAttribute{
+									Optional: true,
+								},
+								"email_address": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var d diag.Diagnostics
+				var priorStateData notificationSettingsEmailResourceModelV0
+
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorStateData)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				from, d := priorStateData.schemaUpgradeFromV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				replyTo, d := priorStateData.schemaUpgradeReplyToV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				upgradedStateData := notificationSettingsEmailResourceModelV1{
+					Id:            priorStateData.Id,
+					EnvironmentId: priorStateData.EnvironmentId,
+					Host:          priorStateData.Host,
+					Port:          priorStateData.Port,
+					Protocol:      priorStateData.Protocol,
+					Username:      priorStateData.Username,
+					Password:      priorStateData.Password,
+					From:          from,
+					ReplyTo:       replyTo,
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
+			},
+		},
+	}
+}
+
+func (p *notificationSettingsEmailResourceModelV0) schemaUpgradeEmailSourceV0toV1(ctx context.Context, planAttribute types.List) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := emailSourceTFObjectTypes
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []emailSourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *notificationSettingsEmailResourceModelV0) schemaUpgradeFromV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return p.schemaUpgradeEmailSourceV0toV1(ctx, p.From)
+}
+
+func (p *notificationSettingsEmailResourceModelV0) schemaUpgradeReplyToV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return p.schemaUpgradeEmailSourceV0toV1(ctx, p.ReplyTo)
+}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_notification_settings_email` state upgrader v0 to v1

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a
<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccNotificationSettingsEmail_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccNotificationSettingsEmail_RemovalDrift
=== PAUSE TestAccNotificationSettingsEmail_RemovalDrift
=== RUN   TestAccNotificationSettingsEmail_Full
=== PAUSE TestAccNotificationSettingsEmail_Full
=== RUN   TestAccNotificationSettingsEmail_EmailSources
=== PAUSE TestAccNotificationSettingsEmail_EmailSources
=== RUN   TestAccNotificationSettingsEmail_BadParameters
=== PAUSE TestAccNotificationSettingsEmail_BadParameters
=== CONT  TestAccNotificationSettingsEmail_RemovalDrift
=== CONT  TestAccNotificationSettingsEmail_Full
=== CONT  TestAccNotificationSettingsEmail_EmailSources
=== CONT  TestAccNotificationSettingsEmail_BadParameters
--- PASS: TestAccNotificationSettingsEmail_RemovalDrift (40.22s)
--- PASS: TestAccNotificationSettingsEmail_Full (42.37s)
--- PASS: TestAccNotificationSettingsEmail_BadParameters (42.79s)
--- PASS: TestAccNotificationSettingsEmail_EmailSources (257.85s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        260.216s
```

</details>