### PR TITLE
`resource/pingone_notification_template_content` schema upgrader v0 to v1

### DIFF
--- a/internal/service/base/resource_notification_template_content.go
+++ b/internal/service/base/resource_notification_template_content.go
@@ -32,7 +32,7 @@ import (
 // Types
 type NotificationTemplateContentResource serviceClientType
 
-type NotificationTemplateContentResourceModel struct {
+type notificationTemplateContentResourceModelV1 struct {
 	Id            pingonetypes.ResourceIDValue `tfsdk:"id"`
 	EnvironmentId pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
 	TemplateName  types.String                 `tfsdk:"template_name"`
@@ -45,7 +45,7 @@ type NotificationTemplateContentResourceModel struct {
 	Voice         types.Object                 `tfsdk:"voice"`
 }
 
-type NotificationTemplateContentEmailResourceModel struct {
+type notificationTemplateContentEmailResourceModelV1 struct {
 	Body         types.String `tfsdk:"body"`
 	From         types.Object `tfsdk:"from"`
 	Subject      types.String `tfsdk:"subject"`
@@ -54,23 +54,23 @@ type NotificationTemplateContentEmailResourceModel struct {
 	ContentType  types.String `tfsdk:"content_type"`
 }
 
-type NotificationTemplateContentEmailAddressResourceModel struct {
+type notificationTemplateContentEmailAddressResourceModelV1 struct {
 	Name    types.String `tfsdk:"name"`
 	Address types.String `tfsdk:"address"`
 }
 
-type NotificationTemplateContentPushResourceModel struct {
+type notificationTemplateContentPushResourceModelV1 struct {
 	Category types.String `tfsdk:"category"`
 	Body     types.String `tfsdk:"body"`
 	Title    types.String `tfsdk:"title"`
 }
 
-type NotificationTemplateContentSmsResourceModel struct {
+type notificationTemplateContentSmsResourceModelV1 struct {
 	Content types.String `tfsdk:"content"`
 	Sender  types.String `tfsdk:"sender"`
 }
 
-type NotificationTemplateContentVoiceResourceModel struct {
+type notificationTemplateContentVoiceResourceModelV1 struct {
 	Content types.String `tfsdk:"content"`
 	Type    types.String `tfsdk:"type"`
 }
@@ -227,6 +227,9 @@ func (r *NotificationTemplateContentResource) Schema(ctx context.Context, req re
 	)
 
 	resp.Schema = schema.Schema{
+
+		Version: 1,
+
 		// This description is used by the documentation generator and the language server.
 		Description: "Resource to create and manage PingOne notification template contents for push, SMS, email and voice notifications in an environment.",
 
@@ -554,7 +557,7 @@ func (r *NotificationTemplateContentResource) Configure(ctx context.Context, req
 }
 
 func (r *NotificationTemplateContentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan, state NotificationTemplateContentResourceModel
+	var plan, state notificationTemplateContentResourceModelV1
 
 	if r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -603,7 +606,7 @@ func (r *NotificationTemplateContentResource) Create(ctx context.Context, req re
 }
 
 func (r *NotificationTemplateContentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *NotificationTemplateContentResourceModel
+	var data *notificationTemplateContentResourceModelV1
 
 	if r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -648,7 +651,7 @@ func (r *NotificationTemplateContentResource) Read(ctx context.Context, req reso
 }
 
 func (r *NotificationTemplateContentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan, state NotificationTemplateContentResourceModel
+	var plan, state notificationTemplateContentResourceModelV1
 
 	if r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -697,7 +700,7 @@ func (r *NotificationTemplateContentResource) Update(ctx context.Context, req re
 }
 
 func (r *NotificationTemplateContentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data *NotificationTemplateContentResourceModel
+	var data *notificationTemplateContentResourceModelV1
 
 	if r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -817,14 +820,14 @@ func notificationTemplateCustomWriteError(error model.P1Error) diag.Diagnostics 
 	return nil
 }
 
-func (p *NotificationTemplateContentResourceModel) expand(ctx context.Context) (*management.TemplateContent, diag.Diagnostics) {
+func (p *notificationTemplateContentResourceModelV1) expand(ctx context.Context) (*management.TemplateContent, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	data := management.TemplateContent{}
 
 	if !p.Email.IsNull() && !p.Email.IsUnknown() {
 
-		var providerPlan NotificationTemplateContentEmailResourceModel
+		var providerPlan notificationTemplateContentEmailResourceModelV1
 		diags.Append(p.Email.As(ctx, &providerPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -845,7 +848,7 @@ func (p *NotificationTemplateContentResourceModel) expand(ctx context.Context) (
 
 		// Email specific
 		if !providerPlan.From.IsNull() && !providerPlan.From.IsUnknown() {
-			var fromPlan NotificationTemplateContentEmailAddressResourceModel
+			var fromPlan notificationTemplateContentEmailAddressResourceModelV1
 			diags.Append(providerPlan.From.As(ctx, &fromPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
 				UnhandledUnknownAsEmpty: false,
@@ -864,7 +867,7 @@ func (p *NotificationTemplateContentResourceModel) expand(ctx context.Context) (
 		}
 
 		if !providerPlan.ReplyTo.IsNull() && !providerPlan.ReplyTo.IsUnknown() {
-			var replyToPlan NotificationTemplateContentEmailAddressResourceModel
+			var replyToPlan notificationTemplateContentEmailAddressResourceModelV1
 			diags.Append(providerPlan.ReplyTo.As(ctx, &replyToPlan, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,
 				UnhandledUnknownAsEmpty: false,
@@ -891,7 +894,7 @@ func (p *NotificationTemplateContentResourceModel) expand(ctx context.Context) (
 
 	if !p.Push.IsNull() && !p.Push.IsUnknown() {
 
-		var providerPlan NotificationTemplateContentPushResourceModel
+		var providerPlan notificationTemplateContentPushResourceModelV1
 		diags.Append(p.Push.As(ctx, &providerPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -921,7 +924,7 @@ func (p *NotificationTemplateContentResourceModel) expand(ctx context.Context) (
 
 	if !p.Sms.IsNull() && !p.Sms.IsUnknown() {
 
-		var providerPlan NotificationTemplateContentSmsResourceModel
+		var providerPlan notificationTemplateContentSmsResourceModelV1
 		diags.Append(p.Sms.As(ctx, &providerPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -950,7 +953,7 @@ func (p *NotificationTemplateContentResourceModel) expand(ctx context.Context) (
 
 	if !p.Voice.IsNull() && !p.Voice.IsUnknown() {
 
-		var providerPlan NotificationTemplateContentVoiceResourceModel
+		var providerPlan notificationTemplateContentVoiceResourceModelV1
 		diags.Append(p.Voice.As(ctx, &providerPlan, basetypes.ObjectAsOptions{
 			UnhandledNullAsEmpty:    false,
 			UnhandledUnknownAsEmpty: false,
@@ -980,7 +983,7 @@ func (p *NotificationTemplateContentResourceModel) expand(ctx context.Context) (
 	return &data, diags
 }
 
-func (p *NotificationTemplateContentEmailAddressResourceModel) expandFrom() *management.TemplateContentEmailAllOfFrom {
+func (p *notificationTemplateContentEmailAddressResourceModelV1) expandFrom() *management.TemplateContentEmailAllOfFrom {
 
 	data := management.NewTemplateContentEmailAllOfFrom()
 
@@ -995,7 +998,7 @@ func (p *NotificationTemplateContentEmailAddressResourceModel) expandFrom() *man
 	return data
 }
 
-func (p *NotificationTemplateContentEmailAddressResourceModel) expandReplyTo() *management.TemplateContentEmailAllOfReplyTo {
+func (p *notificationTemplateContentEmailAddressResourceModelV1) expandReplyTo() *management.TemplateContentEmailAllOfReplyTo {
 
 	data := management.NewTemplateContentEmailAllOfReplyTo()
 
@@ -1010,7 +1013,7 @@ func (p *NotificationTemplateContentEmailAddressResourceModel) expandReplyTo() *
 	return data
 }
 
-func (p *NotificationTemplateContentResourceModel) toState(apiObject *management.TemplateContent) diag.Diagnostics {
+func (p *notificationTemplateContentResourceModelV1) toState(apiObject *management.TemplateContent) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if apiObject == nil {

--- a/internal/service/base/resource_notification_template_content_schema_upgrade_0_to_1.go
+++ b/internal/service/base/resource_notification_template_content_schema_upgrade_0_to_1.go
@@ -1,0 +1,409 @@
+package base
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/patrickcping/pingone-go-sdk-v2/management"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
+)
+
+type notificationTemplateContentResourceModelV0 struct {
+	Id            pingonetypes.ResourceIDValue `tfsdk:"id"`
+	EnvironmentId pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
+	TemplateName  types.String                 `tfsdk:"template_name"`
+	Locale        types.String                 `tfsdk:"locale"`
+	Default       types.Bool                   `tfsdk:"default"`
+	Variant       types.String                 `tfsdk:"variant"`
+	Email         types.List                   `tfsdk:"email"`
+	Push          types.List                   `tfsdk:"push"`
+	Sms           types.List                   `tfsdk:"sms"`
+	Voice         types.List                   `tfsdk:"voice"`
+}
+
+type notificationTemplateContentEmailResourceModelV0 struct {
+	Body         types.String `tfsdk:"body"`
+	From         types.List   `tfsdk:"from"`
+	Subject      types.String `tfsdk:"subject"`
+	ReplyTo      types.List   `tfsdk:"reply_to"`
+	CharacterSet types.String `tfsdk:"character_set"`
+	ContentType  types.String `tfsdk:"content_type"`
+}
+
+type notificationTemplateContentEmailAddressResourceModelV0 notificationTemplateContentEmailAddressResourceModelV1
+
+type notificationTemplateContentPushResourceModelV0 notificationTemplateContentPushResourceModelV1
+
+type notificationTemplateContentSmsResourceModelV0 notificationTemplateContentSmsResourceModelV1
+
+type notificationTemplateContentVoiceResourceModelV0 notificationTemplateContentVoiceResourceModelV1
+
+func (r *NotificationTemplateContentResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		// State upgrade implementation from 0 (prior state version) to 1 (Schema.Version)
+		0: {
+			PriorSchema: &schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"id": framework.Attr_ID(),
+
+					"environment_id": framework.Attr_LinkID(
+						framework.SchemaAttributeDescriptionFromMarkdown(""),
+					),
+
+					"template_name": schema.StringAttribute{
+						Required: true,
+					},
+
+					"locale": schema.StringAttribute{
+						Required: true,
+					},
+
+					"default": schema.BoolAttribute{
+						Computed: true,
+					},
+
+					"variant": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+
+				Blocks: map[string]schema.Block{
+					"email": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"body": schema.StringAttribute{
+									Required: true,
+								},
+
+								"subject": schema.StringAttribute{
+									Required: true,
+								},
+
+								"character_set": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString("UTF-8"),
+								},
+
+								"content_type": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString("text/html"),
+								},
+							},
+
+							Blocks: map[string]schema.Block{
+								"from": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"name": schema.StringAttribute{
+												Optional: true,
+												Computed: true,
+
+												Default: stringdefault.StaticString("PingOne"),
+											},
+
+											"address": schema.StringAttribute{
+												Optional: true,
+												Computed: true,
+
+												Default: stringdefault.StaticString("noreply@pingidentity.com"),
+											},
+										},
+									},
+								},
+
+								"reply_to": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"name": schema.StringAttribute{
+												Optional: true,
+												Computed: true,
+											},
+
+											"address": schema.StringAttribute{
+												Optional: true,
+												Computed: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+
+					"push": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"category": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString(string(management.ENUMTEMPLATECONTENTPUSHCATEGORY_BANNER_BUTTONS)),
+								},
+
+								"body": schema.StringAttribute{
+									Required: true,
+								},
+
+								"title": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+
+					"sms": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"content": schema.StringAttribute{
+									Required: true,
+								},
+
+								"sender": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+
+					"voice": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"content": schema.StringAttribute{
+									Required: true,
+								},
+
+								"type": schema.StringAttribute{
+									Optional: true,
+									Computed: true,
+
+									Default: stringdefault.StaticString("Alice"),
+								},
+							},
+						},
+					},
+				},
+			},
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var d diag.Diagnostics
+				var priorStateData notificationTemplateContentResourceModelV0
+
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorStateData)...)
+
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				email, d := priorStateData.schemaUpgradeEmailV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				push, d := priorStateData.schemaUpgradePushV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				sms, d := priorStateData.schemaUpgradeSmsV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				voice, d := priorStateData.schemaUpgradeVoiceV0toV1(ctx)
+				resp.Diagnostics.Append(d...)
+
+				upgradedStateData := notificationTemplateContentResourceModelV1{
+					Id:            priorStateData.Id,
+					EnvironmentId: priorStateData.EnvironmentId,
+					TemplateName:  priorStateData.TemplateName,
+					Locale:        priorStateData.Locale,
+					Default:       priorStateData.Default,
+					Variant:       priorStateData.Variant,
+					Email:         email,
+					Push:          push,
+					Sms:           sms,
+					Voice:         voice,
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
+			},
+		},
+	}
+}
+
+func (p *notificationTemplateContentResourceModelV0) schemaUpgradeEmailV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := notificationTemplateContentEmailTFObjectTypes
+	planAttribute := p.Email
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []notificationTemplateContentEmailResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		from, d := priorStateData[0].schemaUpgradeFromV0toV1(ctx)
+		diags.Append(d...)
+
+		replyTo, d := priorStateData[0].schemaUpgradeReplyToV0toV1(ctx)
+		diags.Append(d...)
+
+		upgradedStateData := notificationTemplateContentEmailResourceModelV1{
+			Body:         priorStateData[0].Body,
+			From:         from,
+			Subject:      priorStateData[0].Subject,
+			ReplyTo:      replyTo,
+			CharacterSet: priorStateData[0].CharacterSet,
+			ContentType:  priorStateData[0].ContentType,
+		}
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *notificationTemplateContentEmailResourceModelV0) schemaUpgradeEmailAddressV0toV1(ctx context.Context, planAttribute types.List) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := notificationTemplateContentEmailAddressTFObjectTypes
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []notificationTemplateContentEmailAddressResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *notificationTemplateContentEmailResourceModelV0) schemaUpgradeFromV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return p.schemaUpgradeEmailAddressV0toV1(ctx, p.From)
+}
+
+func (p *notificationTemplateContentEmailResourceModelV0) schemaUpgradeReplyToV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	return p.schemaUpgradeEmailAddressV0toV1(ctx, p.ReplyTo)
+}
+
+func (p *notificationTemplateContentResourceModelV0) schemaUpgradePushV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := notificationTemplateContentPushTFObjectTypes
+	planAttribute := p.Push
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []notificationTemplateContentPushResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *notificationTemplateContentResourceModelV0) schemaUpgradeSmsV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := notificationTemplateContentSmsTFObjectTypes
+	planAttribute := p.Sms
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []notificationTemplateContentSmsResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}
+
+func (p *notificationTemplateContentResourceModelV0) schemaUpgradeVoiceV0toV1(ctx context.Context) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := notificationTemplateContentVoiceTFObjectTypes
+	planAttribute := p.Voice
+
+	if planAttribute.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	} else if planAttribute.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	} else {
+		var priorStateData []notificationTemplateContentVoiceResourceModelV0
+		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		if len(priorStateData) == 0 {
+			return types.ObjectNull(attributeTypes), diags
+		}
+
+		upgradedStateData := priorStateData[0]
+
+		returnVar, d := types.ObjectValueFrom(ctx, attributeTypes, upgradedStateData)
+		diags.Append(d...)
+
+		return returnVar, diags
+	}
+}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_notification_template_content` schema upgrader v0 to v1

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccNotificationTemplateContent_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccNotificationTemplateContent_RemovalDrift
=== PAUSE TestAccNotificationTemplateContent_RemovalDrift
=== RUN   TestAccNotificationTemplateContent_OverrideDefaultLocale
=== PAUSE TestAccNotificationTemplateContent_OverrideDefaultLocale
=== RUN   TestAccNotificationTemplateContent_NewLocale
=== PAUSE TestAccNotificationTemplateContent_NewLocale
=== RUN   TestAccNotificationTemplateContent_NewVariant
=== PAUSE TestAccNotificationTemplateContent_NewVariant
=== RUN   TestAccNotificationTemplateContent_ChangeVariant
=== PAUSE TestAccNotificationTemplateContent_ChangeVariant
=== RUN   TestAccNotificationTemplateContent_InvalidData
=== PAUSE TestAccNotificationTemplateContent_InvalidData
=== RUN   TestAccNotificationTemplateContent_Email
=== PAUSE TestAccNotificationTemplateContent_Email
=== RUN   TestAccNotificationTemplateContent_Push
=== PAUSE TestAccNotificationTemplateContent_Push
=== RUN   TestAccNotificationTemplateContent_SMS
=== PAUSE TestAccNotificationTemplateContent_SMS
=== RUN   TestAccNotificationTemplateContent_Voice
=== PAUSE TestAccNotificationTemplateContent_Voice
=== RUN   TestAccNotificationTemplateContent_BadParameters
=== PAUSE TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_RemovalDrift
=== CONT  TestAccNotificationTemplateContent_Email
=== CONT  TestAccNotificationTemplateContent_NewVariant
=== CONT  TestAccNotificationTemplateContent_NewLocale
=== CONT  TestAccNotificationTemplateContent_InvalidData
=== CONT  TestAccNotificationTemplateContent_ChangeVariant
=== CONT  TestAccNotificationTemplateContent_BadParameters
=== CONT  TestAccNotificationTemplateContent_OverrideDefaultLocale
=== CONT  TestAccNotificationTemplateContent_SMS
=== CONT  TestAccNotificationTemplateContent_Push
=== CONT  TestAccNotificationTemplateContent_Voice
--- PASS: TestAccNotificationTemplateContent_InvalidData (39.28s)
--- PASS: TestAccNotificationTemplateContent_BadParameters (44.69s)
--- PASS: TestAccNotificationTemplateContent_RemovalDrift (55.67s)
--- PASS: TestAccNotificationTemplateContent_NewVariant (87.98s)
--- PASS: TestAccNotificationTemplateContent_OverrideDefaultLocale (88.58s)
--- PASS: TestAccNotificationTemplateContent_ChangeVariant (103.90s)
--- PASS: TestAccNotificationTemplateContent_NewLocale (128.32s)
--- PASS: TestAccNotificationTemplateContent_Email (145.01s)
--- PASS: TestAccNotificationTemplateContent_Voice (184.69s)
--- PASS: TestAccNotificationTemplateContent_Push (184.71s)
--- PASS: TestAccNotificationTemplateContent_SMS (185.25s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        186.902s
```

</details>