### PR TITLE
`resource/pingone_language_update`: Add retry condition for language enabled race condition

### DIFF
--- a/.changelog/884.txt
+++ b/.changelog/884.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_language_update`: Fixed "The language must be enabled before it is set as the default" error when setting a language as enabled and the environment default.
+```

--- a/internal/service/base/resource_language_update.go
+++ b/internal/service/base/resource_language_update.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
@@ -293,19 +295,80 @@ func updateLanguageEnabledDefaultSequence(ctx context.Context, apiClient *manage
 		errorFunction = sdk.CustomErrorResourceNotFoundWarning
 	}
 
-	response, d := sdk.ParseResponse(
-		ctx,
+	var response interface{}
 
-		func() (any, *http.Response, error) {
-			fO, fR, fErr := apiClient.LanguagesApi.UpdateLanguage(ctx, environmentID, languageID).Language(language).Execute()
-			return framework.CheckEnvironmentExistsOnPermissionsError(ctx, apiClient, environmentID, fO, fR, fErr)
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			"false",
 		},
-		"UpdateLanguage-UpdateSequence1",
-		errorFunction,
-		nil,
-	)
-	diags = append(diags, d...)
-	if diags.HasError() {
+		Target: []string{
+			"true",
+			"err",
+		},
+		Refresh: func() (interface{}, string, error) {
+
+			// Run the API call
+			responseCreate, d := sdk.ParseResponse(
+				ctx,
+
+				func() (any, *http.Response, error) {
+					fO, fR, fErr := apiClient.LanguagesApi.UpdateLanguage(ctx, environmentID, languageID).Language(language).Execute()
+					return framework.CheckEnvironmentExistsOnPermissionsError(ctx, apiClient, environmentID, fO, fR, fErr)
+				},
+				"UpdateLanguage-UpdateSequence1",
+				errorFunction,
+				nil,
+			)
+			diags = append(diags, d...)
+			if diags.HasError() {
+				return nil, "err", fmt.Errorf("Error reading language")
+			}
+
+			if responseCreate == nil {
+				return nil, "err", fmt.Errorf("Language not found")
+			}
+
+			// Run the API call
+			response, d = sdk.ParseResponse(
+				ctx,
+
+				func() (any, *http.Response, error) {
+					fO, fR, fErr := apiClient.LanguagesApi.ReadOneLanguage(ctx, environmentID, languageID).Execute()
+					return framework.CheckEnvironmentExistsOnPermissionsError(ctx, apiClient, environmentID, fO, fR, fErr)
+				},
+				"ReadOneLanguage-UpdateSequence1",
+				errorFunction,
+				nil,
+			)
+			diags = append(diags, d...)
+			if diags.HasError() {
+				return nil, "err", fmt.Errorf("Error reading language")
+			}
+
+			if response == nil {
+				return nil, "err", fmt.Errorf("Language not found")
+			}
+
+			if response.(*management.Language).GetEnabled() != enabled {
+				return nil, "false", nil
+			}
+
+			return response, "true", nil
+		},
+		Timeout:                   5 * time.Minute,
+		Delay:                     1 * time.Second,
+		MinTimeout:                1 * time.Second,
+		ContinuousTargetOccurence: 1,
+	}
+	response, err := stateConf.WaitForStateContext(ctx)
+
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot find enable language",
+			Detail:   fmt.Sprintf("The language %s for environment %s cannot be enabled: %s", languageID, environmentID, err),
+		})
+
 		return diags
 	}
 
@@ -313,7 +376,9 @@ func updateLanguageEnabledDefaultSequence(ctx context.Context, apiClient *manage
 		return diags
 	}
 
-	if defaultValue && enabled {
+	languageResponse := response.(*management.Language)
+
+	if defaultValue && languageResponse.Enabled {
 
 		language.SetDefault(true)
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- Add retry condition for language enabled race condition
- **Bug**: Fix "The language must be enabled before it is set as the default" error when setting a language as enabled and the environment default.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccLanguageUpdate_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccLanguageUpdate_RemovalDrift
=== PAUSE TestAccLanguageUpdate_RemovalDrift
=== RUN   TestAccLanguageUpdate_Full
=== PAUSE TestAccLanguageUpdate_Full
=== RUN   TestAccLanguageUpdate_Minimal
=== PAUSE TestAccLanguageUpdate_Minimal
=== RUN   TestAccLanguageUpdate_SystemDefined
=== PAUSE TestAccLanguageUpdate_SystemDefined
=== RUN   TestAccLanguageUpdate_Change
=== PAUSE TestAccLanguageUpdate_Change
=== RUN   TestAccLanguageUpdate_BadParameters
=== PAUSE TestAccLanguageUpdate_BadParameters
=== CONT  TestAccLanguageUpdate_RemovalDrift
=== CONT  TestAccLanguageUpdate_SystemDefined
=== CONT  TestAccLanguageUpdate_Minimal
=== CONT  TestAccLanguageUpdate_BadParameters
=== CONT  TestAccLanguageUpdate_Change
=== CONT  TestAccLanguageUpdate_Full
--- PASS: TestAccLanguageUpdate_Minimal (43.85s)
--- PASS: TestAccLanguageUpdate_RemovalDrift (44.39s)
--- PASS: TestAccLanguageUpdate_Full (45.04s)
--- PASS: TestAccLanguageUpdate_BadParameters (45.88s)
--- PASS: TestAccLanguageUpdate_SystemDefined (67.16s)
--- PASS: TestAccLanguageUpdate_Change (76.50s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        78.167s
```

</details>