### PR TITLE
`resource/pingone_population_default`: Suppress warning on creation where the default population for an environment cannot be found

### DIFF
--- a/.changelog/906.txt
+++ b/.changelog/906.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_population_default`: Suppress warning on creation where the default population for an environment cannot be found.
+```

--- a/internal/service/sso/resource_population_default.go
+++ b/internal/service/sso/resource_population_default.go
@@ -485,10 +485,10 @@ func FetchDefaultPopulationWithTimeout(ctx context.Context, apiClient *managemen
 	population, err := stateConf.WaitForStateContext(ctx)
 
 	if err != nil {
-		diags.AddWarning(
-			"Cannot find default population",
-			fmt.Sprintf("The default population for environment %s cannot be found: %s", environmentID, err),
-		)
+		tflog.Warn(ctx, "Cannot find default population for the environment", map[string]interface{}{
+			"environment": environmentID,
+			"err":         err,
+		})
 
 		return nil, diags
 	}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

`resource/pingone_population_default`: Suppress warning on creation where the default population for an environment cannot be found.

It is normal behaviour for a default population to not exist when an environment is created from scratch, the resource simply creates the population if one is not found.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccPopulationDefault_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccPopulationDefault_RemovalDrift
=== PAUSE TestAccPopulationDefault_RemovalDrift
=== RUN   TestAccPopulationDefault_Full
=== PAUSE TestAccPopulationDefault_Full
=== RUN   TestAccPopulationDefault_Minimal
=== PAUSE TestAccPopulationDefault_Minimal
=== RUN   TestAccPopulationDefault_BadParameters
=== PAUSE TestAccPopulationDefault_BadParameters
=== CONT  TestAccPopulationDefault_RemovalDrift
=== CONT  TestAccPopulationDefault_Minimal
=== CONT  TestAccPopulationDefault_Full
=== CONT  TestAccPopulationDefault_BadParameters
--- PASS: TestAccPopulationDefault_RemovalDrift (39.92s)
--- PASS: TestAccPopulationDefault_Minimal (41.47s)
--- PASS: TestAccPopulationDefault_BadParameters (43.07s)
--- PASS: TestAccPopulationDefault_Full (45.32s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/sso 47.873s
```

</details>