### PR TITLE
`resource/pingone_agreement_localization_revision`: Add buffer time to the revision effective date to avoid blocking error

### DIFF
--- a/.changelog/883.txt
+++ b/.changelog/883.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_agreement_localization_revision`: Fixed intermittent "The revision can not take effect in the past" error when leaving `effective_at` blank.
+```

--- a/internal/service/base/resource_agreement_localization_revision.go
+++ b/internal/service/base/resource_agreement_localization_revision.go
@@ -430,7 +430,7 @@ func (p *AgreementLocalizationRevisionResourceModel) expand() (*management.Agree
 		t, d = p.EffectiveAt.ValueRFC3339Time()
 		diags.Append(d...)
 	} else {
-		t = time.Now().Local()
+		t = time.Now().Local().Add(time.Minute * 10)
 	}
 	if diags.HasError() {
 		return nil, diags

--- a/internal/service/base/resource_agreement_localization_revision.go
+++ b/internal/service/base/resource_agreement_localization_revision.go
@@ -430,7 +430,8 @@ func (p *AgreementLocalizationRevisionResourceModel) expand() (*management.Agree
 		t, d = p.EffectiveAt.ValueRFC3339Time()
 		diags.Append(d...)
 	} else {
-		t = time.Now().Local().Add(time.Minute * 10)
+		bufferTimeMins := 10 * time.Minute
+		t = time.Now().Local().Add(bufferTimeMins)
 	}
 	if diags.HasError() {
 		return nil, diags


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_agreement_localization_revision`: Add buffer time to the revision effective date to avoid blocking error
- **Bug** Fixed intermittent "The revision can not take effect in the past" error when leaving `effective_at` blank.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a
<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccAgreementLocalizationRevision_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccAgreementLocalizationRevision_RemovalDrift
=== PAUSE TestAccAgreementLocalizationRevision_RemovalDrift
=== RUN   TestAccAgreementLocalizationRevision_Full
=== PAUSE TestAccAgreementLocalizationRevision_Full
=== RUN   TestAccAgreementLocalizationRevision_BadParameters
=== PAUSE TestAccAgreementLocalizationRevision_BadParameters
=== CONT  TestAccAgreementLocalizationRevision_RemovalDrift
=== CONT  TestAccAgreementLocalizationRevision_BadParameters
=== CONT  TestAccAgreementLocalizationRevision_Full
--- PASS: TestAccAgreementLocalizationRevision_BadParameters (42.70s)
--- PASS: TestAccAgreementLocalizationRevision_RemovalDrift (55.67s)
--- PASS: TestAccAgreementLocalizationRevision_Full (136.15s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        137.757s
```

</details>