### PR TITLE
`resource/pingone_system_application`: Fix system application not found error

### DIFF
--- a/.changelog/885.txt
+++ b/.changelog/885.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_system_application`: Fixed intermittent "Cannot find applications by type" error.
+```

--- a/internal/service/base/resource_system_application.go
+++ b/internal/service/base/resource_system_application.go
@@ -833,7 +833,7 @@ func FetchApplicationsByTypeWithTimeout(ctx context.Context, apiClient *manageme
 			}
 
 			if !found && expectAtLeastOneResult {
-				return nil, "false", fmt.Errorf("No applications found for type %s, but at least one is expected", applicationType)
+				return nil, "false", nil
 			}
 
 			tflog.Debug(ctx, "Find applications by type attempt", map[string]interface{}{


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_system_application`: Fix system application not found error

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a
<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccSystemApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccSystemApplication_RemovalDrift
=== PAUSE TestAccSystemApplication_RemovalDrift
=== RUN   TestAccSystemApplication_NewEnv
=== PAUSE TestAccSystemApplication_NewEnv
=== RUN   TestAccSystemApplication_Portal
=== PAUSE TestAccSystemApplication_Portal
=== RUN   TestAccSystemApplication_SelfService
=== PAUSE TestAccSystemApplication_SelfService
=== RUN   TestAccSystemApplication_BadParameters
=== PAUSE TestAccSystemApplication_BadParameters
=== CONT  TestAccSystemApplication_RemovalDrift
=== CONT  TestAccSystemApplication_SelfService
=== CONT  TestAccSystemApplication_Portal
=== CONT  TestAccSystemApplication_NewEnv
=== CONT  TestAccSystemApplication_BadParameters
--- PASS: TestAccSystemApplication_RemovalDrift (40.78s)
--- PASS: TestAccSystemApplication_NewEnv (41.83s)
--- PASS: TestAccSystemApplication_BadParameters (43.77s)
--- PASS: TestAccSystemApplication_Portal (49.32s)
--- PASS: TestAccSystemApplication_SelfService (52.72s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        54.324s
```

</details>