### PR TITLE
Change 64 bit data types to 32 bit to align with the API

### DIFF
--- a/internal/framework/int32validator/is_divisible_by.go
+++ b/internal/framework/int32validator/is_divisible_by.go
@@ -1,0 +1,47 @@
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// int32IsDivisibleBy validates if the input string is base64encoded.
+type int32IsDivisibleBy struct {
+	Denominator int32
+}
+
+// Description describes the validation in plain text formatting.
+func (v int32IsDivisibleBy) Description(ctx context.Context) string {
+	return fmt.Sprintf("Ensure the integer is exactly divisible by %d.", v.Denominator)
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v int32IsDivisibleBy) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate runs the main validation logic of the validator, reading configuration data out of `req` and updating `resp` with diagnostics.
+func (v int32IsDivisibleBy) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	// If the value is unknown or null, there is nothing to validate.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	if req.ConfigValue.ValueInt32()%v.Denominator != 0 {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Provided value is not valid",
+			fmt.Sprintf("The value provided %d is not valid.  Ensure that the provided value is exactly divisible by %d.", req.ConfigValue.ValueInt32(), v.Denominator),
+		)
+		return
+	}
+}
+
+// IsDivisibleBy checks if an int32 is exactly divisible by the provided denominator.
+func IsDivisibleBy(denominator int32) validator.Int32 {
+	return &int32IsDivisibleBy{
+		Denominator: denominator,
+	}
+}

--- a/internal/framework/int32validator/is_greater_than_equal_to_path_value.go
+++ b/internal/framework/int32validator/is_greater_than_equal_to_path_value.go
@@ -1,0 +1,83 @@
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// int32IsGreaterThanEqualToPathValue validates if the input string is base64encoded.
+type int32IsGreaterThanEqualToPathValue struct {
+	PathExpression path.Expression
+}
+
+// Description describes the validation in plain text formatting.
+func (v int32IsGreaterThanEqualToPathValue) Description(ctx context.Context) string {
+	return fmt.Sprintf("Ensure the integer is greater than or equal to the values configured at paths that match the following path expression: %v", v.PathExpression)
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v int32IsGreaterThanEqualToPathValue) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate runs the main validation logic of the validator, reading configuration data out of `req` and updating `resp` with diagnostics.
+func (v int32IsGreaterThanEqualToPathValue) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	// If the value is unknown or null, there is nothing to validate.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	matchedPaths, d := req.Config.PathMatches(ctx, v.PathExpression)
+	resp.Diagnostics.Append(d...)
+
+	// Collect all errors
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for _, mp := range matchedPaths {
+		// If the user specifies the same attribute this validator is applied to,
+		// also as part of the input, skip it
+		if mp.Equal(req.Path) {
+			continue
+		}
+
+		var mpVal types.Int32
+		diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Delay validation until all involved attribute have a known value
+		if mpVal.IsUnknown() {
+			return
+		}
+
+		if mpVal.ValueInt32() > req.ConfigValue.ValueInt32() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Provided value is not valid",
+				fmt.Sprintf("The value provided %d is not valid.  Ensure that the provided value is greater than or equal to the value configured at path %v.", req.ConfigValue.ValueInt32(), mp),
+			)
+			continue
+		}
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// IsGreaterThanPathValue checks if an int32 is greater than the value configured in the provided path expression.
+func IsGreaterThanEqualToPathValue(pathExpression path.Expression) validator.Int32 {
+	return &int32IsGreaterThanEqualToPathValue{
+		PathExpression: pathExpression,
+	}
+}

--- a/internal/framework/int32validator/is_greater_than_path_value.go
+++ b/internal/framework/int32validator/is_greater_than_path_value.go
@@ -1,0 +1,83 @@
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// int32IsGreaterThanPathValue validates if the input string is base64encoded.
+type int32IsGreaterThanPathValue struct {
+	PathExpression path.Expression
+}
+
+// Description describes the validation in plain text formatting.
+func (v int32IsGreaterThanPathValue) Description(ctx context.Context) string {
+	return fmt.Sprintf("Ensure the integer is greater than the values configured at paths that match the following path expression: %v", v.PathExpression)
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v int32IsGreaterThanPathValue) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate runs the main validation logic of the validator, reading configuration data out of `req` and updating `resp` with diagnostics.
+func (v int32IsGreaterThanPathValue) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	// If the value is unknown or null, there is nothing to validate.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	matchedPaths, d := req.Config.PathMatches(ctx, v.PathExpression)
+	resp.Diagnostics.Append(d...)
+
+	// Collect all errors
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for _, mp := range matchedPaths {
+		// If the user specifies the same attribute this validator is applied to,
+		// also as part of the input, skip it
+		if mp.Equal(req.Path) {
+			continue
+		}
+
+		var mpVal types.Int32
+		diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Delay validation until all involved attribute have a known value
+		if mpVal.IsUnknown() {
+			return
+		}
+
+		if mpVal.ValueInt32() >= req.ConfigValue.ValueInt32() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Provided value is not valid",
+				fmt.Sprintf("The value provided %d is not valid.  Ensure that the provided value is greater than the value configured at path %v.", req.ConfigValue.ValueInt32(), mp),
+			)
+			continue
+		}
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// IsGreaterThanPathValue checks if an int32 is greater than the value configured in the provided path expression.
+func IsGreaterThanPathValue(pathExpression path.Expression) validator.Int32 {
+	return &int32IsGreaterThanPathValue{
+		PathExpression: pathExpression,
+	}
+}

--- a/internal/framework/int32validator/is_less_than_equal_to_path_value.go
+++ b/internal/framework/int32validator/is_less_than_equal_to_path_value.go
@@ -1,0 +1,83 @@
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// int32IsLessThanEqualToPathValue validates if the input string is base64encoded.
+type int32IsLessThanEqualToPathValue struct {
+	PathExpression path.Expression
+}
+
+// Description describes the validation in plain text formatting.
+func (v int32IsLessThanEqualToPathValue) Description(ctx context.Context) string {
+	return fmt.Sprintf("Ensure the integer is less than or equal to the values configured at paths that match the following path expression: %v", v.PathExpression)
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v int32IsLessThanEqualToPathValue) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate runs the main validation logic of the validator, reading configuration data out of `req` and updating `resp` with diagnostics.
+func (v int32IsLessThanEqualToPathValue) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	// If the value is unknown or null, there is nothing to validate.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	matchedPaths, d := req.Config.PathMatches(ctx, v.PathExpression)
+	resp.Diagnostics.Append(d...)
+
+	// Collect all errors
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for _, mp := range matchedPaths {
+		// If the user specifies the same attribute this validator is applied to,
+		// also as part of the input, skip it
+		if mp.Equal(req.Path) {
+			continue
+		}
+
+		var mpVal types.Int32
+		diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Delay validation until all involved attribute have a known value
+		if mpVal.IsUnknown() {
+			return
+		}
+
+		if mpVal.ValueInt32() < req.ConfigValue.ValueInt32() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Provided value is not valid",
+				fmt.Sprintf("The value provided %d is not valid.  Ensure that the provided value is less than or equal to the value configured at path %v.", req.ConfigValue.ValueInt32(), mp),
+			)
+			continue
+		}
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// IsLessThanPathValue checks if an int32 is greater than the value configured in the provided path expression.
+func IsLessThanEqualToPathValue(pathExpression path.Expression) validator.Int32 {
+	return &int32IsLessThanEqualToPathValue{
+		PathExpression: pathExpression,
+	}
+}

--- a/internal/framework/int32validator/is_less_than_path_value.go
+++ b/internal/framework/int32validator/is_less_than_path_value.go
@@ -1,0 +1,83 @@
+package int32validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// int32IsLessThanPathValue validates if the input string is base64encoded.
+type int32IsLessThanPathValue struct {
+	PathExpression path.Expression
+}
+
+// Description describes the validation in plain text formatting.
+func (v int32IsLessThanPathValue) Description(ctx context.Context) string {
+	return fmt.Sprintf("Ensure the integer is less than the values configured at paths that match the following path expression: %v", v.PathExpression)
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v int32IsLessThanPathValue) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate runs the main validation logic of the validator, reading configuration data out of `req` and updating `resp` with diagnostics.
+func (v int32IsLessThanPathValue) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
+	// If the value is unknown or null, there is nothing to validate.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	matchedPaths, d := req.Config.PathMatches(ctx, v.PathExpression)
+	resp.Diagnostics.Append(d...)
+
+	// Collect all errors
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for _, mp := range matchedPaths {
+		// If the user specifies the same attribute this validator is applied to,
+		// also as part of the input, skip it
+		if mp.Equal(req.Path) {
+			continue
+		}
+
+		var mpVal types.Int32
+		diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Delay validation until all involved attribute have a known value
+		if mpVal.IsUnknown() {
+			return
+		}
+
+		if mpVal.ValueInt32() <= req.ConfigValue.ValueInt32() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path,
+				"Provided value is not valid",
+				fmt.Sprintf("The value provided %d is not valid.  Ensure that the provided value is less than the value configured at path %v.", req.ConfigValue.ValueInt32(), mp),
+			)
+			continue
+		}
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// IsLessThanPathValue checks if an int32 is greater than the value configured in the provided path expression.
+func IsLessThanPathValue(pathExpression path.Expression) validator.Int32 {
+	return &int32IsLessThanPathValue{
+		PathExpression: pathExpression,
+	}
+}

--- a/internal/framework/int32validator/regex_matches_path_value.go
+++ b/internal/framework/int32validator/regex_matches_path_value.go
@@ -1,0 +1,20 @@
+package int32validator
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/schemavalidator"
+)
+
+// RegexMatchesPathValue validates if the provided regex matches
+// the value at the provided path expression(s).  If a list of expressions is provided,
+// all expressions are checked until a match is found, or the list of expressions is exhausted.
+func RegexMatchesPathValue(regexp *regexp.Regexp, message string, expressions ...path.Expression) validator.Int32 {
+	return schemavalidator.RegexMatchesPathValueValidator{
+		Regexp:      regexp,
+		Message:     message,
+		Expressions: expressions,
+	}
+}

--- a/internal/framework/resource.go
+++ b/internal/framework/resource.go
@@ -227,8 +227,12 @@ func StringOkToTF(v *string, ok bool) basetypes.StringValue {
 	}
 }
 
-func Int32ToTF(i int32) basetypes.Int64Value {
-	return types.Int64Value(int64(i))
+func Int32ToTF(i int32) basetypes.Int32Value {
+	return types.Int32Value(i)
+}
+
+func Int64ToTF(i int64) basetypes.Int64Value {
+	return types.Int64Value(i)
 }
 
 func EnumToTF(v interface{}) basetypes.StringValue {
@@ -247,19 +251,35 @@ func EnumOkToTF(v interface{}, ok bool) basetypes.StringValue {
 	}
 }
 
-func Int32OkToTF(i *int32, ok bool) basetypes.Int64Value {
+func Int32OkToTF(i *int32, ok bool) basetypes.Int32Value {
 	if !ok || i == nil {
-		return types.Int64Null()
+		return types.Int32Null()
 	} else {
-		return types.Int64Value(int64(*i))
+		return types.Int32Value(*i)
 	}
 }
 
-func Float32OkToTF(i *float32, ok bool) basetypes.Float64Value {
+func Int64OkToTF(i *int64, ok bool) basetypes.Int64Value {
+	if !ok || i == nil {
+		return types.Int64Null()
+	} else {
+		return types.Int64Value(*i)
+	}
+}
+
+func Float32OkToTF(i *float32, ok bool) basetypes.Float32Value {
+	if !ok || i == nil {
+		return types.Float32Null()
+	} else {
+		return types.Float32Value(*i)
+	}
+}
+
+func Float64OkToTF(i *float64, ok bool) basetypes.Float64Value {
 	if !ok || i == nil {
 		return types.Float64Null()
 	} else {
-		return types.Float64Value(float64(*i))
+		return types.Float64Value(*i)
 	}
 }
 

--- a/internal/framework/schemavalidator/conflicts_if_matches_path_value.go
+++ b/internal/framework/schemavalidator/conflicts_if_matches_path_value.go
@@ -16,7 +16,9 @@ import (
 
 var (
 	_ validator.Bool    = ConflictsIfMatchesPathValueValidator{}
+	_ validator.Float32 = ConflictsIfMatchesPathValueValidator{}
 	_ validator.Float64 = ConflictsIfMatchesPathValueValidator{}
+	_ validator.Int32   = ConflictsIfMatchesPathValueValidator{}
 	_ validator.Int64   = ConflictsIfMatchesPathValueValidator{}
 	_ validator.List    = ConflictsIfMatchesPathValueValidator{}
 	_ validator.Map     = ConflictsIfMatchesPathValueValidator{}
@@ -128,7 +130,35 @@ func (validator ConflictsIfMatchesPathValueValidator) ValidateBool(ctx context.C
 	resp.Diagnostics.Append(validateResp.Diagnostics...)
 }
 
+func (validator ConflictsIfMatchesPathValueValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := ConflictsIfMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsIfMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
 func (validator ConflictsIfMatchesPathValueValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := ConflictsIfMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &ConflictsIfMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (validator ConflictsIfMatchesPathValueValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
 	validateReq := ConflictsIfMatchesPathValueValidatorRequest{
 		Config:         req.Config,
 		ConfigValue:    req.ConfigValue,

--- a/internal/framework/schemavalidator/is_required_if_matches_path_value.go
+++ b/internal/framework/schemavalidator/is_required_if_matches_path_value.go
@@ -16,7 +16,9 @@ import (
 
 var (
 	_ validator.Bool    = IsRequiredIfMatchesPathValueValidator{}
+	_ validator.Float32 = IsRequiredIfMatchesPathValueValidator{}
 	_ validator.Float64 = IsRequiredIfMatchesPathValueValidator{}
+	_ validator.Int32   = IsRequiredIfMatchesPathValueValidator{}
 	_ validator.Int64   = IsRequiredIfMatchesPathValueValidator{}
 	_ validator.List    = IsRequiredIfMatchesPathValueValidator{}
 	_ validator.Map     = IsRequiredIfMatchesPathValueValidator{}
@@ -122,7 +124,35 @@ func (validator IsRequiredIfMatchesPathValueValidator) ValidateBool(ctx context.
 	resp.Diagnostics.Append(validateResp.Diagnostics...)
 }
 
+func (validator IsRequiredIfMatchesPathValueValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := IsRequiredIfMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &IsRequiredIfMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
 func (validator IsRequiredIfMatchesPathValueValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := IsRequiredIfMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &IsRequiredIfMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (validator IsRequiredIfMatchesPathValueValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
 	validateReq := IsRequiredIfMatchesPathValueValidatorRequest{
 		Config:         req.Config,
 		ConfigValue:    req.ConfigValue,

--- a/internal/framework/schemavalidator/is_required_if_regex_matches_path_value.go
+++ b/internal/framework/schemavalidator/is_required_if_regex_matches_path_value.go
@@ -17,7 +17,9 @@ import (
 
 var (
 	_ validator.Bool    = IsRequiredIfRegexMatchesPathValueValidator{}
+	_ validator.Float32 = IsRequiredIfRegexMatchesPathValueValidator{}
 	_ validator.Float64 = IsRequiredIfRegexMatchesPathValueValidator{}
+	_ validator.Int32   = IsRequiredIfRegexMatchesPathValueValidator{}
 	_ validator.Int64   = IsRequiredIfRegexMatchesPathValueValidator{}
 	_ validator.List    = IsRequiredIfRegexMatchesPathValueValidator{}
 	_ validator.Map     = IsRequiredIfRegexMatchesPathValueValidator{}
@@ -127,7 +129,35 @@ func (validator IsRequiredIfRegexMatchesPathValueValidator) ValidateBool(ctx con
 	resp.Diagnostics.Append(validateResp.Diagnostics...)
 }
 
+func (validator IsRequiredIfRegexMatchesPathValueValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := IsRequiredIfRegexMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &IsRequiredIfRegexMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
 func (validator IsRequiredIfRegexMatchesPathValueValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := IsRequiredIfRegexMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &IsRequiredIfRegexMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (validator IsRequiredIfRegexMatchesPathValueValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
 	validateReq := IsRequiredIfRegexMatchesPathValueValidatorRequest{
 		Config:         req.Config,
 		ConfigValue:    req.ConfigValue,

--- a/internal/framework/schemavalidator/regex_matches_path_value.go
+++ b/internal/framework/schemavalidator/regex_matches_path_value.go
@@ -17,7 +17,9 @@ import (
 
 var (
 	_ validator.Bool    = RegexMatchesPathValueValidator{}
+	_ validator.Float32 = RegexMatchesPathValueValidator{}
 	_ validator.Float64 = RegexMatchesPathValueValidator{}
+	_ validator.Int32   = RegexMatchesPathValueValidator{}
 	_ validator.Int64   = RegexMatchesPathValueValidator{}
 	_ validator.List    = RegexMatchesPathValueValidator{}
 	_ validator.Map     = RegexMatchesPathValueValidator{}
@@ -131,7 +133,35 @@ func (validator RegexMatchesPathValueValidator) ValidateBool(ctx context.Context
 	resp.Diagnostics.Append(validateResp.Diagnostics...)
 }
 
+func (validator RegexMatchesPathValueValidator) ValidateFloat32(ctx context.Context, req validator.Float32Request, resp *validator.Float32Response) {
+	validateReq := RegexMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RegexMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
 func (validator RegexMatchesPathValueValidator) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := RegexMatchesPathValueValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RegexMatchesPathValueValidatorResponse{}
+
+	validator.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (validator RegexMatchesPathValueValidator) ValidateInt32(ctx context.Context, req validator.Int32Request, resp *validator.Int32Response) {
 	validateReq := RegexMatchesPathValueValidatorRequest{
 		Config:         req.Config,
 		ConfigValue:    req.ConfigValue,

--- a/internal/service/base/data_source_agreement.go
+++ b/internal/service/base/data_source_agreement.go
@@ -29,9 +29,9 @@ type AgreementDataSourceModel struct {
 	Name                  types.String                 `tfsdk:"name"`
 	Enabled               types.Bool                   `tfsdk:"enabled"`
 	Description           types.String                 `tfsdk:"description"`
-	ReconsentPeriodDays   types.Float64                `tfsdk:"reconsent_period_days"`
-	TotalUserConsents     types.Int64                  `tfsdk:"total_user_consent_count"`
-	ExpiredUserConsents   types.Int64                  `tfsdk:"expired_user_consent_count"`
+	ReconsentPeriodDays   types.Float32                `tfsdk:"reconsent_period_days"`
+	TotalUserConsents     types.Int32                  `tfsdk:"total_user_consent_count"`
+	ExpiredUserConsents   types.Int32                  `tfsdk:"expired_user_consent_count"`
 	ConsentCountsUpdateAt timetypes.RFC3339            `tfsdk:"consent_counts_updated_at"`
 }
 
@@ -104,18 +104,18 @@ func (r *AgreementDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				Computed:    true,
 			},
 
-			"reconsent_period_days": schema.Float64Attribute{
+			"reconsent_period_days": schema.Float32Attribute{
 				Description: "A number that specifies the number of days until a consent to this agreement expires.",
 				Computed:    true,
 			},
 
-			"total_user_consent_count": schema.Int64Attribute{
+			"total_user_consent_count": schema.Int32Attribute{
 				Description:         totalUserCountDescription.Description,
 				MarkdownDescription: totalUserCountDescription.MarkdownDescription,
 				Computed:            true,
 			},
 
-			"expired_user_consent_count": schema.Int64Attribute{
+			"expired_user_consent_count": schema.Int32Attribute{
 				Description:         expiredUserCountDescription.Description,
 				MarkdownDescription: expiredUserCountDescription.MarkdownDescription,
 				Computed:            true,

--- a/internal/service/base/data_source_gateway.go
+++ b/internal/service/base/data_source_gateway.go
@@ -227,7 +227,7 @@ func (r *GatewayDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 						Computed:            true,
 					},
 
-					"retain_previous_credentials_mins": schema.Int64Attribute{
+					"retain_previous_credentials_mins": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of minutes for which the previous credentials are persisted.").Description,
 						Computed:    true,
 					},
@@ -367,7 +367,7 @@ func (r *GatewayDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 						Computed:    true,
 					},
 
-					"port": schema.Int64Attribute{
+					"port": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the port number of the NPS.").Description,
 						Computed:    true,
 					},

--- a/internal/service/base/data_source_license.go
+++ b/internal/service/base/data_source_license.go
@@ -33,7 +33,7 @@ type licenseDataSourceModel struct {
 	BeginsAt                  timetypes.RFC3339            `tfsdk:"begins_at"`
 	ExpiresAt                 timetypes.RFC3339            `tfsdk:"expires_at"`
 	TerminatesAt              timetypes.RFC3339            `tfsdk:"terminates_at"`
-	AssignedEnvironmentsCount types.Int64                  `tfsdk:"assigned_environments_count"`
+	AssignedEnvironmentsCount types.Int32                  `tfsdk:"assigned_environments_count"`
 	AdvancedServices          types.Object                 `tfsdk:"advanced_services"`
 	Authorize                 types.Object                 `tfsdk:"authorize"`
 	Credentials               types.Object                 `tfsdk:"credentials"`
@@ -72,7 +72,7 @@ var (
 		"allow_custom_domain": types.BoolType,
 		"allow_custom_schema": types.BoolType,
 		"allow_production":    types.BoolType,
-		"max":                 types.Int64Type,
+		"max":                 types.Int32Type,
 		"regions":             types.SetType{ElemType: types.StringType},
 	}
 
@@ -122,10 +122,10 @@ var (
 		"allow_verification_flow":                 types.BoolType,
 		"allow_update_self":                       types.BoolType,
 		"entitled_to_support":                     types.BoolType,
-		"max":                                     types.Int64Type,
-		"max_hard_limit":                          types.Int64Type,
-		"annual_active_included":                  types.Int64Type,
-		"monthly_active_included":                 types.Int64Type,
+		"max":                                     types.Int32Type,
+		"max_hard_limit":                          types.Int32Type,
+		"annual_active_included":                  types.Int32Type,
+		"monthly_active_included":                 types.Int32Type,
 	}
 
 	licenseVerifyTFObjectTypes = map[string]attr.Type{
@@ -309,7 +309,7 @@ func (r *LicenseDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				CustomType: timetypes.RFC3339Type{},
 			},
 
-			"assigned_environments_count": schema.Int64Attribute{
+			"assigned_environments_count": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the total number of environments associated with this license.").Description,
 				Computed:    true,
 			},
@@ -402,7 +402,7 @@ func (r *LicenseDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 						Computed:    true,
 					},
 
-					"max": schema.Int64Attribute{
+					"max": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the maximum number of environments allowed.").Description,
 						Computed:    true,
 					},
@@ -619,22 +619,22 @@ func (r *LicenseDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 						Computed:    true,
 					},
 
-					"max": schema.Int64Attribute{
+					"max": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the maximum number of users allowed per environment.").Description,
 						Computed:    true,
 					},
 
-					"max_hard_limit": schema.Int64Attribute{
+					"max_hard_limit": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the maximum number of users (hard limit) allowed per environment.").Description,
 						Computed:    true,
 					},
 
-					"annual_active_included": schema.Int64Attribute{
+					"annual_active_included": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies a soft limit on the number of active identities across all environments on the license per year. This property is not visible if a value is not provided at the time the license is created.").Description,
 						Computed:    true,
 					},
 
-					"monthly_active_included": schema.Int64Attribute{
+					"monthly_active_included": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies a soft limit on the number of active identities across all environments on the license per month. This property is not visible if a value is not provided at the time the license is created.").Description,
 						Computed:    true,
 					},

--- a/internal/service/base/resource_agreement.go
+++ b/internal/service/base/resource_agreement.go
@@ -30,7 +30,7 @@ type AgreementResourceModel struct {
 	Name                types.String                 `tfsdk:"name"`
 	Enabled             types.Bool                   `tfsdk:"enabled"`
 	Description         types.String                 `tfsdk:"description"`
-	ReconsentPeriodDays types.Float64                `tfsdk:"reconsent_period_days"`
+	ReconsentPeriodDays types.Float32                `tfsdk:"reconsent_period_days"`
 }
 
 // Framework interfaces
@@ -87,7 +87,7 @@ func (r *AgreementResource) Schema(ctx context.Context, req resource.SchemaReque
 				Computed:    true,
 			},
 
-			"reconsent_period_days": schema.Float64Attribute{
+			"reconsent_period_days": schema.Float32Attribute{
 				Description: "A number that specifies the number of days until a user consent to this agreement expires, and users must then be prompted for reconsent.",
 				Optional:    true,
 			},
@@ -333,7 +333,7 @@ func (p *AgreementResourceModel) expand() *management.Agreement {
 	}
 
 	if !p.ReconsentPeriodDays.IsNull() && !p.ReconsentPeriodDays.IsUnknown() {
-		data.SetReconsentPeriodDays(float32(p.ReconsentPeriodDays.ValueFloat64()))
+		data.SetReconsentPeriodDays(p.ReconsentPeriodDays.ValueFloat32())
 	}
 
 	return data

--- a/internal/service/base/resource_form.go
+++ b/internal/service/base/resource_form.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -42,7 +42,7 @@ type formResourceModel struct {
 	Name              types.String                 `tfsdk:"name"`
 	Description       types.String                 `tfsdk:"description"`
 	Category          types.String                 `tfsdk:"category"`
-	Cols              types.Int64                  `tfsdk:"cols"`
+	Cols              types.Int32                  `tfsdk:"cols"`
 	Components        types.Object                 `tfsdk:"components"`
 	FieldTypes        types.Set                    `tfsdk:"field_types"`
 	MarkOptional      types.Bool                   `tfsdk:"mark_optional"`
@@ -82,9 +82,9 @@ type formComponentsFieldResourceModel struct {
 }
 
 type formComponentsFieldPositionResourceModel struct {
-	Col   types.Int64 `tfsdk:"col"`
-	Row   types.Int64 `tfsdk:"row"`
-	Width types.Int64 `tfsdk:"width"`
+	Col   types.Int32 `tfsdk:"col"`
+	Row   types.Int32 `tfsdk:"row"`
+	Width types.Int32 `tfsdk:"width"`
 }
 
 type formComponentsFieldElementOptionsResourceModel struct {
@@ -112,18 +112,18 @@ type formComponentsFieldStylesResourceModel struct {
 	BackgroundColor types.String `tfsdk:"background_color"`
 	BorderColor     types.String `tfsdk:"border_color"`
 	Enabled         types.Bool   `tfsdk:"enabled"`
-	Height          types.Int64  `tfsdk:"height"`
+	Height          types.Int32  `tfsdk:"height"`
 	Padding         types.Object `tfsdk:"padding"`
 	TextColor       types.String `tfsdk:"text_color"`
-	Width           types.Int64  `tfsdk:"width"`
+	Width           types.Int32  `tfsdk:"width"`
 	WidthUnit       types.String `tfsdk:"width_unit"`
 }
 
 type formComponentsFieldButtonStylesPaddingResourceModel struct {
-	Bottom types.Int64 `tfsdk:"bottom"`
-	Left   types.Int64 `tfsdk:"left"`
-	Right  types.Int64 `tfsdk:"right"`
-	Top    types.Int64 `tfsdk:"top"`
+	Bottom types.Int32 `tfsdk:"bottom"`
+	Left   types.Int32 `tfsdk:"left"`
+	Right  types.Int32 `tfsdk:"right"`
+	Top    types.Int32 `tfsdk:"top"`
 }
 
 type formComponentsFieldsSchemaDef struct {
@@ -169,9 +169,9 @@ var (
 
 	// Form Components Fields Position
 	formComponentsFieldsPositionTFObjectTypes = map[string]attr.Type{
-		"col":   types.Int64Type,
-		"row":   types.Int64Type,
-		"width": types.Int64Type,
+		"col":   types.Int32Type,
+		"row":   types.Int32Type,
+		"width": types.Int32Type,
 	}
 
 	// Form Components Fields Field Element Option
@@ -193,18 +193,18 @@ var (
 		"background_color": types.StringType,
 		"border_color":     types.StringType,
 		"enabled":          types.BoolType,
-		"height":           types.Int64Type,
+		"height":           types.Int32Type,
 		"padding":          types.ObjectType{AttrTypes: formComponentsFieldsFieldStylesPaddingTFObjectTypes},
 		"text_color":       types.StringType,
-		"width":            types.Int64Type,
+		"width":            types.Int32Type,
 		"width_unit":       types.StringType,
 	}
 
 	formComponentsFieldsFieldStylesPaddingTFObjectTypes = map[string]attr.Type{
-		"bottom": types.Int64Type,
-		"left":   types.Int64Type,
-		"right":  types.Int64Type,
-		"top":    types.Int64Type,
+		"bottom": types.Int32Type,
+		"left":   types.Int32Type,
+		"right":  types.Int32Type,
+		"top":    types.Int32Type,
 	}
 
 	formComponentsFieldsSchemaDefMap = map[management.EnumFormFieldType]formComponentsFieldsSchemaDef{
@@ -754,17 +754,17 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Default: stringdefault.StaticString(string(management.ENUMFORMCATEGORY_CUSTOM)),
 			},
 
-			"cols": schema.Int64Attribute{
+			"cols": schema.Int32Attribute{
 				Description:         colsDescription.Description,
 				MarkdownDescription: colsDescription.MarkdownDescription,
 				Required:            true,
 
-				Validators: []validator.Int64{
-					int64validator.Between(colsMinValue, colsMaxValue),
+				Validators: []validator.Int32{
+					int32validator.Between(colsMinValue, colsMaxValue),
 				},
 
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.RequiresReplace(),
 				},
 			},
 
@@ -787,27 +787,27 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 									Required:            true,
 
 									Attributes: map[string]schema.Attribute{
-										"col": schema.Int64Attribute{
+										"col": schema.Int32Attribute{
 											Description:         componentsFieldsPositionColDescription.Description,
 											MarkdownDescription: componentsFieldsPositionColDescription.MarkdownDescription,
 											Required:            true,
 
-											Validators: []validator.Int64{
-												int64validator.AtLeast(colMinValue),
+											Validators: []validator.Int32{
+												int32validator.AtLeast(colMinValue),
 											},
 										},
 
-										"row": schema.Int64Attribute{
+										"row": schema.Int32Attribute{
 											Description:         componentsFieldsPositionRowDescription.Description,
 											MarkdownDescription: componentsFieldsPositionRowDescription.MarkdownDescription,
 											Required:            true,
 
-											Validators: []validator.Int64{
-												int64validator.AtMost(rowMaxValue),
+											Validators: []validator.Int32{
+												int32validator.AtMost(rowMaxValue),
 											},
 										},
 
-										"width": schema.Int64Attribute{
+										"width": schema.Int32Attribute{
 											Description:         componentsFieldsPositionWidthDescription.Description,
 											MarkdownDescription: componentsFieldsPositionWidthDescription.MarkdownDescription,
 											Optional:            true,
@@ -1036,7 +1036,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 											},
 										},
 
-										"height": schema.Int64Attribute{
+										"height": schema.Int32Attribute{
 											Description:         componentsFieldsStylesHeightDescription.Description,
 											MarkdownDescription: componentsFieldsStylesHeightDescription.MarkdownDescription,
 											Optional:            true,
@@ -1048,25 +1048,25 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 											Optional:            true,
 
 											Attributes: map[string]schema.Attribute{
-												"top": schema.Int64Attribute{
+												"top": schema.Int32Attribute{
 													Description:         componentsFieldsStylesPaddingTopDescription.Description,
 													MarkdownDescription: componentsFieldsStylesPaddingTopDescription.MarkdownDescription,
 													Optional:            true,
 												},
 
-												"right": schema.Int64Attribute{
+												"right": schema.Int32Attribute{
 													Description:         componentsFieldsStylesPaddingRightDescription.Description,
 													MarkdownDescription: componentsFieldsStylesPaddingRightDescription.MarkdownDescription,
 													Optional:            true,
 												},
 
-												"bottom": schema.Int64Attribute{
+												"bottom": schema.Int32Attribute{
 													Description:         componentsFieldsStylesPaddingBottomDescription.Description,
 													MarkdownDescription: componentsFieldsStylesPaddingBottomDescription.MarkdownDescription,
 													Optional:            true,
 												},
 
-												"left": schema.Int64Attribute{
+												"left": schema.Int32Attribute{
 													Description:         componentsFieldsStylesPaddingLeftDescription.Description,
 													MarkdownDescription: componentsFieldsStylesPaddingLeftDescription.MarkdownDescription,
 													Optional:            true,
@@ -1080,7 +1080,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 											Optional:            true,
 										},
 
-										"width": schema.Int64Attribute{
+										"width": schema.Int32Attribute{
 											Description:         componentsFieldsStylesWidthDescription.Description,
 											MarkdownDescription: componentsFieldsStylesWidthDescription.MarkdownDescription,
 											Optional:            true,
@@ -1695,7 +1695,7 @@ func (p *formResourceModel) validate(ctx context.Context, allowUnknowns bool) di
 								diags.AddAttributeError(
 									path.Root("components").AtName("fields"),
 									"Invalid DaVinci form configuration",
-									fmt.Sprintf("The combination of `col` and `row` must be unique between form fields.  The position `col`: `%d`, `row`: `%d` is duplicated.", positionPlan.Col.ValueInt64(), positionPlan.Row.ValueInt64()),
+									fmt.Sprintf("The combination of `col` and `row` must be unique between form fields.  The position `col`: `%d`, `row`: `%d` is duplicated.", positionPlan.Col.ValueInt32(), positionPlan.Row.ValueInt32()),
 								)
 							}
 						}
@@ -1837,7 +1837,7 @@ func (p *formResourceModel) expand(ctx context.Context) (*management.Form, diag.
 	}
 
 	if !p.Cols.IsNull() && !p.Cols.IsUnknown() {
-		data.SetCols(int32(p.Cols.ValueInt64()))
+		data.SetCols(p.Cols.ValueInt32())
 	}
 
 	if !p.FieldTypes.IsNull() && !p.FieldTypes.IsUnknown() {
@@ -1933,12 +1933,12 @@ func (p *formComponentsFieldResourceModel) expand(ctx context.Context) (*managem
 func (p *formComponentsFieldPositionResourceModel) expand() *management.FormFieldCommonPosition {
 
 	data := management.NewFormFieldCommonPosition(
-		int32(p.Row.ValueInt64()),
-		int32(p.Col.ValueInt64()),
+		p.Row.ValueInt32(),
+		p.Col.ValueInt32(),
 	)
 
 	if !p.Width.IsNull() && !p.Width.IsUnknown() {
-		data.SetWidth(int32(p.Width.ValueInt64()))
+		data.SetWidth(p.Width.ValueInt32())
 	}
 
 	return data
@@ -2498,7 +2498,7 @@ func (p *formComponentsFieldStylesResourceModel) expand(ctx context.Context, sty
 		}
 
 		if !p.Height.IsNull() && !p.Height.IsUnknown() {
-			data.SetHeight(int32(p.Height.ValueInt64()))
+			data.SetHeight(p.Height.ValueInt32())
 		}
 
 		if !p.Padding.IsNull() && !p.Padding.IsUnknown() {
@@ -2514,19 +2514,19 @@ func (p *formComponentsFieldStylesResourceModel) expand(ctx context.Context, sty
 			padding := management.NewFormStylesPadding()
 
 			if !plan.Bottom.IsNull() && !plan.Bottom.IsUnknown() {
-				padding.SetBottom(int32(plan.Bottom.ValueInt64()))
+				padding.SetBottom(plan.Bottom.ValueInt32())
 			}
 
 			if !plan.Left.IsNull() && !plan.Left.IsUnknown() {
-				padding.SetLeft(int32(plan.Left.ValueInt64()))
+				padding.SetLeft(plan.Left.ValueInt32())
 			}
 
 			if !plan.Right.IsNull() && !plan.Right.IsUnknown() {
-				padding.SetRight(int32(plan.Right.ValueInt64()))
+				padding.SetRight(plan.Right.ValueInt32())
 			}
 
 			if !plan.Top.IsNull() && !plan.Top.IsUnknown() {
-				padding.SetTop(int32(plan.Top.ValueInt64()))
+				padding.SetTop(plan.Top.ValueInt32())
 			}
 
 			data.SetPadding(*padding)
@@ -2537,7 +2537,7 @@ func (p *formComponentsFieldStylesResourceModel) expand(ctx context.Context, sty
 		}
 
 		if !p.Width.IsNull() && !p.Width.IsUnknown() {
-			data.SetWidth(int32(p.Width.ValueInt64()))
+			data.SetWidth(p.Width.ValueInt32())
 		}
 
 		if !p.WidthUnit.IsNull() && !p.WidthUnit.IsUnknown() {
@@ -2571,19 +2571,19 @@ func (p *formComponentsFieldStylesResourceModel) expand(ctx context.Context, sty
 			padding := management.NewFormStylesPadding()
 
 			if !plan.Bottom.IsNull() && !plan.Bottom.IsUnknown() {
-				padding.SetBottom(int32(plan.Bottom.ValueInt64()))
+				padding.SetBottom(plan.Bottom.ValueInt32())
 			}
 
 			if !plan.Left.IsNull() && !plan.Left.IsUnknown() {
-				padding.SetLeft(int32(plan.Left.ValueInt64()))
+				padding.SetLeft(plan.Left.ValueInt32())
 			}
 
 			if !plan.Right.IsNull() && !plan.Right.IsUnknown() {
-				padding.SetRight(int32(plan.Right.ValueInt64()))
+				padding.SetRight(plan.Right.ValueInt32())
 			}
 
 			if !plan.Top.IsNull() && !plan.Top.IsUnknown() {
-				padding.SetTop(int32(plan.Top.ValueInt64()))
+				padding.SetTop(plan.Top.ValueInt32())
 			}
 
 			data.SetPadding(*padding)
@@ -3176,10 +3176,10 @@ func formComponentsFieldsFlowLinkStylesOkToTF(apiObject *management.FormFlowLink
 		"background_color": types.StringNull(),
 		"border_color":     types.StringNull(),
 		"enabled":          framework.BoolOkToTF(apiObject.GetEnabledOk()),
-		"height":           types.Int64Null(),
+		"height":           types.Int32Null(),
 		"padding":          padding,
 		"text_color":       framework.StringOkToTF(apiObject.GetTextColorOk()),
-		"width":            types.Int64Null(),
+		"width":            types.Int32Null(),
 		"width_unit":       types.StringNull(),
 	})
 	diags.Append(d...)

--- a/internal/service/base/resource_gateway.go
+++ b/internal/service/base/resource_gateway.go
@@ -68,7 +68,7 @@ type gatewayResourceModelV1 struct {
 type gatewayKerberosResourceModelV1 struct {
 	ServiceAccountPassword        types.String `tfsdk:"service_account_password"`
 	ServiceAccountUPN             types.String `tfsdk:"service_account_upn"`
-	RetainPreviousCredentialsMins types.Int64  `tfsdk:"retain_previous_credentials_mins"`
+	RetainPreviousCredentialsMins types.Int32  `tfsdk:"retain_previous_credentials_mins"`
 }
 
 type gatewayUserTypeResourceModelV1 struct {
@@ -99,12 +99,12 @@ type gatewayRadiusClientsResourceModelV1 struct {
 
 type gatewayRadiusNetworkPolicyServerResourceModelV1 struct {
 	IP   types.String `tfsdk:"ip"`
-	Port types.Int64  `tfsdk:"port"`
+	Port types.Int32  `tfsdk:"port"`
 }
 
 var (
 	gatewayKerberosTFObjectTypes = map[string]attr.Type{
-		"retain_previous_credentials_mins": types.Int64Type,
+		"retain_previous_credentials_mins": types.Int32Type,
 		"service_account_password":         types.StringType,
 		"service_account_upn":              types.StringType,
 	}
@@ -141,7 +141,7 @@ var (
 
 	gatewayRadiusNetworkPolicyServerTFObjectTypes = map[string]attr.Type{
 		"ip":   types.StringType,
-		"port": types.Int64Type,
+		"port": types.Int32Type,
 	}
 )
 
@@ -445,7 +445,7 @@ func (r *GatewayResource) Schema(ctx context.Context, req resource.SchemaRequest
 						Required:            true,
 					},
 
-					"retain_previous_credentials_mins": schema.Int64Attribute{
+					"retain_previous_credentials_mins": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of minutes for which the previous credentials are persisted.").Description,
 						Optional:    true,
 					},
@@ -811,7 +811,7 @@ func (r *GatewayResource) Schema(ctx context.Context, req resource.SchemaRequest
 						},
 					},
 
-					"port": schema.Int64Attribute{
+					"port": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the port number of the NPS.").Description,
 						Required:    true,
 					},
@@ -1154,7 +1154,7 @@ func (p *gatewayResourceModelV1) expand(ctx context.Context) (*management.Create
 			}
 
 			if !kerberosPlan.RetainPreviousCredentialsMins.IsNull() && !kerberosPlan.RetainPreviousCredentialsMins.IsUnknown() {
-				kerberos.SetMinutesToRetainPreviousCredentials(int32(kerberosPlan.RetainPreviousCredentialsMins.ValueInt64()))
+				kerberos.SetMinutesToRetainPreviousCredentials(kerberosPlan.RetainPreviousCredentialsMins.ValueInt32())
 			}
 
 			gateway.SetKerberos(*kerberos)
@@ -1235,7 +1235,7 @@ func (p *gatewayResourceModelV1) expand(ctx context.Context) (*management.Create
 
 			radiusNPS := management.NewGatewayTypeRADIUSAllOfNetworkPolicyServer(
 				radiusNPSPlan.IP.ValueString(),
-				int32(radiusNPSPlan.Port.ValueInt64()),
+				radiusNPSPlan.Port.ValueInt32(),
 			)
 
 			gateway.SetNetworkPolicyServer(*radiusNPS)

--- a/internal/service/base/resource_gateway_schema_upgrade_0_to_1.go
+++ b/internal/service/base/resource_gateway_schema_upgrade_0_to_1.go
@@ -28,7 +28,7 @@ type gatewayResourceModelV0 struct {
 	ConnectionSecurity                    types.String `tfsdk:"connection_security"`
 	KerberosServiceAccountPassword        types.String `tfsdk:"kerberos_service_account_password"`
 	KerberosServiceAccountUpn             types.String `tfsdk:"kerberos_service_account_upn"`
-	KerberosRetailPreviousCredentialsMins types.Int64  `tfsdk:"kerberos_retain_previous_credentials_mins"`
+	KerberosRetailPreviousCredentialsMins types.Int32  `tfsdk:"kerberos_retain_previous_credentials_mins"`
 	Servers                               types.Set    `tfsdk:"servers"`
 	ValidateTLSCertificates               types.Bool   `tfsdk:"validate_tls_certificates"`
 	Vendor                                types.String `tfsdk:"vendor"`
@@ -109,7 +109,7 @@ func (r *GatewayResource) UpgradeState(ctx context.Context) map[int64]resource.S
 						Optional: true,
 					},
 
-					"kerberos_retain_previous_credentials_mins": schema.Int64Attribute{
+					"kerberos_retain_previous_credentials_mins": schema.Int32Attribute{
 						Optional: true,
 					},
 

--- a/internal/service/base/resource_image.go
+++ b/internal/service/base/resource_image.go
@@ -36,16 +36,16 @@ type imageResourceModelV1 struct {
 }
 
 type imageUploadedImageResourceModelV1 struct {
-	Width  types.Int64  `tfsdk:"width"`
-	Height types.Int64  `tfsdk:"height"`
+	Width  types.Int32  `tfsdk:"width"`
+	Height types.Int32  `tfsdk:"height"`
 	Type   types.String `tfsdk:"type"`
 	Href   types.String `tfsdk:"href"`
 }
 
 var (
 	imageUploadedImageTFObjectTypes = map[string]attr.Type{
-		"width":  types.Int64Type,
-		"height": types.Int64Type,
+		"width":  types.Int32Type,
+		"height": types.Int32Type,
 		"type":   types.StringType,
 		"href":   types.StringType,
 	}
@@ -111,12 +111,12 @@ func (r *ImageResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Computed:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"width": schema.Int64Attribute{
+					"width": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("The width of the image (in pixels).").Description,
 						Computed:    true,
 					},
 
-					"height": schema.Int64Attribute{
+					"height": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("The height of the image (in pixels).").Description,
 						Computed:    true,
 					},

--- a/internal/service/base/resource_image_schema_upgrade_0_to_1.go
+++ b/internal/service/base/resource_image_schema_upgrade_0_to_1.go
@@ -42,10 +42,10 @@ func (r *ImageResource) UpgradeState(ctx context.Context) map[int64]resource.Sta
 					"uploaded_image": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"width": schema.Int64Attribute{
+								"width": schema.Int32Attribute{
 									Computed: true,
 								},
-								"height": schema.Int64Attribute{
+								"height": schema.Int32Attribute{
 									Computed: true,
 								},
 								"type": schema.StringAttribute{

--- a/internal/service/base/resource_key.go
+++ b/internal/service/base/resource_key.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -45,14 +45,14 @@ type keyResourceModel struct {
 	Default            types.Bool                   `tfsdk:"default"`
 	ExpiresAt          timetypes.RFC3339            `tfsdk:"expires_at"`
 	IssuerDn           types.String                 `tfsdk:"issuer_dn"`
-	KeyLength          types.Int64                  `tfsdk:"key_length"`
+	KeyLength          types.Int32                  `tfsdk:"key_length"`
 	SerialNumber       types.String                 `tfsdk:"serial_number"`
 	SignatureAlgorithm types.String                 `tfsdk:"signature_algorithm"`
 	StartsAt           timetypes.RFC3339            `tfsdk:"starts_at"`
 	Status             types.String                 `tfsdk:"status"`
 	SubjectDn          types.String                 `tfsdk:"subject_dn"`
 	UsageType          types.String                 `tfsdk:"usage_type"`
-	ValidityPeriod     types.Int64                  `tfsdk:"validity_period"`
+	ValidityPeriod     types.Int32                  `tfsdk:"validity_period"`
 	CustomCrl          types.String                 `tfsdk:"custom_crl"`
 	PKCS12FileBase64   types.String                 `tfsdk:"pkcs12_file_base64"`
 	PKCS12FilePassword types.String                 `tfsdk:"pkcs12_file_password"`
@@ -67,8 +67,8 @@ var (
 )
 
 var (
-	allowedKeyLengthsRSA = []int64{2048, 3072, 4096, 7680}
-	allowedKeyLengthsEC  = []int64{224, 256, 384, 521}
+	allowedKeyLengthsRSA = []int32{2048, 3072, 4096, 7680}
+	allowedKeyLengthsEC  = []int32{224, 256, 384, 521}
 )
 
 // New Object
@@ -249,30 +249,30 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 
-			"key_length": schema.Int64Attribute{
+			"key_length": schema.Int32Attribute{
 				Description:         keyLengthDescription.Description,
 				MarkdownDescription: keyLengthDescription.MarkdownDescription,
 				Optional:            true,
 				Computed:            true,
 
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.RequiresReplace(),
 				},
 
-				Validators: []validator.Int64{
-					int64validator.Any(
-						int64validator.OneOf(
+				Validators: []validator.Int32{
+					int32validator.Any(
+						int32validator.OneOf(
 							allowedKeyLengthsRSA...,
 						),
-						int64validator.OneOf(
+						int32validator.OneOf(
 							allowedKeyLengthsEC...,
 						),
 					),
-					int64validator.ConflictsWith(
+					int32validator.ConflictsWith(
 						path.MatchRelative().AtParent().AtName("pkcs12_file_base64"),
 						path.MatchRelative().AtParent().AtName("pkcs12_file_password"),
 					),
-					int64validator.AlsoRequires(
+					int32validator.AlsoRequires(
 						path.MatchRelative().AtParent().AtName("name"),
 						path.MatchRelative().AtParent().AtName("algorithm"),
 						path.MatchRelative().AtParent().AtName("key_length"),
@@ -387,23 +387,23 @@ func (r *KeyResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 
-			"validity_period": schema.Int64Attribute{
+			"validity_period": schema.Int32Attribute{
 				Description:         validityPeriodDescription.Description,
 				MarkdownDescription: validityPeriodDescription.MarkdownDescription,
 				Optional:            true,
 				Computed:            true,
 
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
+				PlanModifiers: []planmodifier.Int32{
+					int32planmodifier.RequiresReplace(),
 				},
 
-				Validators: []validator.Int64{
-					int64validator.AtLeast(attrMinLength),
-					int64validator.ConflictsWith(
+				Validators: []validator.Int32{
+					int32validator.AtLeast(attrMinLength),
+					int32validator.ConflictsWith(
 						path.MatchRelative().AtParent().AtName("pkcs12_file_base64"),
 						path.MatchRelative().AtParent().AtName("pkcs12_file_password"),
 					),
-					int64validator.AlsoRequires(
+					int32validator.AlsoRequires(
 						path.MatchRelative().AtParent().AtName("name"),
 						path.MatchRelative().AtParent().AtName("algorithm"),
 						path.MatchRelative().AtParent().AtName("key_length"),
@@ -800,12 +800,12 @@ func (p *keyResourceModel) expand() *management.Certificate {
 
 	data := management.NewCertificate(
 		management.EnumCertificateKeyAlgorithm(p.Algorithm.ValueString()),
-		int32(p.KeyLength.ValueInt64()),
+		p.KeyLength.ValueInt32(),
 		p.Name.ValueString(),
 		management.EnumCertificateKeySignagureAlgorithm(p.SignatureAlgorithm.ValueString()),
 		p.SubjectDn.ValueString(),
 		usageType,
-		int32(p.ValidityPeriod.ValueInt64()),
+		p.ValidityPeriod.ValueInt32(),
 	)
 
 	if !p.CustomCrl.IsNull() && !p.CustomCrl.IsUnknown() {
@@ -884,7 +884,7 @@ func (p *keyResourceModel) validate(allowUnknowns bool) diag.Diagnostics {
 		if !p.Algorithm.IsNull() && !p.Algorithm.IsUnknown() && !p.KeyLength.IsNull() && !p.KeyLength.IsUnknown() {
 			var validKeyLengths string
 			keyLengthValidationError := false
-			if p.Algorithm.Equal(types.StringValue(string(management.ENUMCERTIFICATEKEYALGORITHM_RSA))) && !slices.Contains(allowedKeyLengthsRSA, p.KeyLength.ValueInt64()) {
+			if p.Algorithm.Equal(types.StringValue(string(management.ENUMCERTIFICATEKEYALGORITHM_RSA))) && !slices.Contains(allowedKeyLengthsRSA, p.KeyLength.ValueInt32()) {
 
 				keyLengthStrs := make([]string, len(allowedKeyLengthsRSA))
 				for i, v := range allowedKeyLengthsRSA {
@@ -895,7 +895,7 @@ func (p *keyResourceModel) validate(allowUnknowns bool) diag.Diagnostics {
 				validKeyLengths = strings.Join(keyLengthStrs, "`, `")
 			}
 
-			if p.Algorithm.Equal(types.StringValue(string(management.ENUMCERTIFICATEKEYALGORITHM_EC))) && !slices.Contains(allowedKeyLengthsEC, p.KeyLength.ValueInt64()) {
+			if p.Algorithm.Equal(types.StringValue(string(management.ENUMCERTIFICATEKEYALGORITHM_EC))) && !slices.Contains(allowedKeyLengthsEC, p.KeyLength.ValueInt32()) {
 
 				keyLengthStrs := make([]string, len(allowedKeyLengthsEC))
 				for i, v := range allowedKeyLengthsEC {

--- a/internal/service/base/resource_notification_policy.go
+++ b/internal/service/base/resource_notification_policy.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -46,9 +46,9 @@ type NotificationPolicyResourceModel struct {
 type NotificationPolicyQuotaResourceModel struct {
 	Type            types.String `tfsdk:"type"`
 	DeliveryMethods types.Set    `tfsdk:"delivery_methods"`
-	Total           types.Int64  `tfsdk:"total"`
-	Used            types.Int64  `tfsdk:"used"`
-	Unused          types.Int64  `tfsdk:"unused"`
+	Total           types.Int32  `tfsdk:"total"`
+	Used            types.Int32  `tfsdk:"used"`
+	Unused          types.Int32  `tfsdk:"unused"`
 }
 
 type NotificationPolicyCountryLimitResourceModel struct {
@@ -63,9 +63,9 @@ var (
 		"delivery_methods": types.SetType{
 			ElemType: types.StringType,
 		},
-		"total":  types.Int64Type,
-		"used":   types.Int64Type,
-		"unused": types.Int64Type,
+		"total":  types.Int32Type,
+		"used":   types.Int32Type,
+		"unused": types.Int32Type,
 	}
 
 	countryLimitTFObjectTypes = map[string]attr.Type{
@@ -297,33 +297,33 @@ func (r *NotificationPolicyResource) Schema(ctx context.Context, req resource.Sc
 							},
 						},
 
-						"total": schema.Int64Attribute{
+						"total": schema.Int32Attribute{
 							Description:         quotaTotalDescription.Description,
 							MarkdownDescription: quotaTotalDescription.MarkdownDescription,
 							Optional:            true,
-							Validators: []validator.Int64{
-								int64validator.ConflictsWith(path.MatchRelative().AtParent().AtName("used")),
-								int64validator.ConflictsWith(path.MatchRelative().AtParent().AtName("unused")),
+							Validators: []validator.Int32{
+								int32validator.ConflictsWith(path.MatchRelative().AtParent().AtName("used")),
+								int32validator.ConflictsWith(path.MatchRelative().AtParent().AtName("unused")),
 							},
 						},
 
-						"used": schema.Int64Attribute{
+						"used": schema.Int32Attribute{
 							Description:         quotaUsedDescription.Description,
 							MarkdownDescription: quotaUsedDescription.MarkdownDescription,
 							Optional:            true,
-							Validators: []validator.Int64{
-								int64validator.ConflictsWith(path.MatchRelative().AtParent().AtName("total")),
-								int64validator.AlsoRequires(path.MatchRelative().AtParent().AtName("unused")),
+							Validators: []validator.Int32{
+								int32validator.ConflictsWith(path.MatchRelative().AtParent().AtName("total")),
+								int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("unused")),
 							},
 						},
 
-						"unused": schema.Int64Attribute{
+						"unused": schema.Int32Attribute{
 							Description:         quotaUnusedDescription.Description,
 							MarkdownDescription: quotaUnusedDescription.MarkdownDescription,
 							Optional:            true,
-							Validators: []validator.Int64{
-								int64validator.ConflictsWith(path.MatchRelative().AtParent().AtName("total")),
-								int64validator.AlsoRequires(path.MatchRelative().AtParent().AtName("used")),
+							Validators: []validator.Int32{
+								int32validator.ConflictsWith(path.MatchRelative().AtParent().AtName("total")),
+								int32validator.AlsoRequires(path.MatchRelative().AtParent().AtName("used")),
 							},
 						},
 					},
@@ -648,15 +648,15 @@ func (p *NotificationPolicyResourceModel) expand(ctx context.Context) (*manageme
 		)
 
 		if !v.Total.IsNull() && !v.Total.IsUnknown() {
-			quota.SetTotal(int32(v.Total.ValueInt64()))
+			quota.SetTotal(v.Total.ValueInt32())
 		}
 
 		if !v.Used.IsNull() && !v.Used.IsUnknown() {
-			quota.SetClaimed(int32(v.Used.ValueInt64()))
+			quota.SetClaimed(v.Used.ValueInt32())
 		}
 
 		if !v.Unused.IsNull() && !v.Unused.IsUnknown() {
-			quota.SetUnclaimed(int32(v.Unused.ValueInt64()))
+			quota.SetUnclaimed(v.Unused.ValueInt32())
 		}
 
 		if management.EnumNotificationsPolicyQuotaItemType(v.Type.ValueString()) == management.ENUMNOTIFICATIONSPOLICYQUOTAITEMTYPE_USER &&

--- a/internal/service/base/resource_notification_settings_email.go
+++ b/internal/service/base/resource_notification_settings_email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -29,7 +29,7 @@ type notificationSettingsEmailResourceModelV1 struct {
 	Id            pingonetypes.ResourceIDValue `tfsdk:"id"`
 	EnvironmentId pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
 	Host          types.String                 `tfsdk:"host"`
-	Port          types.Int64                  `tfsdk:"port"`
+	Port          types.Int32                  `tfsdk:"port"`
 	Protocol      types.String                 `tfsdk:"protocol"`
 	Username      types.String                 `tfsdk:"username"`
 	Password      types.String                 `tfsdk:"password"`
@@ -98,12 +98,12 @@ func (r *NotificationSettingsEmailResource) Schema(ctx context.Context, req reso
 				},
 			},
 
-			"port": schema.Int64Attribute{
+			"port": schema.Int32Attribute{
 				MarkdownDescription: portDescription.MarkdownDescription,
 				Description:         portDescription.Description,
 				Required:            true,
-				Validators: []validator.Int64{
-					int64validator.AtLeast(attrMinLength),
+				Validators: []validator.Int32{
+					int32validator.AtLeast(attrMinLength),
 				},
 			},
 
@@ -406,7 +406,7 @@ func (p *notificationSettingsEmailResourceModelV1) expand(ctx context.Context) (
 	}
 
 	if !p.Port.IsNull() && !p.Port.IsUnknown() {
-		data.SetPort(int32(p.Port.ValueInt64()))
+		data.SetPort(p.Port.ValueInt32())
 	}
 
 	if !p.Username.IsNull() && !p.Username.IsUnknown() {

--- a/internal/service/base/resource_notification_settings_email_schema_upgrade_0_to_1.go
+++ b/internal/service/base/resource_notification_settings_email_schema_upgrade_0_to_1.go
@@ -15,7 +15,7 @@ type notificationSettingsEmailResourceModelV0 struct {
 	Id            pingonetypes.ResourceIDValue `tfsdk:"id"`
 	EnvironmentId pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
 	Host          types.String                 `tfsdk:"host"`
-	Port          types.Int64                  `tfsdk:"port"`
+	Port          types.Int32                  `tfsdk:"port"`
 	Protocol      types.String                 `tfsdk:"protocol"`
 	Username      types.String                 `tfsdk:"username"`
 	Password      types.String                 `tfsdk:"password"`
@@ -41,7 +41,7 @@ func (r *NotificationSettingsEmailResource) UpgradeState(ctx context.Context) ma
 						Required: true,
 					},
 
-					"port": schema.Int64Attribute{
+					"port": schema.Int32Attribute{
 						Required: true,
 					},
 

--- a/internal/service/credentials/data_source_credential_type.go
+++ b/internal/service/credentials/data_source_credential_type.go
@@ -38,12 +38,12 @@ type CredentialTypeDataSourceModel struct {
 
 type MetadataDataSourceModel struct {
 	BackgroundImage  types.String `tfsdk:"background_image"`
-	BgOpacityPercent types.Int64  `tfsdk:"bg_opacity_percent"`
+	BgOpacityPercent types.Int32  `tfsdk:"bg_opacity_percent"`
 	CardColor        types.String `tfsdk:"card_color"`
-	Columns          types.Int64  `tfsdk:"columns"`
+	Columns          types.Int32  `tfsdk:"columns"`
 	Description      types.String `tfsdk:"description"`
 	TextColor        types.String `tfsdk:"text_color"`
-	Version          types.Int64  `tfsdk:"version"`
+	Version          types.Int32  `tfsdk:"version"`
 	LogoImage        types.String `tfsdk:"logo_image"`
 	Name             types.String `tfsdk:"name"`
 	Fields           types.List   `tfsdk:"fields"`
@@ -63,12 +63,12 @@ type FieldsDataSourceModel struct {
 var (
 	metadataDataSourceServiceTFObjectTypes = map[string]attr.Type{
 		"background_image":   types.StringType,
-		"bg_opacity_percent": types.Int64Type,
+		"bg_opacity_percent": types.Int32Type,
 		"card_color":         types.StringType,
-		"columns":            types.Int64Type,
+		"columns":            types.Int32Type,
 		"description":        types.StringType,
 		"text_color":         types.StringType,
-		"version":            types.Int64Type,
+		"version":            types.Int32Type,
 		"logo_image":         types.StringType,
 		"name":               types.StringType,
 		"fields":             types.ListType{ElemType: types.ObjectType{AttrTypes: innerFieldsDataSourceServiceTFObjectTypes}},
@@ -165,7 +165,7 @@ func (r *CredentialTypeDataSource) Schema(ctx context.Context, req datasource.Sc
 						Computed:    true,
 					},
 
-					"bg_opacity_percent": schema.Int64Attribute{
+					"bg_opacity_percent": schema.Int32Attribute{
 						Description: "Percent opacity of the background image in the credential.",
 						Computed:    true,
 					},
@@ -175,7 +175,7 @@ func (r *CredentialTypeDataSource) Schema(ctx context.Context, req datasource.Sc
 						Computed:    true,
 					},
 
-					"columns": schema.Int64Attribute{
+					"columns": schema.Int32Attribute{
 						Description: "Number of columns to organize the fields displayed on the credential.",
 						Computed:    true,
 					},
@@ -199,7 +199,7 @@ func (r *CredentialTypeDataSource) Schema(ctx context.Context, req datasource.Sc
 						Description: "Color of the text to show on the credential.",
 						Computed:    true},
 
-					"version": schema.Int64Attribute{
+					"version": schema.Int32Attribute{
 						Description: "Version of this credential.",
 						Computed:    true,
 					},

--- a/internal/service/credentials/resource_credential_type.go
+++ b/internal/service/credentials/resource_credential_type.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -53,12 +53,12 @@ type CredentialTypeResourceModel struct {
 
 type MetadataModel struct {
 	BackgroundImage  types.String `tfsdk:"background_image"`
-	BgOpacityPercent types.Int64  `tfsdk:"bg_opacity_percent"`
+	BgOpacityPercent types.Int32  `tfsdk:"bg_opacity_percent"`
 	CardColor        types.String `tfsdk:"card_color"`
-	Columns          types.Int64  `tfsdk:"columns"`
+	Columns          types.Int32  `tfsdk:"columns"`
 	Description      types.String `tfsdk:"description"`
 	TextColor        types.String `tfsdk:"text_color"`
-	Version          types.Int64  `tfsdk:"version"`
+	Version          types.Int32  `tfsdk:"version"`
 	LogoImage        types.String `tfsdk:"logo_image"`
 	Name             types.String `tfsdk:"name"`
 	Fields           types.List   `tfsdk:"fields"`
@@ -78,12 +78,12 @@ type FieldsModel struct {
 var (
 	metadataServiceTFObjectTypes = map[string]attr.Type{
 		"background_image":   types.StringType,
-		"bg_opacity_percent": types.Int64Type,
+		"bg_opacity_percent": types.Int32Type,
 		"card_color":         types.StringType,
-		"columns":            types.Int64Type,
+		"columns":            types.Int32Type,
 		"description":        types.StringType,
 		"text_color":         types.StringType,
-		"version":            types.Int64Type,
+		"version":            types.Int32Type,
 		"logo_image":         types.StringType,
 		"name":               types.StringType,
 		"fields":             types.ListType{ElemType: types.ObjectType{AttrTypes: innerFieldsServiceTFObjectTypes}},
@@ -287,11 +287,11 @@ func (r *CredentialTypeResource) Schema(ctx context.Context, req resource.Schema
 						},
 					},
 
-					"bg_opacity_percent": schema.Int64Attribute{
+					"bg_opacity_percent": schema.Int32Attribute{
 						Description: "A numnber indicating the percent opacity of the background image in the credential. High percentage opacity may make text on the credential difficult to read.",
 						Optional:    true,
-						Validators: []validator.Int64{
-							int64validator.Between(attrMinPercent, attrMaxPercent),
+						Validators: []validator.Int32{
+							int32validator.Between(attrMinPercent, attrMaxPercent),
 						},
 					},
 
@@ -315,11 +315,11 @@ func (r *CredentialTypeResource) Schema(ctx context.Context, req resource.Schema
 						},
 					},
 
-					"columns": schema.Int64Attribute{
+					"columns": schema.Int32Attribute{
 						Description: "Indicates a number (between 1-3) of columns to display visible fields on the credential.",
 						Optional:    true,
-						Validators: []validator.Int64{
-							int64validator.Between(attrMinColumns, attrMaxColumns),
+						Validators: []validator.Int32{
+							int32validator.Between(attrMinColumns, attrMaxColumns),
 						},
 					},
 
@@ -378,7 +378,7 @@ func (r *CredentialTypeResource) Schema(ctx context.Context, req resource.Schema
 							),
 						},
 					},
-					"version": schema.Int64Attribute{
+					"version": schema.Int32Attribute{
 						Description: "Number version of this credential.",
 						Computed:    true,
 					},
@@ -846,7 +846,7 @@ func (p *MetadataModel) expandMetaDataModel(ctx context.Context) (*credentials.C
 	}
 
 	if !p.BgOpacityPercent.IsNull() && !p.BgOpacityPercent.IsUnknown() {
-		cardMetadata.SetBgOpacityPercent(int32(p.BgOpacityPercent.ValueInt64()))
+		cardMetadata.SetBgOpacityPercent(p.BgOpacityPercent.ValueInt32())
 	}
 
 	if !p.CardColor.IsNull() && !p.CardColor.IsUnknown() {
@@ -854,7 +854,7 @@ func (p *MetadataModel) expandMetaDataModel(ctx context.Context) (*credentials.C
 	}
 
 	if !p.Columns.IsNull() && !p.Columns.IsUnknown() {
-		cardMetadata.SetColumns(int32(p.Columns.ValueInt64()))
+		cardMetadata.SetColumns(p.Columns.ValueInt32())
 	}
 
 	if !p.Description.IsNull() && !p.Description.IsUnknown() {
@@ -870,7 +870,7 @@ func (p *MetadataModel) expandMetaDataModel(ctx context.Context) (*credentials.C
 	}
 
 	if !p.Version.IsNull() && !p.Version.IsUnknown() {
-		cardMetadata.SetVersion(int32(p.Version.ValueInt64()))
+		cardMetadata.SetVersion(p.Version.ValueInt32())
 	}
 
 	// expand fields

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -77,7 +77,7 @@ type MFADevicePolicyOtpResourceModel struct {
 
 type MFADevicePolicyFailureResourceModel struct {
 	CoolDown types.Object `tfsdk:"cool_down"`
-	Count    types.Int64  `tfsdk:"count"`
+	Count    types.Int32  `tfsdk:"count"`
 }
 
 type MFADevicePolicyCooldownResourceModel MFADevicePolicyTimePeriodResourceModel
@@ -85,7 +85,7 @@ type MFADevicePolicyPushTimeoutResourceModel MFADevicePolicyTimePeriodResourceMo
 type MFADevicePolicyLockDurationResourceModel MFADevicePolicyTimePeriodResourceModel
 type MFADevicePolicyPairingKeyLifetimeResourceModel MFADevicePolicyTimePeriodResourceModel
 type MFADevicePolicyTimePeriodResourceModel struct {
-	Duration types.Int64  `tfsdk:"duration"`
+	Duration types.Int32  `tfsdk:"duration"`
 	TimeUnit types.String `tfsdk:"time_unit"`
 }
 
@@ -131,7 +131,7 @@ type MFADevicePolicyEnabledResourceModel struct {
 }
 
 type MFADevicePolicyPushLimitResourceModel struct {
-	Count        types.Int64  `tfsdk:"count"`
+	Count        types.Int32  `tfsdk:"count"`
 	LockDuration types.Object `tfsdk:"lock_duration"`
 	TimePeriod   types.Object `tfsdk:"time_period"`
 }
@@ -155,11 +155,11 @@ var (
 
 	MFADevicePolicyFailureTFObjectTypes = map[string]attr.Type{
 		"cool_down": types.ObjectType{AttrTypes: MFADevicePolicyTimePeriodTFObjectTypes},
-		"count":     types.Int64Type,
+		"count":     types.Int32Type,
 	}
 
 	MFADevicePolicyTimePeriodTFObjectTypes = map[string]attr.Type{
-		"duration":  types.Int64Type,
+		"duration":  types.Int32Type,
 		"time_unit": types.StringType,
 	}
 
@@ -200,7 +200,7 @@ var (
 	}
 
 	MFADevicePolicyMobileApplicationPushLimitTFObjectTypes = map[string]attr.Type{
-		"count":         types.Int64Type,
+		"count":         types.Int32Type,
 		"lock_duration": types.ObjectType{AttrTypes: MFADevicePolicyTimePeriodTFObjectTypes},
 		"time_period":   types.ObjectType{AttrTypes: MFADevicePolicyTimePeriodTFObjectTypes},
 	}
@@ -210,7 +210,7 @@ var (
 	}
 
 	MFADevicePolicyMobileOtpFailureTFObjectTypes = map[string]attr.Type{
-		"count":     types.Int64Type,
+		"count":     types.Int32Type,
 		"cool_down": types.ObjectType{AttrTypes: MFADevicePolicyTimePeriodTFObjectTypes},
 	}
 
@@ -226,7 +226,7 @@ var (
 	}
 
 	MFADevicePolicyTotpOtpFailureTFObjectTypes = map[string]attr.Type{
-		"count":     types.Int64Type,
+		"count":     types.Int32Type,
 		"cool_down": types.ObjectType{AttrTypes: MFADevicePolicyTimePeriodTFObjectTypes},
 	}
 
@@ -516,7 +516,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 									Optional:    true,
 
 									Attributes: map[string]schema.Attribute{
-										"duration": schema.Int64Attribute{
+										"duration": schema.Int32Attribute{
 											Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the amount of time an issued pairing key can be used until it expires. Minimum is 1 minute and maximum is 48 hours. If this parameter is not provided, the duration is set to 10 minutes.").Description,
 											Required:    true,
 										},
@@ -553,18 +553,18 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 									Default: objectdefault.StaticValue(types.ObjectValueMust(
 										MFADevicePolicyMobileApplicationPushLimitTFObjectTypes,
 										map[string]attr.Value{
-											"count": types.Int64Value(mobileApplicationsPushLimitCountDefault),
+											"count": types.Int32Value(mobileApplicationsPushLimitCountDefault),
 											"lock_duration": types.ObjectValueMust(
 												MFADevicePolicyTimePeriodTFObjectTypes,
 												map[string]attr.Value{
-													"duration":  types.Int64Value(mobileApplicationsPushLimitLockDurationDurationDefault),
+													"duration":  types.Int32Value(mobileApplicationsPushLimitLockDurationDurationDefault),
 													"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
 												},
 											),
 											"time_period": types.ObjectValueMust(
 												MFADevicePolicyTimePeriodTFObjectTypes,
 												map[string]attr.Value{
-													"duration":  types.Int64Value(mobileApplicationsPushLimitTimePeriodDurationDefault),
+													"duration":  types.Int32Value(mobileApplicationsPushLimitTimePeriodDurationDefault),
 													"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
 												},
 											),
@@ -572,15 +572,15 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 									)),
 
 									Attributes: map[string]schema.Attribute{
-										"count": schema.Int64Attribute{
+										"count": schema.Int32Attribute{
 											Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of consecutive push notifications that can be ignored or rejected by a user within a defined period before push notifications are blocked for the application. The minimum value is `1` and the maximum value is `50`. If this parameter is not provided, the default value is `5`.").Description,
 											Optional:    true,
 											Computed:    true,
 
-											Default: int64default.StaticInt64(mobileApplicationsPushLimitCountDefault),
+											Default: int32default.StaticInt32(mobileApplicationsPushLimitCountDefault),
 
-											Validators: []validator.Int64{
-												int64validator.Between(mobileApplicationsPushLimitCountMin, mobileApplicationsPushLimitCountMax),
+											Validators: []validator.Int32{
+												int32validator.Between(mobileApplicationsPushLimitCountMin, mobileApplicationsPushLimitCountMax),
 											},
 										},
 
@@ -589,7 +589,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 											Optional:    true,
 
 											Attributes: map[string]schema.Attribute{
-												"duration": schema.Int64Attribute{
+												"duration": schema.Int32Attribute{
 													Description:         mobileApplicationsPushLimitLockDurationDurationDescription.Description,
 													MarkdownDescription: mobileApplicationsPushLimitLockDurationDurationDescription.MarkdownDescription,
 													Required:            true,
@@ -612,7 +612,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 											Optional:    true,
 
 											Attributes: map[string]schema.Attribute{
-												"duration": schema.Int64Attribute{
+												"duration": schema.Int32Attribute{
 													Description:         mobileApplicationsPushLimitTimePeriodDurationDescription.Description,
 													MarkdownDescription: mobileApplicationsPushLimitTimePeriodDurationDescription.MarkdownDescription,
 													Required:            true,
@@ -637,7 +637,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 									Optional:    true,
 
 									Attributes: map[string]schema.Attribute{
-										"duration": schema.Int64Attribute{
+										"duration": schema.Int32Attribute{
 											Description:         mobileApplicationsPushTimeoutDurationDescription.Description,
 											MarkdownDescription: mobileApplicationsPushTimeoutDurationDescription.MarkdownDescription,
 											Required:            true,
@@ -672,11 +672,11 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 								"failure": types.ObjectValueMust(
 									MFADevicePolicyMobileOtpFailureTFObjectTypes,
 									map[string]attr.Value{
-										"count": types.Int64Value(mobileOtpFailureCountDefault),
+										"count": types.Int32Value(mobileOtpFailureCountDefault),
 										"cool_down": types.ObjectValueMust(
 											MFADevicePolicyTimePeriodTFObjectTypes,
 											map[string]attr.Value{
-												"duration":  types.Int64Value(mobileApplicationsOtpFailureCoolDownDurationDefault),
+												"duration":  types.Int32Value(mobileApplicationsOtpFailureCoolDownDurationDefault),
 												"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
 											},
 										),
@@ -691,16 +691,16 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 								Required:    true,
 
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description:         mobileOtpFailureCountDescription.Description,
 										MarkdownDescription: mobileOtpFailureCountDescription.MarkdownDescription,
 										Optional:            true,
 										Computed:            true,
 
-										Default: int64default.StaticInt64(mobileOtpFailureCountDefault),
+										Default: int32default.StaticInt32(mobileOtpFailureCountDefault),
 
-										Validators: []validator.Int64{
-											int64validator.Between(mobileOtpFailureCountMin, mobileOtpFailureCountMax),
+										Validators: []validator.Int32{
+											int32validator.Between(mobileOtpFailureCountMin, mobileOtpFailureCountMax),
 										},
 									},
 
@@ -709,7 +709,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 										Required:    true,
 
 										Attributes: map[string]schema.Attribute{
-											"duration": schema.Int64Attribute{
+											"duration": schema.Int32Attribute{
 												Description:         mobileOtpFailureCoolDownDurationDescription.Description,
 												MarkdownDescription: mobileOtpFailureCoolDownDurationDescription.MarkdownDescription,
 												Required:            true,
@@ -769,11 +769,11 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 								"failure": types.ObjectValueMust(
 									MFADevicePolicyTotpOtpFailureTFObjectTypes,
 									map[string]attr.Value{
-										"count": types.Int64Value(totpOtpFailureCountDefault),
+										"count": types.Int32Value(totpOtpFailureCountDefault),
 										"cool_down": types.ObjectValueMust(
 											MFADevicePolicyTimePeriodTFObjectTypes,
 											map[string]attr.Value{
-												"duration":  types.Int64Value(totpOtpFailureCoolDownDurationDefault),
+												"duration":  types.Int32Value(totpOtpFailureCoolDownDurationDefault),
 												"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
 											},
 										),
@@ -793,7 +793,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 										Optional:    true,
 
 										Attributes: map[string]schema.Attribute{
-											"duration": schema.Int64Attribute{
+											"duration": schema.Int32Attribute{
 												Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.").Description,
 												Required:    true,
 											},
@@ -810,7 +810,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 										},
 									},
 
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.").Description,
 										Required:    true,
 									},
@@ -912,11 +912,11 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 						"failure": types.ObjectValueMust(
 							MFADevicePolicyFailureTFObjectTypes,
 							map[string]attr.Value{
-								"count": types.Int64Value(otpFailureCountDefault),
+								"count": types.Int32Value(otpFailureCountDefault),
 								"cool_down": types.ObjectValueMust(
 									MFADevicePolicyTimePeriodTFObjectTypes,
 									map[string]attr.Value{
-										"duration":  types.Int64Value(otpFailureCoolDownDurationDefault),
+										"duration":  types.Int32Value(otpFailureCoolDownDurationDefault),
 										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
 									},
 								),
@@ -925,7 +925,7 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 						"lifetime": types.ObjectValueMust(
 							MFADevicePolicyTimePeriodTFObjectTypes,
 							map[string]attr.Value{
-								"duration":  types.Int64Value(otpLifetimeDurationDefault),
+								"duration":  types.Int32Value(otpLifetimeDurationDefault),
 								"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
 							},
 						),
@@ -943,7 +943,7 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 								Required:    true,
 
 								Attributes: map[string]schema.Attribute{
-									"duration": schema.Int64Attribute{
+									"duration": schema.Int32Attribute{
 										Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.").Description,
 										Required:    true,
 									},
@@ -960,7 +960,7 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 								},
 							},
 
-							"count": schema.Int64Attribute{
+							"count": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.").Description,
 								Required:    true,
 							},
@@ -972,7 +972,7 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 						Optional:    true,
 
 						Attributes: map[string]schema.Attribute{
-							"duration": schema.Int64Attribute{
+							"duration": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the duration (number of time units) that the passcode is valid before it expires.").Description,
 								Required:    true,
 							},
@@ -1474,7 +1474,7 @@ func (p *MFADevicePolicyOfflineDeviceOtpResourceModel) expand(ctx context.Contex
 	}
 
 	lifetime := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpLifeTime(
-		int32(lifetimePlan.Duration.ValueInt64()),
+		lifetimePlan.Duration.ValueInt32(),
 		mfa.EnumTimeUnit(lifetimePlan.TimeUnit.ValueString()),
 	)
 
@@ -1499,9 +1499,9 @@ func (p *MFADevicePolicyOfflineDeviceOtpResourceModel) expand(ctx context.Contex
 	}
 
 	failure := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(
-		int32(failurePlan.Count.ValueInt64()),
+		failurePlan.Count.ValueInt32(),
 		*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(
-			int32(failureCooldownPlan.Duration.ValueInt64()),
+			failureCooldownPlan.Duration.ValueInt32(),
 			mfa.EnumTimeUnit(failureCooldownPlan.TimeUnit.ValueString()),
 		),
 	)
@@ -1599,9 +1599,9 @@ func (p *MFADevicePolicyFailureResourceModel) expand(ctx context.Context) (*mfa.
 	}
 
 	data := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(
-		int32(p.Count.ValueInt64()),
+		p.Count.ValueInt32(),
 		*mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(
-			int32(cooldownPlan.Duration.ValueInt64()),
+			cooldownPlan.Duration.ValueInt32(),
 			mfa.EnumTimeUnit(cooldownPlan.TimeUnit.ValueString()),
 		),
 	)
@@ -1719,7 +1719,7 @@ func (p *MFADevicePolicyMobileApplicationResourceModel) expand(ctx context.Conte
 
 		data.SetPairingKeyLifetime(
 			*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPairingKeyLifetime(
-				int32(plan.Duration.ValueInt64()),
+				plan.Duration.ValueInt32(),
 				mfa.EnumTimeUnitPairingKeyLifetime(plan.TimeUnit.ValueString()),
 			),
 		)
@@ -1776,7 +1776,7 @@ func (p *MFADevicePolicyMobileApplicationResourceModel) expand(ctx context.Conte
 
 		data.SetPushTimeout(
 			*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPushTimeout(
-				int32(plan.Duration.ValueInt64()),
+				plan.Duration.ValueInt32(),
 				mfa.EnumTimeUnitPushTimeout(plan.TimeUnit.ValueString()),
 			),
 		)
@@ -1791,7 +1791,7 @@ func (p *MFADevicePolicyPushLimitResourceModel) expand(ctx context.Context) (*mf
 	data := mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPushLimit()
 
 	if !p.Count.IsNull() && !p.Count.IsUnknown() {
-		data.SetCount(int32(p.Count.ValueInt64()))
+		data.SetCount(p.Count.ValueInt32())
 	}
 
 	if !p.LockDuration.IsNull() && !p.LockDuration.IsUnknown() {
@@ -1806,7 +1806,7 @@ func (p *MFADevicePolicyPushLimitResourceModel) expand(ctx context.Context) (*mf
 
 		data.SetLockDuration(
 			*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPushLimitLockDuration(
-				int32(plan.Duration.ValueInt64()),
+				plan.Duration.ValueInt32(),
 				mfa.EnumTimeUnit(plan.TimeUnit.ValueString()),
 			),
 		)
@@ -1824,7 +1824,7 @@ func (p *MFADevicePolicyPushLimitResourceModel) expand(ctx context.Context) (*mf
 
 		data.SetTimePeriod(
 			*mfa.NewDeviceAuthenticationPolicyMobileApplicationsInnerPushLimitTimePeriod(
-				int32(plan.Duration.ValueInt64()),
+				plan.Duration.ValueInt32(),
 				mfa.EnumTimeUnit(plan.TimeUnit.ValueString()),
 			),
 		)

--- a/internal/service/mfa/resource_mfa_settings.go
+++ b/internal/service/mfa/resource_mfa_settings.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -37,12 +37,12 @@ type mFASettingsResourceModelV1 struct {
 }
 
 type mFASettingsLockoutResourceModelV1 struct {
-	FailureCount    types.Int64 `tfsdk:"failure_count"`
-	DurationSeconds types.Int64 `tfsdk:"duration_seconds"`
+	FailureCount    types.Int32 `tfsdk:"failure_count"`
+	DurationSeconds types.Int32 `tfsdk:"duration_seconds"`
 }
 
 type mFASettingsPairingResourceModelV1 struct {
-	MaxAllowedDevices types.Int64  `tfsdk:"max_allowed_devices"`
+	MaxAllowedDevices types.Int32  `tfsdk:"max_allowed_devices"`
 	PairingKeyFormat  types.String `tfsdk:"pairing_key_format"`
 }
 
@@ -56,12 +56,12 @@ type mFASettingsUsersResourceModelV1 struct {
 
 var (
 	MFASettingsLockoutTFObjectTypes = map[string]attr.Type{
-		"failure_count":    types.Int64Type,
-		"duration_seconds": types.Int64Type,
+		"failure_count":    types.Int32Type,
+		"duration_seconds": types.Int32Type,
 	}
 
 	MFASettingsPairingTFObjectTypes = map[string]attr.Type{
-		"max_allowed_devices": types.Int64Type,
+		"max_allowed_devices": types.Int32Type,
 		"pairing_key_format":  types.StringType,
 	}
 
@@ -135,21 +135,21 @@ func (r *MFASettingsResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"failure_count": schema.Int64Attribute{
+					"failure_count": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the maximum number of incorrect authentication attempts before the account is locked.").Description,
 						Required:    true,
 
-						Validators: []validator.Int64{
-							int64validator.AtLeast(0),
+						Validators: []validator.Int32{
+							int32validator.AtLeast(0),
 						},
 					},
 
-					"duration_seconds": schema.Int64Attribute{
+					"duration_seconds": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the number of seconds to keep the account in a locked state").Description,
 						Optional:    true,
 
-						Validators: []validator.Int64{
-							int64validator.AtLeast(0),
+						Validators: []validator.Int32{
+							int32validator.AtLeast(0),
 						},
 					},
 				},
@@ -160,16 +160,16 @@ func (r *MFASettingsResource) Schema(ctx context.Context, req resource.SchemaReq
 				Required:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"max_allowed_devices": schema.Int64Attribute{
+					"max_allowed_devices": schema.Int32Attribute{
 						Description:         pairingMaxAllowedDevicesDescription.Description,
 						MarkdownDescription: pairingMaxAllowedDevicesDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(maxAllowedDevicesDefault),
+						Default: int32default.StaticInt32(maxAllowedDevicesDefault),
 
-						Validators: []validator.Int64{
-							int64validator.Between(maxAllowedDevicesMin, maxAllowedDevicesMax),
+						Validators: []validator.Int32{
+							int32validator.Between(maxAllowedDevicesMin, maxAllowedDevicesMax),
 						},
 					},
 
@@ -476,7 +476,7 @@ func (p *mFASettingsResourceModelV1) expand(ctx context.Context) (*mfa.MFASettin
 		return nil, diags
 	}
 	pairing := mfa.NewMFASettingsPairing(
-		int32(pairingPlan.MaxAllowedDevices.ValueInt64()),
+		pairingPlan.MaxAllowedDevices.ValueInt32(),
 		mfa.EnumMFASettingsPairingKeyFormat(pairingPlan.PairingKeyFormat.ValueString()),
 	)
 
@@ -496,11 +496,11 @@ func (p *mFASettingsResourceModelV1) expand(ctx context.Context) (*mfa.MFASettin
 			return nil, diags
 		}
 		lockout := mfa.NewMFASettingsLockout(
-			int32(lockoutPlan.FailureCount.ValueInt64()),
+			lockoutPlan.FailureCount.ValueInt32(),
 		)
 
 		if !lockoutPlan.DurationSeconds.IsNull() && !lockoutPlan.DurationSeconds.IsUnknown() {
-			lockout.SetDurationSeconds(int32(lockoutPlan.DurationSeconds.ValueInt64()))
+			lockout.SetDurationSeconds(lockoutPlan.DurationSeconds.ValueInt32())
 		}
 
 		data.SetLockout(*lockout)

--- a/internal/service/mfa/resource_mfa_settings_schema_upgrade_0_to_1.go
+++ b/internal/service/mfa/resource_mfa_settings_schema_upgrade_0_to_1.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
@@ -53,11 +53,11 @@ func (r *MFASettingsResource) UpgradeState(ctx context.Context) map[int64]resour
 					"pairing": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"max_allowed_devices": schema.Int64Attribute{
+								"max_allowed_devices": schema.Int32Attribute{
 									Optional: true,
 									Computed: true,
 
-									Default: int64default.StaticInt64(pairingMaxAllowedDevicesDescription),
+									Default: int32default.StaticInt32(pairingMaxAllowedDevicesDescription),
 								},
 
 								"pairing_key_format": schema.StringAttribute{
@@ -70,11 +70,11 @@ func (r *MFASettingsResource) UpgradeState(ctx context.Context) map[int64]resour
 					"lockout": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"failure_count": schema.Int64Attribute{
+								"failure_count": schema.Int32Attribute{
 									Required: true,
 								},
 
-								"duration_seconds": schema.Int64Attribute{
+								"duration_seconds": schema.Int32Attribute{
 									Optional: true,
 								},
 							},

--- a/internal/service/risk/resource_risk_policy.go
+++ b/internal/service/risk/resource_risk_policy.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -35,7 +35,7 @@ import (
 	"github.com/patrickcping/pingone-go-sdk-v2/risk"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
-	int64validatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/int64validator"
+	int32validatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/int32validator"
 	setvalidatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/setvalidator"
 	stringvalidatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/stringvalidator"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
@@ -70,25 +70,25 @@ type riskPolicyResourcePolicyModel struct {
 }
 
 type riskPolicyResourcePolicyThresholdScoreBetweenModel struct {
-	MinScore types.Int64 `tfsdk:"min_score"`
-	MaxScore types.Int64 `tfsdk:"max_score"`
+	MinScore types.Int32 `tfsdk:"min_score"`
+	MaxScore types.Int32 `tfsdk:"max_score"`
 }
 
 type riskPolicyResourcePolicyWeightsPredictorModel struct {
 	CompactName             types.String `tfsdk:"compact_name"`
 	PredictorReferenceValue types.String `tfsdk:"predictor_reference_value"`
-	Weight                  types.Int64  `tfsdk:"weight"`
+	Weight                  types.Int32  `tfsdk:"weight"`
 }
 
 type riskPolicyResourcePolicyScoresPredictorModel struct {
 	CompactName             types.String `tfsdk:"compact_name"`
 	PredictorReferenceValue types.String `tfsdk:"predictor_reference_value"`
-	Score                   types.Int64  `tfsdk:"score"`
+	Score                   types.Int32  `tfsdk:"score"`
 }
 
 type riskPolicyResourcePolicyOverrideModel struct {
 	Name      types.String `tfsdk:"name"`
-	Priority  types.Int64  `tfsdk:"priority"`
+	Priority  types.Int32  `tfsdk:"priority"`
 	Result    types.Object `tfsdk:"result"`
 	Condition types.Object `tfsdk:"condition"`
 }
@@ -110,8 +110,8 @@ type riskPolicyResourcePolicyOverrideConditionModel struct {
 
 var (
 	policyThresholdsTFObjectTypes = map[string]attr.Type{
-		"min_score": types.Int64Type,
-		"max_score": types.Int64Type,
+		"min_score": types.Int32Type,
+		"max_score": types.Int32Type,
 	}
 
 	// Weights
@@ -130,7 +130,7 @@ var (
 	policyWeightsPredictorTFObjectTypes = map[string]attr.Type{
 		"compact_name":              types.StringType,
 		"predictor_reference_value": types.StringType,
-		"weight":                    types.Int64Type,
+		"weight":                    types.Int32Type,
 	}
 
 	// Scores
@@ -149,12 +149,12 @@ var (
 	policyScoresPredictorTFObjectTypes = map[string]attr.Type{
 		"compact_name":              types.StringType,
 		"predictor_reference_value": types.StringType,
-		"score":                     types.Int64Type,
+		"score":                     types.Int32Type,
 	}
 
 	overridesTFObjectTypes = map[string]attr.Type{
 		"name":     types.StringType,
-		"priority": types.Int64Type,
+		"priority": types.Int32Type,
 		"result": types.ObjectType{
 			AttrTypes: overridesResultTFObjectTypes,
 		},
@@ -368,8 +368,8 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 						framework.SchemaAttributeDescriptionFromMarkdown(
 							"An object that specifies the lower and upper bound threshold score values that define the medium risk outcome as a result of the policy evaluation.",
 						),
-						[]validator.Int64{
-							int64validatorinternal.IsLessThanPathValue(
+						[]validator.Int32{
+							int32validatorinternal.IsLessThanPathValue(
 								path.MatchRoot("policy_weights").AtName("policy_threshold_high").AtName("min_score"),
 							),
 						},
@@ -380,8 +380,8 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 						framework.SchemaAttributeDescriptionFromMarkdown(
 							"An object that specifies the lower and upper bound threshold score values that define the high risk outcome as a result of the policy evaluation.",
 						),
-						[]validator.Int64{
-							int64validatorinternal.IsGreaterThanPathValue(
+						[]validator.Int32{
+							int32validatorinternal.IsGreaterThanPathValue(
 								path.MatchRoot("policy_weights").AtName("policy_threshold_medium").AtName("min_score"),
 							),
 						},
@@ -405,13 +405,13 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 									Computed:    true,
 								},
 
-								"weight": schema.Int64Attribute{
+								"weight": schema.Int32Attribute{
 									Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the weight to apply to the predictor when calculating the overall risk score.").Description,
 									Required:    true,
 
-									Validators: []validator.Int64{
-										int64validator.AtLeast(weightMinimumDefault),
-										int64validator.AtMost(weightMaximumDefault),
+									Validators: []validator.Int32{
+										int32validator.AtLeast(weightMinimumDefault),
+										int32validator.AtMost(weightMaximumDefault),
 									},
 								},
 							},
@@ -442,8 +442,8 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 						framework.SchemaAttributeDescriptionFromMarkdown(
 							"An object that specifies the lower and upper bound threshold values that define the medium risk outcome as a result of the policy evaluation.",
 						),
-						[]validator.Int64{
-							int64validatorinternal.IsLessThanPathValue(
+						[]validator.Int32{
+							int32validatorinternal.IsLessThanPathValue(
 								path.MatchRoot("policy_scores").AtName("policy_threshold_high").AtName("min_score"),
 							),
 						},
@@ -454,8 +454,8 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 						framework.SchemaAttributeDescriptionFromMarkdown(
 							"An object that specifies the lower and upper bound threshold values that define the high risk outcome as a result of the policy evaluation.",
 						),
-						[]validator.Int64{
-							int64validatorinternal.IsGreaterThanPathValue(
+						[]validator.Int32{
+							int32validatorinternal.IsGreaterThanPathValue(
 								path.MatchRoot("policy_scores").AtName("policy_threshold_medium").AtName("min_score"),
 							),
 						},
@@ -479,13 +479,13 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 									Computed:    true,
 								},
 
-								"score": schema.Int64Attribute{
+								"score": schema.Int32Attribute{
 									Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the score to apply to the High risk / true outcome of the predictor, to apply to the overall risk calculation.").Description,
 									Required:    true,
 
-									Validators: []validator.Int64{
-										int64validator.AtLeast(scoreMinimumDefault),
-										int64validator.AtMost(scoreMaximumDefault),
+									Validators: []validator.Int32{
+										int32validator.AtLeast(scoreMinimumDefault),
+										int32validator.AtMost(scoreMaximumDefault),
 									},
 								},
 							},
@@ -519,7 +519,7 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 							Computed:    true,
 						},
 
-						"priority": schema.Int64Attribute{
+						"priority": schema.Int32Attribute{
 							Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that indicates the order in which the override is applied during risk policy evaluation.  The lower the value, the higher the priority.  The priority is determined by the order in which the overrides are defined in HCL.").Description,
 							Computed:    true,
 						},
@@ -649,9 +649,9 @@ func (r *RiskPolicyResource) Schema(ctx context.Context, req resource.SchemaRequ
 	}
 }
 
-func riskPolicyThresholdSchema(useScores bool, policyThresholdsDescription framework.SchemaAttributeDescription, validators []validator.Int64) schema.SingleNestedAttribute {
+func riskPolicyThresholdSchema(useScores bool, policyThresholdsDescription framework.SchemaAttributeDescription, validators []validator.Int32) schema.SingleNestedAttribute {
 
-	validators = append(validators, int64validator.AtLeast(1))
+	validators = append(validators, int32validator.AtLeast(1))
 
 	policyThresholdScoresMediumScoreDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"An integer that specifies the minimum score to use as the lower bound value of the policy threshold.",
@@ -664,13 +664,13 @@ func riskPolicyThresholdSchema(useScores bool, policyThresholdsDescription frame
 	if !useScores {
 		maxAllowedValue := 100
 		denominator := 10
-		validators = append(validators, int64validator.AtMost(int64(maxAllowedValue)))
-		validators = append(validators, int64validatorinternal.IsDivisibleBy(int64(denominator)))
+		validators = append(validators, int32validator.AtMost(int32(maxAllowedValue)))
+		validators = append(validators, int32validatorinternal.IsDivisibleBy(int32(denominator)))
 
 		policyThresholdScoresMediumScoreDescription = policyThresholdScoresMediumScoreDescription.AppendMarkdownString(fmt.Sprintf("For weights policies, the score values should be 10x the desired risk value in the console. For example, a risk score of `5` in the console should be entered as `50`.  The provided score must be exactly divisible by 10.  Maximum value allowed is `%d`", maxAllowedValue))
 	} else {
 		maxAllowedValue := 1000
-		validators = append(validators, int64validator.AtMost(int64(maxAllowedValue)))
+		validators = append(validators, int32validator.AtMost(int32(maxAllowedValue)))
 		policyThresholdScoresMediumScoreDescription = policyThresholdScoresMediumScoreDescription.AppendMarkdownString(fmt.Sprintf("Maximum value allowed is `%d`", maxAllowedValue))
 	}
 
@@ -680,7 +680,7 @@ func riskPolicyThresholdSchema(useScores bool, policyThresholdsDescription frame
 		Required:            true,
 
 		Attributes: map[string]schema.Attribute{
-			"min_score": schema.Int64Attribute{
+			"min_score": schema.Int32Attribute{
 				Description:         policyThresholdScoresMediumScoreDescription.Description,
 				MarkdownDescription: policyThresholdScoresMediumScoreDescription.MarkdownDescription,
 				Required:            true,
@@ -688,7 +688,7 @@ func riskPolicyThresholdSchema(useScores bool, policyThresholdsDescription frame
 				Validators: validators,
 			},
 
-			"max_score": schema.Int64Attribute{
+			"max_score": schema.Int32Attribute{
 				Description:         policyThresholdScoresHighScoreDescription.Description,
 				MarkdownDescription: policyThresholdScoresHighScoreDescription.MarkdownDescription,
 				Computed:            true,
@@ -837,14 +837,14 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 	}
 
 	// Set the min-max threshold scores/weights
-	var policyThresholdHighMinValue *int64
+	var policyThresholdHighMinValue *int32
 	resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root(rootPath).AtName("policy_threshold_high").AtName("min_score"), &policyThresholdHighMinValue)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Plan.SetAttribute(ctx, path.Root(rootPath).AtName("policy_threshold_medium").AtName("max_score"), types.Int64Value(*policyThresholdHighMinValue))
-	resp.Plan.SetAttribute(ctx, path.Root(rootPath).AtName("policy_threshold_high").AtName("max_score"), types.Int64Value(int64(maxScore)))
+	resp.Plan.SetAttribute(ctx, path.Root(rootPath).AtName("policy_threshold_medium").AtName("max_score"), types.Int32Value(*policyThresholdHighMinValue))
+	resp.Plan.SetAttribute(ctx, path.Root(rootPath).AtName("policy_threshold_high").AtName("max_score"), types.Int32Value(int32(maxScore)))
 
 	// Set the predictors
 	plannedPredictors, d := types.SetValue(types.ObjectType{AttrTypes: predictorAttrType}, flattenedPolicyList)
@@ -920,7 +920,7 @@ func (r *RiskPolicyResource) ModifyPlan(ctx context.Context, req resource.Modify
 
 			overrideMap := map[string]attr.Value{
 				"name":      types.StringValue(overrideName),
-				"priority":  types.Int64Value(int64(priorityCount)),
+				"priority":  types.Int32Value(int32(priorityCount)),
 				"result":    overridePlan.Result,
 				"condition": conditionObj,
 			}
@@ -1427,7 +1427,7 @@ func (p *riskPolicyResourceModel) expand(ctx context.Context, apiClient *risk.AP
 				*result,
 			)
 
-			op.SetPriority(int32(overridePlan.Priority.ValueInt64()))
+			op.SetPriority(overridePlan.Priority.ValueInt32())
 
 			riskPolicies = append(riskPolicies, op)
 		}
@@ -1520,8 +1520,8 @@ func (p *riskPolicyResourcePolicyModel) expand(ctx context.Context, useScores bo
 
 		mediumPolicyCondition.SetBetween(
 			*risk.NewRiskPolicyConditionBetween(
-				int32(plan.MinScore.ValueInt64()),
-				int32(plan.MaxScore.ValueInt64()),
+				plan.MinScore.ValueInt32(),
+				plan.MaxScore.ValueInt32(),
 			),
 		)
 	}
@@ -1540,8 +1540,8 @@ func (p *riskPolicyResourcePolicyModel) expand(ctx context.Context, useScores bo
 
 		highPolicyCondition.SetBetween(
 			*risk.NewRiskPolicyConditionBetween(
-				int32(plan.MinScore.ValueInt64()),
-				int32(plan.MaxScore.ValueInt64()),
+				plan.MinScore.ValueInt32(),
+				plan.MaxScore.ValueInt32(),
 			),
 		)
 	}
@@ -1561,7 +1561,7 @@ func (p *riskPolicyResourcePolicyModel) expand(ctx context.Context, useScores bo
 					aggregatedScores,
 					*risk.NewRiskPolicyConditionAggregatedScoresInner(
 						predictor.PredictorReferenceValue.ValueString(),
-						int32(predictor.Score.ValueInt64()),
+						predictor.Score.ValueInt32(),
 					),
 				)
 
@@ -1585,7 +1585,7 @@ func (p *riskPolicyResourcePolicyModel) expand(ctx context.Context, useScores bo
 					aggregatedWeights,
 					*risk.NewRiskPolicyConditionAggregatedWeightsInner(
 						predictor.PredictorReferenceValue.ValueString(),
-						int32(predictor.Weight.ValueInt64()),
+						predictor.Weight.ValueInt32(),
 					),
 				)
 

--- a/internal/service/risk/resource_risk_predictor.go
+++ b/internal/service/risk/resource_risk_predictor.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float32planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
@@ -109,8 +109,8 @@ type predictorCustomMapHML struct {
 }
 
 type predictorCustomMapHMLBetweenRanges struct {
-	MinScore types.Float64 `tfsdk:"min_value"`
-	MaxScore types.Float64 `tfsdk:"max_value"`
+	MinScore types.Float32 `tfsdk:"min_value"`
+	MaxScore types.Float32 `tfsdk:"max_value"`
 }
 
 type predictorCustomMapHMLList struct {
@@ -126,11 +126,11 @@ type predictorDevice struct {
 // User Location Anomaly
 type predictorUserLocationAnomaly struct {
 	Radius types.Object `tfsdk:"radius"`
-	Days   types.Int64  `tfsdk:"days"`
+	Days   types.Int32  `tfsdk:"days"`
 }
 
 type predictorUserLocationAnomalyRadius struct {
-	Distance types.Int64  `tfsdk:"distance"`
+	Distance types.Int32  `tfsdk:"distance"`
 	Unit     types.String `tfsdk:"unit"`
 }
 
@@ -156,31 +156,31 @@ type predictorVelocity struct {
 
 type predictorVelocityEvery struct {
 	Unit      types.String `tfsdk:"unit"`
-	Quantity  types.Int64  `tfsdk:"quantity"`
-	MinSample types.Int64  `tfsdk:"min_sample"`
+	Quantity  types.Int32  `tfsdk:"quantity"`
+	MinSample types.Int32  `tfsdk:"min_sample"`
 }
 
 type predictorVelocityFallback struct {
 	Strategy types.String  `tfsdk:"strategy"`
-	High     types.Float64 `tfsdk:"high"`
-	Medium   types.Float64 `tfsdk:"medium"`
+	High     types.Float32 `tfsdk:"high"`
+	Medium   types.Float32 `tfsdk:"medium"`
 }
 
 type predictorVelocitySlidingWindow struct {
 	Unit      types.String `tfsdk:"unit"`
-	Quantity  types.Int64  `tfsdk:"quantity"`
-	MinSample types.Int64  `tfsdk:"min_sample"`
+	Quantity  types.Int32  `tfsdk:"quantity"`
+	MinSample types.Int32  `tfsdk:"min_sample"`
 }
 
 type predictorVelocityUse struct {
 	UseType types.String  `tfsdk:"type"`
-	Medium  types.Float64 `tfsdk:"medium"`
-	High    types.Float64 `tfsdk:"high"`
+	Medium  types.Float32 `tfsdk:"medium"`
+	High    types.Float32 `tfsdk:"high"`
 }
 
 // Default
 type predictorDefault struct {
-	Weight types.Int64  `tfsdk:"weight"`
+	Weight types.Int32  `tfsdk:"weight"`
 	Result types.Object `tfsdk:"result"`
 }
 
@@ -192,7 +192,7 @@ type predictorDefaultResult struct {
 var (
 	// Default
 	defaultTFObjectTypes = map[string]attr.Type{
-		"weight": types.Int64Type,
+		"weight": types.Int32Type,
 		"result": types.ObjectType{
 			AttrTypes: defaultResultTFObjectTypes,
 		},
@@ -260,8 +260,8 @@ var (
 	}
 
 	predictorCustomMapHMLBetweenRangesTFObjectTypes = map[string]attr.Type{
-		"min_value": types.Float64Type,
-		"max_value": types.Float64Type,
+		"min_value": types.Float32Type,
+		"max_value": types.Float32Type,
 	}
 
 	predictorCustomMapHMLListTFObjectTypes = map[string]attr.Type{
@@ -279,11 +279,11 @@ var (
 		"radius": types.ObjectType{
 			AttrTypes: predictorUserLocationAnomalyRadiusTFObjectTypes,
 		},
-		"days": types.Int64Type,
+		"days": types.Int32Type,
 	}
 
 	predictorUserLocationAnomalyRadiusTFObjectTypes = map[string]attr.Type{
-		"distance": types.Int64Type,
+		"distance": types.Int32Type,
 		"unit":     types.StringType,
 	}
 
@@ -319,26 +319,26 @@ var (
 
 	predictorVelocityEveryTFObjectTypes = map[string]attr.Type{
 		"unit":       types.StringType,
-		"quantity":   types.Int64Type,
-		"min_sample": types.Int64Type,
+		"quantity":   types.Int32Type,
+		"min_sample": types.Int32Type,
 	}
 
 	predictorVelocityFallbackTFObjectTypes = map[string]attr.Type{
 		"strategy": types.StringType,
-		"high":     types.Float64Type,
-		"medium":   types.Float64Type,
+		"high":     types.Float32Type,
+		"medium":   types.Float32Type,
 	}
 
 	predictorVelocitySlidingWindowTFObjectTypes = map[string]attr.Type{
 		"unit":       types.StringType,
-		"quantity":   types.Int64Type,
-		"min_sample": types.Int64Type,
+		"quantity":   types.Int32Type,
+		"min_sample": types.Int32Type,
 	}
 
 	predictorVelocityUseTFObjectTypes = map[string]attr.Type{
 		"type":   types.StringType,
-		"medium": types.Float64Type,
-		"high":   types.Float64Type,
+		"medium": types.Float32Type,
+		"high":   types.Float32Type,
 	}
 )
 
@@ -585,13 +585,13 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 				Computed:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"weight": schema.Int64Attribute{
+					"weight": schema.Int32Attribute{
 						Description:         defaultWeightDescription.Description,
 						MarkdownDescription: defaultWeightDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(defaultWeightValue),
+						Default: int32default.StaticInt32(defaultWeightValue),
 					},
 
 					"result": schema.SingleNestedAttribute{
@@ -944,7 +944,7 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 						Optional:    true,
 
 						Attributes: map[string]schema.Attribute{
-							"distance": schema.Int64Attribute{
+							"distance": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the distance to apply to the predictor evaluation.").Description,
 								Required:    true,
 							},
@@ -964,12 +964,12 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 						},
 					},
 
-					"days": schema.Int64Attribute{
+					"days": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of days to apply to the predictor evaluation.").Description,
 						Computed:    true,
 
-						PlanModifiers: []planmodifier.Int64{
-							int64planmodifier.UseStateForUnknown(),
+						PlanModifiers: []planmodifier.Int32{
+							int32planmodifier.UseStateForUnknown(),
 						},
 					},
 				},
@@ -1081,21 +1081,21 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 								},
 							},
 
-							"medium": schema.Float64Attribute{
+							"medium": schema.Float32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("A floating point value that specifies a medium risk threshold for the velocity algorithm.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Float64{
-									float64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Float32{
+									float32planmodifier.UseStateForUnknown(),
 								},
 							},
 
-							"high": schema.Float64Attribute{
+							"high": schema.Float32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("A floating point value that specifies a high risk threshold for the velocity algorithm.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Float64{
-									float64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Float32{
+									float32planmodifier.UseStateForUnknown(),
 								},
 							},
 						},
@@ -1120,21 +1120,21 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 								},
 							},
 
-							"high": schema.Float64Attribute{
+							"high": schema.Float32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("A floating point value that specifies a high risk threshold for the fallback strategy.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Float64{
-									float64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Float32{
+									float32planmodifier.UseStateForUnknown(),
 								},
 							},
 
-							"medium": schema.Float64Attribute{
+							"medium": schema.Float32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("A floating point value that specifies a medium risk threshold for the fallback strategy.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Float64{
-									float64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Float32{
+									float32planmodifier.UseStateForUnknown(),
 								},
 							},
 						},
@@ -1159,21 +1159,21 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 								},
 							},
 
-							"quantity": schema.Int64Attribute{
+							"quantity": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that denotes the quantity of unit intervals to use for the velocity algorithm.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Int64{
-									int64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Int32{
+									int32planmodifier.UseStateForUnknown(),
 								},
 							},
 
-							"min_sample": schema.Int64Attribute{
+							"min_sample": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that denotes the minimum sample of data to use for the velocity algorithm.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Int64{
-									int64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Int32{
+									int32planmodifier.UseStateForUnknown(),
 								},
 							},
 						},
@@ -1198,21 +1198,21 @@ func (r *RiskPredictorResource) Schema(ctx context.Context, req resource.SchemaR
 								},
 							},
 
-							"quantity": schema.Int64Attribute{
+							"quantity": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that denotes the quantity of unit intervals to use for the velocity algorithm.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Int64{
-									int64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Int32{
+									int32planmodifier.UseStateForUnknown(),
 								},
 							},
 
-							"min_sample": schema.Int64Attribute{
+							"min_sample": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that denotes the minimum sample of data to use for the velocity algorithm.").Description,
 								Computed:    true,
 
-								PlanModifiers: []planmodifier.Int64{
-									int64planmodifier.UseStateForUnknown(),
+								PlanModifiers: []planmodifier.Int32{
+									int32planmodifier.UseStateForUnknown(),
 								},
 							},
 						},
@@ -1298,13 +1298,13 @@ func customMapBetweenRangesBoundSchema(riskResult string) schema.SingleNestedAtt
 		Optional:    true,
 
 		Attributes: map[string]schema.Attribute{
-			"min_value": schema.Float64Attribute{
+			"min_value": schema.Float32Attribute{
 				Description:         predictorCustomMapBetweenRangesMinValueDescription.Description,
 				MarkdownDescription: predictorCustomMapBetweenRangesMinValueDescription.MarkdownDescription,
 				Required:            true,
 			},
 
-			"max_value": schema.Float64Attribute{
+			"max_value": schema.Float32Attribute{
 				Description:         predictorCustomMapBetweenRangesMinValueDescription.Description,
 				MarkdownDescription: predictorCustomMapBetweenRangesMinValueDescription.MarkdownDescription,
 				Required:            true,
@@ -1824,7 +1824,7 @@ func (p *riskPredictorResourceModel) expand(ctx context.Context, apiClient *risk
 			return nil, nil, diags
 		}
 
-		dataDefault := risk.NewRiskPredictorCommonDefault(int32(defaultPlan.Weight.ValueInt64()))
+		dataDefault := risk.NewRiskPredictorCommonDefault(defaultPlan.Weight.ValueInt32())
 
 		if !defaultPlan.Result.IsNull() && !defaultPlan.Result.IsUnknown() {
 			var defaultResultPlan predictorDefaultResult
@@ -2122,8 +2122,8 @@ func (p *riskPredictorResourceModel) expandPredictorCustom(ctx context.Context, 
 			v := risk.NewRiskPredictorCustomItemBetween(
 				contains,
 				*risk.NewRiskPredictorCustomItemBetweenBetween(
-					float32(highHmlPlan.MinScore.ValueFloat64()),
-					float32(highHmlPlan.MaxScore.ValueFloat64()),
+					highHmlPlan.MinScore.ValueFloat32(),
+					highHmlPlan.MaxScore.ValueFloat32(),
 				),
 			)
 
@@ -2146,8 +2146,8 @@ func (p *riskPredictorResourceModel) expandPredictorCustom(ctx context.Context, 
 			v := risk.NewRiskPredictorCustomItemBetween(
 				contains,
 				*risk.NewRiskPredictorCustomItemBetweenBetween(
-					float32(mediumHmlPlan.MinScore.ValueFloat64()),
-					float32(mediumHmlPlan.MaxScore.ValueFloat64()),
+					mediumHmlPlan.MinScore.ValueFloat32(),
+					mediumHmlPlan.MaxScore.ValueFloat32(),
 				),
 			)
 
@@ -2170,8 +2170,8 @@ func (p *riskPredictorResourceModel) expandPredictorCustom(ctx context.Context, 
 			v := risk.NewRiskPredictorCustomItemBetween(
 				contains,
 				*risk.NewRiskPredictorCustomItemBetweenBetween(
-					float32(lowHmlPlan.MinScore.ValueFloat64()),
-					float32(lowHmlPlan.MaxScore.ValueFloat64()),
+					lowHmlPlan.MinScore.ValueFloat32(),
+					lowHmlPlan.MaxScore.ValueFloat32(),
 				),
 			)
 
@@ -2610,7 +2610,7 @@ func (p *riskPredictorResourceModel) expandPredictorUserLocationAnomaly(ctx cont
 			radiusPlanUnit = risk.EnumDistanceUnit(radiusPlan.Unit.ValueString())
 		}
 
-		radius := risk.NewRiskPredictorUserLocationAnomalyAllOfRadius(int32(radiusPlan.Distance.ValueInt64()), radiusPlanUnit)
+		radius := risk.NewRiskPredictorUserLocationAnomalyAllOfRadius(radiusPlan.Distance.ValueInt32(), radiusPlanUnit)
 
 		data.SetRadius(*radius)
 	}
@@ -2732,11 +2732,11 @@ func (p *riskPredictorResourceModel) expandPredictorVelocity(ctx context.Context
 		}
 
 		if !plan.Quantity.IsNull() && !plan.Quantity.IsUnknown() {
-			every.SetQuantity(int32(plan.Quantity.ValueInt64()))
+			every.SetQuantity(plan.Quantity.ValueInt32())
 		}
 
 		if !plan.MinSample.IsNull() && !plan.MinSample.IsUnknown() {
-			every.SetMinSample(int32(plan.MinSample.ValueInt64()))
+			every.SetMinSample(plan.MinSample.ValueInt32())
 		}
 
 		data.SetEvery(*every)
@@ -2769,11 +2769,11 @@ func (p *riskPredictorResourceModel) expandPredictorVelocity(ctx context.Context
 		}
 
 		if !plan.High.IsNull() && !plan.High.IsUnknown() {
-			fallback.SetHigh(float32(plan.High.ValueFloat64()))
+			fallback.SetHigh(plan.High.ValueFloat32())
 		}
 
 		if !plan.Medium.IsNull() && !plan.Medium.IsUnknown() {
-			fallback.SetMedium(float32(plan.Medium.ValueFloat64()))
+			fallback.SetMedium(plan.Medium.ValueFloat32())
 		}
 
 		data.SetFallback(*fallback)
@@ -2824,11 +2824,11 @@ func (p *riskPredictorResourceModel) expandPredictorVelocity(ctx context.Context
 		}
 
 		if !plan.Quantity.IsNull() && !plan.Quantity.IsUnknown() {
-			slidingWindow.SetQuantity(int32(plan.Quantity.ValueInt64()))
+			slidingWindow.SetQuantity(plan.Quantity.ValueInt32())
 		}
 
 		if !plan.MinSample.IsNull() && !plan.MinSample.IsUnknown() {
-			slidingWindow.SetMinSample(int32(plan.MinSample.ValueInt64()))
+			slidingWindow.SetMinSample(plan.MinSample.ValueInt32())
 		}
 
 		data.SetSlidingWindow(*slidingWindow)
@@ -2861,11 +2861,11 @@ func (p *riskPredictorResourceModel) expandPredictorVelocity(ctx context.Context
 		}
 
 		if !plan.Medium.IsNull() && !plan.Medium.IsUnknown() {
-			use.SetMedium(float32(plan.Medium.ValueFloat64()))
+			use.SetMedium(plan.Medium.ValueFloat32())
 		}
 
 		if !plan.High.IsNull() && !plan.High.IsUnknown() {
-			use.SetHigh(float32(plan.High.ValueFloat64()))
+			use.SetHigh(plan.High.ValueFloat32())
 		}
 
 		data.SetUse(*use)

--- a/internal/service/sso/data_source_application.go
+++ b/internal/service/sso/data_source_application.go
@@ -271,12 +271,12 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 						MarkdownDescription: oidcOptionsDeviceCustomVerificationUriDescription.MarkdownDescription,
 						Computed:            true,
 					},
-					"device_timeout": schema.Int64Attribute{
+					"device_timeout": schema.Int32Attribute{
 						Description:         oidcOptionsDeviceTimeoutDescription.Description,
 						MarkdownDescription: oidcOptionsDeviceTimeoutDescription.MarkdownDescription,
 						Computed:            true,
 					},
-					"device_polling_interval": schema.Int64Attribute{
+					"device_polling_interval": schema.Int32Attribute{
 						Description:         oidcOptionsDevicePollingIntervalDescription.Description,
 						MarkdownDescription: oidcOptionsDevicePollingIntervalDescription.MarkdownDescription,
 						Computed:            true,
@@ -317,7 +317,7 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies whether pushed authorization requests (PAR) are required.").Description,
 						Computed:    true,
 					},
-					"par_timeout": schema.Int64Attribute{
+					"par_timeout": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the pushed authorization request (PAR) timeout in seconds.").Description,
 						Computed:    true,
 					},
@@ -342,15 +342,15 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 						ElementType:         types.StringType,
 						Computed:            true,
 					},
-					"refresh_token_duration": schema.Int64Attribute{
+					"refresh_token_duration": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the lifetime in seconds of the refresh token.").Description,
 						Computed:    true,
 					},
-					"refresh_token_rolling_duration": schema.Int64Attribute{
+					"refresh_token_rolling_duration": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of seconds a refresh token can be exchanged before re-authentication is required.").Description,
 						Computed:    true,
 					},
-					"refresh_token_rolling_grace_period_duration": schema.Int64Attribute{
+					"refresh_token_rolling_grace_period_duration": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("The number of seconds that a refresh token may be reused after having been exchanged for a new set of tokens.").Description,
 						Computed:    true,
 					},
@@ -401,7 +401,7 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("The package name associated with the application, for push notifications in native apps.").Description,
 								Computed:    true,
 							},
-							"passcode_refresh_seconds": schema.Int64Attribute{
+							"passcode_refresh_seconds": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("The amount of time a passcode should be displayed before being replaced with a new passcode.").Description,
 								Computed:    true,
 							},
@@ -428,7 +428,7 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 										Computed:    true,
 
 										Attributes: map[string]schema.Attribute{
-											"amount": schema.Int64Attribute{
+											"amount": schema.Int32Attribute{
 												Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of minutes or hours that specify the duration between successful integrity detection calls.").Description,
 												Computed:    true,
 											},
@@ -490,7 +490,7 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 						ElementType: types.StringType,
 						Computed:    true,
 					},
-					"assertion_duration": schema.Int64Attribute{
+					"assertion_duration": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the assertion validity duration in seconds.").Description,
 						Computed:    true,
 					},
@@ -543,7 +543,7 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("A string that specifies the endpoint URL to submit the logout response.").Description,
 						Computed:    true,
 					},
-					"slo_window": schema.Int64Attribute{
+					"slo_window": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines how long (hours) PingOne can exchange logout messages with the application, specifically a logout request from the application, since the initial request.").Description,
 						Computed:    true,
 					},

--- a/internal/service/sso/data_source_password_policy.go
+++ b/internal/service/sso/data_source_password_policy.go
@@ -34,13 +34,13 @@ type PasswordPolicyDataSourceModel struct {
 	Length                        types.Object                 `tfsdk:"length"`
 	Lockout                       types.Object                 `tfsdk:"lockout"`
 	MinCharacters                 types.Object                 `tfsdk:"min_characters"`
-	PasswordAgeMax                types.Int64                  `tfsdk:"password_age_max"`
-	PasswordAgeMin                types.Int64                  `tfsdk:"password_age_min"`
-	MaxRepeatedCharacters         types.Int64                  `tfsdk:"max_repeated_characters"`
-	MinComplexity                 types.Int64                  `tfsdk:"min_complexity"`
-	MinUniqueCharacters           types.Int64                  `tfsdk:"min_unique_characters"`
+	PasswordAgeMax                types.Int32                  `tfsdk:"password_age_max"`
+	PasswordAgeMin                types.Int32                  `tfsdk:"password_age_min"`
+	MaxRepeatedCharacters         types.Int32                  `tfsdk:"max_repeated_characters"`
+	MinComplexity                 types.Int32                  `tfsdk:"min_complexity"`
+	MinUniqueCharacters           types.Int32                  `tfsdk:"min_unique_characters"`
 	NotSimilarToCurrent           types.Bool                   `tfsdk:"not_similar_to_current"`
-	PopulationCount               types.Int64                  `tfsdk:"population_count"`
+	PopulationCount               types.Int32                  `tfsdk:"population_count"`
 }
 
 // Framework interfaces
@@ -183,12 +183,12 @@ func (r *PasswordPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"count": schema.Int64Attribute{
+					"count": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of prior passwords to keep for prevention of password re-use. The value must be a positive, non-zero integer.").Description,
 						Computed:    true,
 					},
 
-					"retention_days": schema.Int64Attribute{
+					"retention_days": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the length of time to keep recent passwords for prevention of password re-use. The value must be a positive, non-zero integer.").Description,
 						Computed:    true,
 					},
@@ -200,13 +200,13 @@ func (r *PasswordPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"max": schema.Int64Attribute{
+					"max": schema.Int32Attribute{
 						Description:         passwordLengthMaxDescription.Description,
 						MarkdownDescription: passwordLengthMaxDescription.MarkdownDescription,
 						Computed:            true,
 					},
 
-					"min": schema.Int64Attribute{
+					"min": schema.Int32Attribute{
 						Description:         passwordLengthMinDescription.Description,
 						MarkdownDescription: passwordLengthMinDescription.MarkdownDescription,
 						Computed:            true,
@@ -219,12 +219,12 @@ func (r *PasswordPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"duration_seconds": schema.Int64Attribute{
+					"duration_seconds": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the length of time before a password is automatically moved out of the lock out state. The value must be a positive, non-zero integer.").Description,
 						Computed:    true,
 					},
 
-					"failure_count": schema.Int64Attribute{
+					"failure_count": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of tries before a password is placed in the lockout state. The value must be a positive, non-zero integer.").Description,
 						Computed:    true,
 					},
@@ -237,25 +237,25 @@ func (r *PasswordPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:            true,
 
 				Attributes: map[string]schema.Attribute{
-					"alphabetical_uppercase": schema.Int64Attribute{
+					"alphabetical_uppercase": schema.Int32Attribute{
 						Description:         minCharactersAlphabeticalUppercaseDescription.Description,
 						MarkdownDescription: minCharactersAlphabeticalUppercaseDescription.MarkdownDescription,
 						Computed:            true,
 					},
 
-					"alphabetical_lowercase": schema.Int64Attribute{
+					"alphabetical_lowercase": schema.Int32Attribute{
 						Description:         minCharactersAlphabeticalLowercaseDescription.Description,
 						MarkdownDescription: minCharactersAlphabeticalLowercaseDescription.MarkdownDescription,
 						Computed:            true,
 					},
 
-					"numeric": schema.Int64Attribute{
+					"numeric": schema.Int32Attribute{
 						Description:         minCharactersNumericDescription.Description,
 						MarkdownDescription: minCharactersNumericDescription.MarkdownDescription,
 						Computed:            true,
 					},
 
-					"special_characters": schema.Int64Attribute{
+					"special_characters": schema.Int32Attribute{
 						Description:         minCharactersSpecialCharactersDescription.Description,
 						MarkdownDescription: minCharactersSpecialCharactersDescription.MarkdownDescription,
 						Computed:            true,
@@ -263,28 +263,28 @@ func (r *PasswordPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				},
 			},
 
-			"password_age_max": schema.Int64Attribute{
+			"password_age_max": schema.Int32Attribute{
 				Description:         passwordAgeMaxDescription.Description,
 				MarkdownDescription: passwordAgeMaxDescription.MarkdownDescription,
 				Computed:            true,
 			},
 
-			"password_age_min": schema.Int64Attribute{
+			"password_age_min": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the minimum number of days a password must be used before changing. The value must be a positive, non-zero integer. This property is not enforced when not present.").Description,
 				Computed:    true,
 			},
 
-			"max_repeated_characters": schema.Int64Attribute{
+			"max_repeated_characters": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the maximum number of repeated characters allowed. This property is not enforced when not present.").Description,
 				Computed:    true,
 			},
 
-			"min_complexity": schema.Int64Attribute{
+			"min_complexity": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the minimum complexity of the password based on the concept of password haystacks. The value is the number of days required to exhaust the entire search space during a brute force attack. This property is not enforced when not present.").Description,
 				Computed:    true,
 			},
 
-			"min_unique_characters": schema.Int64Attribute{
+			"min_unique_characters": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the minimum number of unique characters required. This property is not enforced when not present.").Description,
 				Computed:    true,
 			},
@@ -295,7 +295,7 @@ func (r *PasswordPolicyDataSource) Schema(ctx context.Context, req datasource.Sc
 				Computed:            true,
 			},
 
-			"population_count": schema.Int64Attribute{
+			"population_count": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of populations associated with the password policy.").Description,
 				Computed:    true,
 			},

--- a/internal/service/sso/data_source_resource.go
+++ b/internal/service/sso/data_source_resource.go
@@ -27,7 +27,7 @@ type ResourceDataSourceModel struct {
 	Description                    types.String                 `tfsdk:"description"`
 	Type                           types.String                 `tfsdk:"type"`
 	Audience                       types.String                 `tfsdk:"audience"`
-	AccessTokenValiditySeconds     types.Int64                  `tfsdk:"access_token_validity_seconds"`
+	AccessTokenValiditySeconds     types.Int32                  `tfsdk:"access_token_validity_seconds"`
 	ApplicationPermissionsSettings types.Object                 `tfsdk:"application_permissions_settings"`
 	IntrospectEndpointAuthMethod   types.String                 `tfsdk:"introspect_endpoint_auth_method"`
 }
@@ -128,7 +128,7 @@ func (r *ResourceDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 				Computed:            true,
 			},
 
-			"access_token_validity_seconds": schema.Int64Attribute{
+			"access_token_validity_seconds": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of seconds that the access token is valid.").Description,
 				Computed:    true,
 			},

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -73,8 +73,8 @@ type applicationOIDCOptionsResourceModelV1 struct {
 	CorsSettings                                  types.Object `tfsdk:"cors_settings"`
 	DevicePathId                                  types.String `tfsdk:"device_path_id"`
 	DeviceCustomVerificationUri                   types.String `tfsdk:"device_custom_verification_uri"`
-	DeviceTimeout                                 types.Int64  `tfsdk:"device_timeout"`
-	DevicePollingInterval                         types.Int64  `tfsdk:"device_polling_interval"`
+	DeviceTimeout                                 types.Int32  `tfsdk:"device_timeout"`
+	DevicePollingInterval                         types.Int32  `tfsdk:"device_polling_interval"`
 	GrantTypes                                    types.Set    `tfsdk:"grant_types"`
 	HomePageUrl                                   types.String `tfsdk:"home_page_url"`
 	InitiateLoginUri                              types.String `tfsdk:"initiate_login_uri"`
@@ -82,13 +82,13 @@ type applicationOIDCOptionsResourceModelV1 struct {
 	JwksUrl                                       types.String `tfsdk:"jwks_url"`
 	MobileApp                                     types.Object `tfsdk:"mobile_app"`
 	ParRequirement                                types.String `tfsdk:"par_requirement"`
-	ParTimeout                                    types.Int64  `tfsdk:"par_timeout"`
+	ParTimeout                                    types.Int32  `tfsdk:"par_timeout"`
 	PKCEEnforcement                               types.String `tfsdk:"pkce_enforcement"`
 	PostLogoutRedirectUris                        types.Set    `tfsdk:"post_logout_redirect_uris"`
 	RedirectUris                                  types.Set    `tfsdk:"redirect_uris"`
-	RefreshTokenDuration                          types.Int64  `tfsdk:"refresh_token_duration"`
-	RefreshTokenRollingDuration                   types.Int64  `tfsdk:"refresh_token_rolling_duration"`
-	RefreshTokenRollingGracePeriodDuration        types.Int64  `tfsdk:"refresh_token_rolling_grace_period_duration"`
+	RefreshTokenDuration                          types.Int32  `tfsdk:"refresh_token_duration"`
+	RefreshTokenRollingDuration                   types.Int32  `tfsdk:"refresh_token_rolling_duration"`
+	RefreshTokenRollingGracePeriodDuration        types.Int32  `tfsdk:"refresh_token_rolling_grace_period_duration"`
 	RequireSignedRequestObject                    types.Bool   `tfsdk:"require_signed_request_object"`
 	ResponseTypes                                 types.Set    `tfsdk:"response_types"`
 	SupportUnsignedRequestObject                  types.Bool   `tfsdk:"support_unsigned_request_object"`
@@ -112,7 +112,7 @@ type applicationOIDCMobileAppResourceModelV1 struct {
 	HuaweiPackageName      types.String `tfsdk:"huawei_package_name"`
 	IntegrityDetection     types.Object `tfsdk:"integrity_detection"`
 	PackageName            types.String `tfsdk:"package_name"`
-	PasscodeRefreshSeconds types.Int64  `tfsdk:"passcode_refresh_seconds"`
+	PasscodeRefreshSeconds types.Int32  `tfsdk:"passcode_refresh_seconds"`
 	UniversalAppLink       types.String `tfsdk:"universal_app_link"`
 }
 
@@ -124,7 +124,7 @@ type applicationOIDCMobileAppIntegrityDetectionResourceModelV1 struct {
 }
 
 type applicationOIDCMobileAppIntegrityDetectionCacheDurationResourceModelV1 struct {
-	Amount types.Int64  `tfsdk:"amount"`
+	Amount types.Int32  `tfsdk:"amount"`
 	Units  types.String `tfsdk:"units"`
 }
 
@@ -137,7 +137,7 @@ type applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV1 struct 
 
 type applicationSAMLOptionsResourceModelV1 struct {
 	AcsUrls                     types.Set    `tfsdk:"acs_urls"`
-	AssertionDuration           types.Int64  `tfsdk:"assertion_duration"`
+	AssertionDuration           types.Int32  `tfsdk:"assertion_duration"`
 	AssertionSignedEnabled      types.Bool   `tfsdk:"assertion_signed_enabled"`
 	CorsSettings                types.Object `tfsdk:"cors_settings"`
 	EnableRequestedAuthnContext types.Bool   `tfsdk:"enable_requested_authn_context"`
@@ -149,7 +149,7 @@ type applicationSAMLOptionsResourceModelV1 struct {
 	SloBinding                  types.String `tfsdk:"slo_binding"`
 	SloEndpoint                 types.String `tfsdk:"slo_endpoint"`
 	SloResponseEndpoint         types.String `tfsdk:"slo_response_endpoint"`
-	SloWindow                   types.Int64  `tfsdk:"slo_window"`
+	SloWindow                   types.Int32  `tfsdk:"slo_window"`
 	SpEncryption                types.Object `tfsdk:"sp_encryption"`
 	SpEntityId                  types.String `tfsdk:"sp_entity_id"`
 	SpVerification              types.Object `tfsdk:"sp_verification"`
@@ -189,8 +189,8 @@ var (
 		"cors_settings":                                      types.ObjectType{AttrTypes: applicationCorsSettingsTFObjectTypes},
 		"device_path_id":                                     types.StringType,
 		"device_custom_verification_uri":                     types.StringType,
-		"device_timeout":                                     types.Int64Type,
-		"device_polling_interval":                            types.Int64Type,
+		"device_timeout":                                     types.Int32Type,
+		"device_polling_interval":                            types.Int32Type,
 		"grant_types":                                        types.SetType{ElemType: types.StringType},
 		"home_page_url":                                      types.StringType,
 		"initiate_login_uri":                                 types.StringType,
@@ -198,13 +198,13 @@ var (
 		"jwks":                                               types.StringType,
 		"mobile_app":                                         types.ObjectType{AttrTypes: applicationOidcMobileAppTFObjectTypes},
 		"par_requirement":                                    types.StringType,
-		"par_timeout":                                        types.Int64Type,
+		"par_timeout":                                        types.Int32Type,
 		"pkce_enforcement":                                   types.StringType,
 		"post_logout_redirect_uris":                          types.SetType{ElemType: types.StringType},
 		"redirect_uris":                                      types.SetType{ElemType: types.StringType},
-		"refresh_token_duration":                             types.Int64Type,
-		"refresh_token_rolling_duration":                     types.Int64Type,
-		"refresh_token_rolling_grace_period_duration":        types.Int64Type,
+		"refresh_token_duration":                             types.Int32Type,
+		"refresh_token_rolling_duration":                     types.Int32Type,
+		"refresh_token_rolling_grace_period_duration":        types.Int32Type,
 		"require_signed_request_object":                      types.BoolType,
 		"response_types":                                     types.SetType{ElemType: types.StringType},
 		"support_unsigned_request_object":                    types.BoolType,
@@ -219,7 +219,7 @@ var (
 		"huawei_package_name":      types.StringType,
 		"integrity_detection":      types.ObjectType{AttrTypes: applicationOidcMobileAppIntegrityDetectionTFObjectTypes},
 		"package_name":             types.StringType,
-		"passcode_refresh_seconds": types.Int64Type,
+		"passcode_refresh_seconds": types.Int32Type,
 		"universal_app_link":       types.StringType,
 	}
 
@@ -231,7 +231,7 @@ var (
 	}
 
 	applicationOidcMobileAppIntegrityDetectionCacheDurationTFObjectTypes = map[string]attr.Type{
-		"amount": types.Int64Type,
+		"amount": types.Int32Type,
 		"units":  types.StringType,
 	}
 
@@ -248,7 +248,7 @@ var (
 
 	applicationSamlOptionsTFObjectTypes = map[string]attr.Type{
 		"acs_urls":                       types.SetType{ElemType: types.StringType},
-		"assertion_duration":             types.Int64Type,
+		"assertion_duration":             types.Int32Type,
 		"assertion_signed_enabled":       types.BoolType,
 		"cors_settings":                  types.ObjectType{AttrTypes: applicationCorsSettingsTFObjectTypes},
 		"enable_requested_authn_context": types.BoolType,
@@ -260,7 +260,7 @@ var (
 		"slo_binding":                    types.StringType,
 		"slo_endpoint":                   types.StringType,
 		"slo_response_endpoint":          types.StringType,
-		"slo_window":                     types.Int64Type,
+		"slo_window":                     types.Int32Type,
 		"sp_encryption":                  types.ObjectType{AttrTypes: applicationSamlOptionsSpEncryptionTFObjectTypes},
 		"sp_entity_id":                   types.StringType,
 		"sp_verification":                types.ObjectType{AttrTypes: applicationSamlOptionsSpVerificationTFObjectTypes},
@@ -860,29 +860,29 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 						Optional:            true,
 					},
 
-					"device_timeout": schema.Int64Attribute{
+					"device_timeout": schema.Int32Attribute{
 						Description:         oidcOptionsDeviceTimeoutDescription.Description,
 						MarkdownDescription: oidcOptionsDeviceTimeoutDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(oidcOptionsDeviceTimeoutDefault),
+						Default: int32default.StaticInt32(oidcOptionsDeviceTimeoutDefault),
 
-						Validators: []validator.Int64{
-							int64validator.Between(oidcOptionsDeviceTimeoutMin, oidcOptionsDeviceTimeoutMax),
+						Validators: []validator.Int32{
+							int32validator.Between(oidcOptionsDeviceTimeoutMin, oidcOptionsDeviceTimeoutMax),
 						},
 					},
 
-					"device_polling_interval": schema.Int64Attribute{
+					"device_polling_interval": schema.Int32Attribute{
 						Description:         oidcOptionsDevicePollingIntervalDescription.Description,
 						MarkdownDescription: oidcOptionsDevicePollingIntervalDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(oidcOptionsDevicePollingIntervalDefault),
+						Default: int32default.StaticInt32(oidcOptionsDevicePollingIntervalDefault),
 
-						Validators: []validator.Int64{
-							int64validator.Between(oidcOptionsDevicePollingIntervalMin, oidcOptionsDevicePollingIntervalMax),
+						Validators: []validator.Int32{
+							int32validator.Between(oidcOptionsDevicePollingIntervalMin, oidcOptionsDevicePollingIntervalMax),
 						},
 					},
 
@@ -984,16 +984,16 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 						},
 					},
 
-					"par_timeout": schema.Int64Attribute{
+					"par_timeout": schema.Int32Attribute{
 						Description:         oidcOptionsParTimeoutDescription.Description,
 						MarkdownDescription: oidcOptionsParTimeoutDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(oidcOptionsParTimeoutDefault),
+						Default: int32default.StaticInt32(oidcOptionsParTimeoutDefault),
 
-						Validators: []validator.Int64{
-							int64validator.Between(oidcOptionsParTimeoutMin, oidcOptionsParTimeoutMax),
+						Validators: []validator.Int32{
+							int32validator.Between(oidcOptionsParTimeoutMin, oidcOptionsParTimeoutMax),
 						},
 					},
 
@@ -1047,39 +1047,39 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 						},
 					},
 
-					"refresh_token_duration": schema.Int64Attribute{
+					"refresh_token_duration": schema.Int32Attribute{
 						Description:         oidcOptionsRefreshTokenDurationDescription.Description,
 						MarkdownDescription: oidcOptionsRefreshTokenDurationDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(oidcOptionsRefreshTokenDurationDefault),
+						Default: int32default.StaticInt32(oidcOptionsRefreshTokenDurationDefault),
 
-						Validators: []validator.Int64{
-							int64validator.Between(oidcOptionsRefreshTokenDurationMin, oidcOptionsRefreshTokenDurationMax),
+						Validators: []validator.Int32{
+							int32validator.Between(oidcOptionsRefreshTokenDurationMin, oidcOptionsRefreshTokenDurationMax),
 						},
 					},
 
-					"refresh_token_rolling_duration": schema.Int64Attribute{
+					"refresh_token_rolling_duration": schema.Int32Attribute{
 						Description:         oidcOptionsRefreshTokenRollingDurationDescription.Description,
 						MarkdownDescription: oidcOptionsRefreshTokenRollingDurationDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(oidcOptionsRefreshTokenRollingDurationDefault),
+						Default: int32default.StaticInt32(oidcOptionsRefreshTokenRollingDurationDefault),
 
-						Validators: []validator.Int64{
-							int64validator.Between(oidcOptionsRefreshTokenRollingDurationMin, oidcOptionsRefreshTokenRollingDurationMax),
+						Validators: []validator.Int32{
+							int32validator.Between(oidcOptionsRefreshTokenRollingDurationMin, oidcOptionsRefreshTokenRollingDurationMax),
 						},
 					},
 
-					"refresh_token_rolling_grace_period_duration": schema.Int64Attribute{
+					"refresh_token_rolling_grace_period_duration": schema.Int32Attribute{
 						Description:         oidcOptionsRefreshTokenRollingGracePeriodDurationDescription.Description,
 						MarkdownDescription: oidcOptionsRefreshTokenRollingGracePeriodDurationDescription.MarkdownDescription,
 						Optional:            true,
 
-						Validators: []validator.Int64{
-							int64validator.Between(oidcOptionsRefreshTokenRollingGracePeriodDurationMin, oidcOptionsRefreshTokenRollingGracePeriodDurationMax),
+						Validators: []validator.Int32{
+							int32validator.Between(oidcOptionsRefreshTokenRollingGracePeriodDurationMin, oidcOptionsRefreshTokenRollingGracePeriodDurationMax),
 						},
 					},
 
@@ -1206,16 +1206,16 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 								},
 							},
 
-							"passcode_refresh_seconds": schema.Int64Attribute{
+							"passcode_refresh_seconds": schema.Int32Attribute{
 								Description:         oidcOptionsMobileAppPasscodeRefreshSecondsDescription.Description,
 								MarkdownDescription: oidcOptionsMobileAppPasscodeRefreshSecondsDescription.MarkdownDescription,
 								Optional:            true,
 								Computed:            true,
 
-								Default: int64default.StaticInt64(oidcOptionsMobileAppPasscodeRefreshSecondsDefault),
+								Default: int32default.StaticInt32(oidcOptionsMobileAppPasscodeRefreshSecondsDefault),
 
-								Validators: []validator.Int64{
-									int64validator.Between(oidcOptionsMobileAppPasscodeRefreshSecondsMin, oidcOptionsMobileAppPasscodeRefreshSecondsMax),
+								Validators: []validator.Int32{
+									int32validator.Between(oidcOptionsMobileAppPasscodeRefreshSecondsMin, oidcOptionsMobileAppPasscodeRefreshSecondsMax),
 								},
 							},
 
@@ -1265,7 +1265,7 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 										Optional:            true,
 
 										Attributes: map[string]schema.Attribute{
-											"amount": schema.Int64Attribute{
+											"amount": schema.Int32Attribute{
 												Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of minutes or hours that specify the duration between successful integrity detection calls.").Description,
 												Required:    true,
 											},
@@ -1407,7 +1407,7 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 						ElementType: types.StringType,
 					},
 
-					"assertion_duration": schema.Int64Attribute{
+					"assertion_duration": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the assertion validity duration in seconds.").Description,
 						Required:    true,
 					},
@@ -1479,13 +1479,13 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 						},
 					},
 
-					"slo_window": schema.Int64Attribute{
+					"slo_window": schema.Int32Attribute{
 						Description:         samlOptionsSloWindowDescription.Description,
 						MarkdownDescription: samlOptionsSloWindowDescription.MarkdownDescription,
 						Optional:            true,
 
-						Validators: []validator.Int64{
-							int64validator.Between(samlOptionsSloWindowMin, samlOptionsSloWindowMax),
+						Validators: []validator.Int32{
+							int32validator.Between(samlOptionsSloWindowMin, samlOptionsSloWindowMax),
 						},
 					},
 
@@ -2208,11 +2208,11 @@ func (p *applicationResourceModelV1) expandApplicationOIDC(ctx context.Context) 
 		}
 
 		if !plan.DeviceTimeout.IsNull() && !plan.DeviceTimeout.IsUnknown() {
-			data.SetDeviceTimeout(int32(plan.DeviceTimeout.ValueInt64()))
+			data.SetDeviceTimeout(plan.DeviceTimeout.ValueInt32())
 		}
 
 		if !plan.DevicePollingInterval.IsNull() && !plan.DevicePollingInterval.IsUnknown() {
-			data.SetDevicePollingInterval(int32(plan.DevicePollingInterval.ValueInt64()))
+			data.SetDevicePollingInterval(plan.DevicePollingInterval.ValueInt32())
 		}
 
 		if !plan.InitiateLoginUri.IsNull() && !plan.InitiateLoginUri.IsUnknown() {
@@ -2258,7 +2258,7 @@ func (p *applicationResourceModelV1) expandApplicationOIDC(ctx context.Context) 
 		}
 
 		if !plan.ParTimeout.IsNull() && !plan.ParTimeout.IsUnknown() {
-			data.SetParTimeout(int32(plan.ParTimeout.ValueInt64()))
+			data.SetParTimeout(plan.ParTimeout.ValueInt32())
 		}
 
 		if !plan.PKCEEnforcement.IsNull() && !plan.PKCEEnforcement.IsUnknown() {
@@ -2303,15 +2303,15 @@ func (p *applicationResourceModelV1) expandApplicationOIDC(ctx context.Context) 
 		}
 
 		if !plan.RefreshTokenDuration.IsNull() && !plan.RefreshTokenDuration.IsUnknown() {
-			data.SetRefreshTokenDuration(int32(plan.RefreshTokenDuration.ValueInt64()))
+			data.SetRefreshTokenDuration(plan.RefreshTokenDuration.ValueInt32())
 		}
 
 		if !plan.RefreshTokenRollingDuration.IsNull() && !plan.RefreshTokenRollingDuration.IsUnknown() {
-			data.SetRefreshTokenRollingDuration(int32(plan.RefreshTokenRollingDuration.ValueInt64()))
+			data.SetRefreshTokenRollingDuration(plan.RefreshTokenRollingDuration.ValueInt32())
 		}
 
 		if !plan.RefreshTokenRollingGracePeriodDuration.IsNull() && !plan.RefreshTokenRollingGracePeriodDuration.IsUnknown() {
-			data.SetRefreshTokenRollingGracePeriodDuration(int32(plan.RefreshTokenRollingGracePeriodDuration.ValueInt64()))
+			data.SetRefreshTokenRollingGracePeriodDuration(plan.RefreshTokenRollingGracePeriodDuration.ValueInt32())
 		}
 
 		if !plan.AdditionalRefreshTokenReplayProtectionEnabled.IsNull() && !plan.AdditionalRefreshTokenReplayProtectionEnabled.IsUnknown() {
@@ -2442,7 +2442,7 @@ func (p *applicationOIDCMobileAppResourceModelV1) expand(ctx context.Context) (*
 
 	if !p.PasscodeRefreshSeconds.IsNull() && !p.PasscodeRefreshSeconds.IsUnknown() {
 		data.SetPasscodeRefreshDuration(*management.NewApplicationOIDCAllOfMobilePasscodeRefreshDuration(
-			int32(p.PasscodeRefreshSeconds.ValueInt64()),
+			p.PasscodeRefreshSeconds.ValueInt32(),
 			management.ENUMPASSCODEREFRESHTIMEUNIT_SECONDS,
 		))
 	}
@@ -2551,7 +2551,7 @@ func (p *applicationOIDCMobileAppIntegrityDetectionResourceModelV1) expand(ctx c
 		cacheDuration := management.NewApplicationOIDCAllOfMobileIntegrityDetectionCacheDuration()
 
 		if !cacheDurationPlan.Amount.IsNull() && !cacheDurationPlan.Amount.IsUnknown() {
-			cacheDuration.SetAmount(int32(cacheDurationPlan.Amount.ValueInt64()))
+			cacheDuration.SetAmount(cacheDurationPlan.Amount.ValueInt32())
 		}
 
 		if !cacheDurationPlan.Units.IsNull() && !cacheDurationPlan.Units.IsUnknown() {
@@ -2599,7 +2599,7 @@ func (p *applicationResourceModelV1) expandApplicationSAML(ctx context.Context) 
 			management.ENUMAPPLICATIONPROTOCOL_SAML,
 			management.EnumApplicationType(plan.Type.ValueString()),
 			acsUrls,
-			int32(plan.AssertionDuration.ValueInt64()),
+			plan.AssertionDuration.ValueInt32(),
 			plan.SpEntityId.ValueString(),
 		)
 
@@ -2690,7 +2690,7 @@ func (p *applicationResourceModelV1) expandApplicationSAML(ctx context.Context) 
 		}
 
 		if !plan.SloWindow.IsNull() && !plan.SloWindow.IsUnknown() {
-			data.SetSloWindow(int32(plan.SloWindow.ValueInt64()))
+			data.SetSloWindow(plan.SloWindow.ValueInt32())
 		}
 
 		if !plan.SpEncryption.IsNull() && !plan.SpEncryption.IsUnknown() {

--- a/internal/service/sso/resource_application_flow_policy_assignment.go
+++ b/internal/service/sso/resource_application_flow_policy_assignment.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -28,7 +28,7 @@ type ApplicationFlowPolicyAssignmentResourceModel struct {
 	EnvironmentId pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
 	ApplicationId pingonetypes.ResourceIDValue `tfsdk:"application_id"`
 	FlowPolicyId  davincitypes.ResourceIDValue `tfsdk:"flow_policy_id"`
-	Priority      types.Int64                  `tfsdk:"priority"`
+	Priority      types.Int32                  `tfsdk:"priority"`
 }
 
 // Framework interfaces
@@ -72,11 +72,11 @@ func (r *ApplicationFlowPolicyAssignmentResource) Schema(ctx context.Context, re
 				CustomType: davincitypes.ResourceIDType{},
 			},
 
-			"priority": schema.Int64Attribute{
+			"priority": schema.Int32Attribute{
 				Description: "The order in which the policy referenced by this assignment is evaluated during an authentication flow relative to other policies. An assignment with a lower priority will be evaluated first.",
 				Required:    true,
-				Validators: []validator.Int64{
-					int64validator.AtLeast(1),
+				Validators: []validator.Int32{
+					int32validator.AtLeast(1),
 				},
 			},
 		},
@@ -319,7 +319,7 @@ func (r *ApplicationFlowPolicyAssignmentResource) ImportState(ctx context.Contex
 func (p *ApplicationFlowPolicyAssignmentResourceModel) expand() *management.FlowPolicyAssignment {
 
 	flowPolicy := management.NewFlowPolicyAssignmentFlowPolicy(p.FlowPolicyId.ValueString())
-	data := management.NewFlowPolicyAssignment(*flowPolicy, int32(p.Priority.ValueInt64()))
+	data := management.NewFlowPolicyAssignment(*flowPolicy, p.Priority.ValueInt32())
 
 	return data
 }

--- a/internal/service/sso/resource_application_schema_upgrade_0_to_1.go
+++ b/internal/service/sso/resource_application_schema_upgrade_0_to_1.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
@@ -50,13 +50,13 @@ type applicationOIDCOptionsResourceModelV0 struct {
 	JwksUrl                                       types.String                 `tfsdk:"jwks_url"`
 	MobileApp                                     types.List                   `tfsdk:"mobile_app"`
 	ParRequirement                                types.String                 `tfsdk:"par_requirement"`
-	ParTimeout                                    types.Int64                  `tfsdk:"par_timeout"`
+	ParTimeout                                    types.Int32                  `tfsdk:"par_timeout"`
 	PKCEEnforcement                               types.String                 `tfsdk:"pkce_enforcement"`
 	PostLogoutRedirectUris                        types.Set                    `tfsdk:"post_logout_redirect_uris"`
 	RedirectUris                                  types.Set                    `tfsdk:"redirect_uris"`
-	RefreshTokenDuration                          types.Int64                  `tfsdk:"refresh_token_duration"`
-	RefreshTokenRollingDuration                   types.Int64                  `tfsdk:"refresh_token_rolling_duration"`
-	RefreshTokenRollingGracePeriodDuration        types.Int64                  `tfsdk:"refresh_token_rolling_grace_period_duration"`
+	RefreshTokenDuration                          types.Int32                  `tfsdk:"refresh_token_duration"`
+	RefreshTokenRollingDuration                   types.Int32                  `tfsdk:"refresh_token_rolling_duration"`
+	RefreshTokenRollingGracePeriodDuration        types.Int32                  `tfsdk:"refresh_token_rolling_grace_period_duration"`
 	RequireSignedRequestObject                    types.Bool                   `tfsdk:"require_signed_request_object"`
 	ResponseTypes                                 types.Set                    `tfsdk:"response_types"`
 	SupportUnsignedRequestObject                  types.Bool                   `tfsdk:"support_unsigned_request_object"`
@@ -79,7 +79,7 @@ type applicationOIDCMobileAppResourceModelV0 struct {
 	HuaweiPackageName      types.String `tfsdk:"huawei_package_name"`
 	IntegrityDetection     types.List   `tfsdk:"integrity_detection"`
 	PackageName            types.String `tfsdk:"package_name"`
-	PasscodeRefreshSeconds types.Int64  `tfsdk:"passcode_refresh_seconds"`
+	PasscodeRefreshSeconds types.Int32  `tfsdk:"passcode_refresh_seconds"`
 	UniversalAppLink       types.String `tfsdk:"universal_app_link"`
 }
 
@@ -101,7 +101,7 @@ type applicationOIDCMobileAppIntegrityDetectionGooglePlayResourceModelV0 struct 
 
 type applicationSAMLOptionsResourceModelV0 struct {
 	AcsUrls                      types.Set    `tfsdk:"acs_urls"`
-	AssertionDuration            types.Int64  `tfsdk:"assertion_duration"`
+	AssertionDuration            types.Int32  `tfsdk:"assertion_duration"`
 	AssertionSignedEnabled       types.Bool   `tfsdk:"assertion_signed_enabled"`
 	CorsSettings                 types.List   `tfsdk:"cors_settings"`
 	EnableRequestedAuthnContext  types.Bool   `tfsdk:"enable_requested_authn_context"`
@@ -114,7 +114,7 @@ type applicationSAMLOptionsResourceModelV0 struct {
 	SloBinding                   types.String `tfsdk:"slo_binding"`
 	SloEndpoint                  types.String `tfsdk:"slo_endpoint"`
 	SloResponseEndpoint          types.String `tfsdk:"slo_response_endpoint"`
-	SloWindow                    types.Int64  `tfsdk:"slo_window"`
+	SloWindow                    types.Int32  `tfsdk:"slo_window"`
 	SpEncryption                 types.List   `tfsdk:"sp_encryption"`
 	SpEntityId                   types.String `tfsdk:"sp_entity_id"`
 	SpVerificationCertificateIds types.Set    `tfsdk:"sp_verification_certificate_ids"`
@@ -281,11 +281,11 @@ func (r *ApplicationResource) UpgradeState(ctx context.Context) map[int64]resour
 									Default: stringdefault.StaticString(string(management.ENUMAPPLICATIONOIDCPARREQUIREMENT_OPTIONAL)),
 								},
 
-								"par_timeout": schema.Int64Attribute{
+								"par_timeout": schema.Int32Attribute{
 									Optional: true,
 									Computed: true,
 
-									Default: int64default.StaticInt64(oidcOptionsParTimeoutDefault),
+									Default: int32default.StaticInt32(oidcOptionsParTimeoutDefault),
 								},
 
 								"pkce_enforcement": schema.StringAttribute{
@@ -314,21 +314,21 @@ func (r *ApplicationResource) UpgradeState(ctx context.Context) map[int64]resour
 									ElementType: types.StringType,
 								},
 
-								"refresh_token_duration": schema.Int64Attribute{
+								"refresh_token_duration": schema.Int32Attribute{
 									Optional: true,
 									Computed: true,
 
-									Default: int64default.StaticInt64(oidcOptionsRefreshTokenDurationDefault),
+									Default: int32default.StaticInt32(oidcOptionsRefreshTokenDurationDefault),
 								},
 
-								"refresh_token_rolling_duration": schema.Int64Attribute{
+								"refresh_token_rolling_duration": schema.Int32Attribute{
 									Optional: true,
 									Computed: true,
 
-									Default: int64default.StaticInt64(oidcOptionsRefreshTokenRollingDurationDefault),
+									Default: int32default.StaticInt32(oidcOptionsRefreshTokenRollingDurationDefault),
 								},
 
-								"refresh_token_rolling_grace_period_duration": schema.Int64Attribute{
+								"refresh_token_rolling_grace_period_duration": schema.Int32Attribute{
 									Optional: true,
 								},
 
@@ -409,11 +409,11 @@ func (r *ApplicationResource) UpgradeState(ctx context.Context) map[int64]resour
 												Optional: true,
 											},
 
-											"passcode_refresh_seconds": schema.Int64Attribute{
+											"passcode_refresh_seconds": schema.Int32Attribute{
 												Optional: true,
 												Computed: true,
 
-												Default: int64default.StaticInt64(oidcOptionsMobileAppPasscodeRefreshSecondsDefault),
+												Default: int32default.StaticInt32(oidcOptionsMobileAppPasscodeRefreshSecondsDefault),
 											},
 
 											"universal_app_link": schema.StringAttribute{
@@ -443,7 +443,7 @@ func (r *ApplicationResource) UpgradeState(ctx context.Context) map[int64]resour
 														"cache_duration": schema.ListNestedBlock{
 															NestedObject: schema.NestedBlockObject{
 																Attributes: map[string]schema.Attribute{
-																	"amount": schema.Int64Attribute{
+																	"amount": schema.Int32Attribute{
 																		Required: true,
 																	},
 
@@ -511,7 +511,7 @@ func (r *ApplicationResource) UpgradeState(ctx context.Context) map[int64]resour
 									ElementType: types.StringType,
 								},
 
-								"assertion_duration": schema.Int64Attribute{
+								"assertion_duration": schema.Int32Attribute{
 									Required: true,
 								},
 
@@ -561,7 +561,7 @@ func (r *ApplicationResource) UpgradeState(ctx context.Context) map[int64]resour
 									Optional: true,
 								},
 
-								"slo_window": schema.Int64Attribute{
+								"slo_window": schema.Int32Attribute{
 									Optional: true,
 								},
 
@@ -822,8 +822,8 @@ func (p *applicationResourceModelV0) schemaUpgradeOIDCOptionsV0toV1(ctx context.
 			CorsSettings:                                  corsSettings,
 			DevicePathId:                                  types.StringNull(),
 			DeviceCustomVerificationUri:                   types.StringNull(),
-			DeviceTimeout:                                 types.Int64Value(deviceTimeoutDefault),
-			DevicePollingInterval:                         types.Int64Value(devicePollingIntervalDefault),
+			DeviceTimeout:                                 types.Int32Value(deviceTimeoutDefault),
+			DevicePollingInterval:                         types.Int32Value(devicePollingIntervalDefault),
 			GrantTypes:                                    priorStateData[0].GrantTypes,
 			HomePageUrl:                                   priorStateData[0].HomePageUrl,
 			InitiateLoginUri:                              priorStateData[0].InitiateLoginUri,

--- a/internal/service/sso/resource_identity_provider.go
+++ b/internal/service/sso/resource_identity_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -123,7 +123,7 @@ type identityProviderSAMLResourceModelV1 struct {
 	SloBinding                  types.String `tfsdk:"slo_binding"`
 	SloEndpoint                 types.String `tfsdk:"slo_endpoint"`
 	SloResponseEndpoint         types.String `tfsdk:"slo_response_endpoint"`
-	SloWindow                   types.Int64  `tfsdk:"slo_window"`
+	SloWindow                   types.Int32  `tfsdk:"slo_window"`
 }
 
 type identityProviderSAMLResourceIdPVerificationModelV1 struct {
@@ -192,7 +192,7 @@ var (
 		"slo_binding":                   types.StringType,
 		"slo_endpoint":                  types.StringType,
 		"slo_response_endpoint":         types.StringType,
-		"slo_window":                    types.Int64Type,
+		"slo_window":                    types.Int32Type,
 	}
 
 	identityProviderSAMLIdPVerificationTFObjectTypes = map[string]attr.Type{
@@ -835,13 +835,13 @@ func (r *IdentityProviderResource) Schema(ctx context.Context, req resource.Sche
 						},
 					},
 
-					"slo_window": schema.Int64Attribute{
+					"slo_window": schema.Int32Attribute{
 						Description:         samlSLOWindowDescription.Description,
 						MarkdownDescription: samlSLOWindowDescription.MarkdownDescription,
 						Optional:            true,
 
-						Validators: []validator.Int64{
-							int64validator.Between(samlSloWindowMin, samlSloWindowMax),
+						Validators: []validator.Int32{
+							int32validator.Between(samlSloWindowMin, samlSloWindowMax),
 						},
 					},
 				},
@@ -1654,7 +1654,7 @@ func (p *identityProviderResourceModelV1) expand(ctx context.Context) (*manageme
 		}
 
 		if !plan.SloWindow.IsNull() && !plan.SloWindow.IsUnknown() {
-			idpData.SetSloWindow(int32(plan.SloWindow.ValueInt64()))
+			idpData.SetSloWindow(plan.SloWindow.ValueInt32())
 		}
 
 		data.IdentityProviderSAML = &idpData

--- a/internal/service/sso/resource_identity_provider_schema_upgrade_0_to_1.go
+++ b/internal/service/sso/resource_identity_provider_schema_upgrade_0_to_1.go
@@ -70,7 +70,7 @@ type identityProviderSAMLResourceModelV0 struct {
 	SloBinding                    types.String                 `tfsdk:"slo_binding"`
 	SloEndpoint                   types.String                 `tfsdk:"slo_endpoint"`
 	SloResponseEndpoint           types.String                 `tfsdk:"slo_response_endpoint"`
-	SloWindow                     types.Int64                  `tfsdk:"slo_window"`
+	SloWindow                     types.Int32                  `tfsdk:"slo_window"`
 }
 
 func (r *IdentityProviderResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
@@ -408,7 +408,7 @@ func (r *IdentityProviderResource) UpgradeState(ctx context.Context) map[int64]r
 									Optional: true,
 								},
 
-								"slo_window": schema.Int64Attribute{
+								"slo_window": schema.Int32Attribute{
 									Optional: true,
 								},
 							},

--- a/internal/service/sso/resource_password_policy.go
+++ b/internal/service/sso/resource_password_policy.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -41,58 +41,58 @@ type passwordPolicyResourceModelV1 struct {
 	Length                        types.Object                 `tfsdk:"length"`
 	Lockout                       types.Object                 `tfsdk:"lockout"`
 	MinCharacters                 types.Object                 `tfsdk:"min_characters"`
-	PasswordAgeMax                types.Int64                  `tfsdk:"password_age_max"`
-	PasswordAgeMin                types.Int64                  `tfsdk:"password_age_min"`
-	MaxRepeatedCharacters         types.Int64                  `tfsdk:"max_repeated_characters"`
-	MinComplexity                 types.Int64                  `tfsdk:"min_complexity"`
-	MinUniqueCharacters           types.Int64                  `tfsdk:"min_unique_characters"`
+	PasswordAgeMax                types.Int32                  `tfsdk:"password_age_max"`
+	PasswordAgeMin                types.Int32                  `tfsdk:"password_age_min"`
+	MaxRepeatedCharacters         types.Int32                  `tfsdk:"max_repeated_characters"`
+	MinComplexity                 types.Int32                  `tfsdk:"min_complexity"`
+	MinUniqueCharacters           types.Int32                  `tfsdk:"min_unique_characters"`
 	NotSimilarToCurrent           types.Bool                   `tfsdk:"not_similar_to_current"`
-	PopulationCount               types.Int64                  `tfsdk:"population_count"`
+	PopulationCount               types.Int32                  `tfsdk:"population_count"`
 }
 
 type passwordPolicyHistoryResourceModelV1 struct {
-	Count         types.Int64 `tfsdk:"count"`
-	RetentionDays types.Int64 `tfsdk:"retention_days"`
+	Count         types.Int32 `tfsdk:"count"`
+	RetentionDays types.Int32 `tfsdk:"retention_days"`
 }
 
 type passwordPolicyLengthResourceModelV1 struct {
-	Max types.Int64 `tfsdk:"max"`
-	Min types.Int64 `tfsdk:"min"`
+	Max types.Int32 `tfsdk:"max"`
+	Min types.Int32 `tfsdk:"min"`
 }
 
 type passwordPolicyLockoutResourceModelV1 struct {
-	DurationSeconds types.Int64 `tfsdk:"duration_seconds"`
-	FailureCount    types.Int64 `tfsdk:"failure_count"`
+	DurationSeconds types.Int32 `tfsdk:"duration_seconds"`
+	FailureCount    types.Int32 `tfsdk:"failure_count"`
 }
 
 type passwordPolicyMinCharactersResourceModelV1 struct {
-	AlphabeticalUppercase types.Int64 `tfsdk:"alphabetical_uppercase"`
-	AlphabeticalLowercase types.Int64 `tfsdk:"alphabetical_lowercase"`
-	Numeric               types.Int64 `tfsdk:"numeric"`
-	SpecialCharacters     types.Int64 `tfsdk:"special_characters"`
+	AlphabeticalUppercase types.Int32 `tfsdk:"alphabetical_uppercase"`
+	AlphabeticalLowercase types.Int32 `tfsdk:"alphabetical_lowercase"`
+	Numeric               types.Int32 `tfsdk:"numeric"`
+	SpecialCharacters     types.Int32 `tfsdk:"special_characters"`
 }
 
 var (
 	passwordPolicyHistoryTFObjectTypes = map[string]attr.Type{
-		"count":          types.Int64Type,
-		"retention_days": types.Int64Type,
+		"count":          types.Int32Type,
+		"retention_days": types.Int32Type,
 	}
 
 	passwordPolicyLengthTFObjectTypes = map[string]attr.Type{
-		"max": types.Int64Type,
-		"min": types.Int64Type,
+		"max": types.Int32Type,
+		"min": types.Int32Type,
 	}
 
 	passwordPolicyLockoutTFObjectTypes = map[string]attr.Type{
-		"duration_seconds": types.Int64Type,
-		"failure_count":    types.Int64Type,
+		"duration_seconds": types.Int32Type,
+		"failure_count":    types.Int32Type,
 	}
 
 	passwordPolicyMinCharactersTFObjectTypes = map[string]attr.Type{
-		"alphabetical_uppercase": types.Int64Type,
-		"alphabetical_lowercase": types.Int64Type,
-		"numeric":                types.Int64Type,
-		"special_characters":     types.Int64Type,
+		"alphabetical_uppercase": types.Int32Type,
+		"alphabetical_lowercase": types.Int32Type,
+		"numeric":                types.Int32Type,
+		"special_characters":     types.Int32Type,
 	}
 )
 
@@ -245,21 +245,21 @@ func (r *PasswordPolicyResource) Schema(ctx context.Context, req resource.Schema
 				Optional:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"count": schema.Int64Attribute{
+					"count": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of prior passwords to keep for prevention of password re-use. The value must be a positive, non-zero integer.").Description,
 						Required:    true,
 
-						Validators: []validator.Int64{
-							int64validator.AtLeast(attrMinLength),
+						Validators: []validator.Int32{
+							int32validator.AtLeast(attrMinLength),
 						},
 					},
 
-					"retention_days": schema.Int64Attribute{
+					"retention_days": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the length of time to keep recent passwords for prevention of password re-use. The value must be a positive, non-zero integer.").Description,
 						Required:    true,
 
-						Validators: []validator.Int64{
-							int64validator.AtLeast(attrMinLength),
+						Validators: []validator.Int32{
+							int32validator.AtLeast(attrMinLength),
 						},
 					},
 				},
@@ -270,26 +270,26 @@ func (r *PasswordPolicyResource) Schema(ctx context.Context, req resource.Schema
 				Optional:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"max": schema.Int64Attribute{
+					"max": schema.Int32Attribute{
 						Description:         passwordLengthMaxDescription.Description,
 						MarkdownDescription: passwordLengthMaxDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(passwordLengthMax),
+						Default: int32default.StaticInt32(passwordLengthMax),
 
-						Validators: []validator.Int64{
-							int64validator.Between(passwordLengthMax, passwordLengthMax),
+						Validators: []validator.Int32{
+							int32validator.Between(passwordLengthMax, passwordLengthMax),
 						},
 					},
 
-					"min": schema.Int64Attribute{
+					"min": schema.Int32Attribute{
 						Description:         passwordLengthMinDescription.Description,
 						MarkdownDescription: passwordLengthMinDescription.MarkdownDescription,
 						Required:            true,
 
-						Validators: []validator.Int64{
-							int64validator.Between(passwordLengthMinMin, passwordLengthMinMax),
+						Validators: []validator.Int32{
+							int32validator.Between(passwordLengthMinMin, passwordLengthMinMax),
 						},
 					},
 				},
@@ -300,21 +300,21 @@ func (r *PasswordPolicyResource) Schema(ctx context.Context, req resource.Schema
 				Optional:    true,
 
 				Attributes: map[string]schema.Attribute{
-					"duration_seconds": schema.Int64Attribute{
+					"duration_seconds": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the length of time before a password is automatically moved out of the lock out state. The value must be a positive, non-zero integer.").Description,
 						Required:    true,
 
-						Validators: []validator.Int64{
-							int64validator.AtLeast(attrMinLength),
+						Validators: []validator.Int32{
+							int32validator.AtLeast(attrMinLength),
 						},
 					},
 
-					"failure_count": schema.Int64Attribute{
+					"failure_count": schema.Int32Attribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of tries before a password is placed in the lockout state. The value must be a positive, non-zero integer.").Description,
 						Required:    true,
 
-						Validators: []validator.Int64{
-							int64validator.AtLeast(attrMinLength),
+						Validators: []validator.Int32{
+							int32validator.AtLeast(attrMinLength),
 						},
 					},
 				},
@@ -326,106 +326,106 @@ func (r *PasswordPolicyResource) Schema(ctx context.Context, req resource.Schema
 				Optional:            true,
 
 				Attributes: map[string]schema.Attribute{
-					"alphabetical_uppercase": schema.Int64Attribute{
+					"alphabetical_uppercase": schema.Int32Attribute{
 						Description:         minCharactersAlphabeticalUppercaseDescription.Description,
 						MarkdownDescription: minCharactersAlphabeticalUppercaseDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(minCharactersFixedValue),
+						Default: int32default.StaticInt32(minCharactersFixedValue),
 
-						Validators: []validator.Int64{
-							int64validator.Between(minCharactersFixedValue, minCharactersFixedValue),
+						Validators: []validator.Int32{
+							int32validator.Between(minCharactersFixedValue, minCharactersFixedValue),
 						},
 					},
 
-					"alphabetical_lowercase": schema.Int64Attribute{
+					"alphabetical_lowercase": schema.Int32Attribute{
 						Description:         minCharactersAlphabeticalLowercaseDescription.Description,
 						MarkdownDescription: minCharactersAlphabeticalLowercaseDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(minCharactersFixedValue),
+						Default: int32default.StaticInt32(minCharactersFixedValue),
 
-						Validators: []validator.Int64{
-							int64validator.Between(minCharactersFixedValue, minCharactersFixedValue),
+						Validators: []validator.Int32{
+							int32validator.Between(minCharactersFixedValue, minCharactersFixedValue),
 						},
 					},
 
-					"numeric": schema.Int64Attribute{
+					"numeric": schema.Int32Attribute{
 						Description:         minCharactersNumericDescription.Description,
 						MarkdownDescription: minCharactersNumericDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(minCharactersFixedValue),
+						Default: int32default.StaticInt32(minCharactersFixedValue),
 
-						Validators: []validator.Int64{
-							int64validator.Between(minCharactersFixedValue, minCharactersFixedValue),
+						Validators: []validator.Int32{
+							int32validator.Between(minCharactersFixedValue, minCharactersFixedValue),
 						},
 					},
 
-					"special_characters": schema.Int64Attribute{
+					"special_characters": schema.Int32Attribute{
 						Description:         minCharactersSpecialCharactersDescription.Description,
 						MarkdownDescription: minCharactersSpecialCharactersDescription.MarkdownDescription,
 						Optional:            true,
 						Computed:            true,
 
-						Default: int64default.StaticInt64(minCharactersFixedValue),
+						Default: int32default.StaticInt32(minCharactersFixedValue),
 
-						Validators: []validator.Int64{
-							int64validator.Between(minCharactersFixedValue, minCharactersFixedValue),
+						Validators: []validator.Int32{
+							int32validator.Between(minCharactersFixedValue, minCharactersFixedValue),
 						},
 					},
 				},
 			},
 
-			"password_age_max": schema.Int64Attribute{
+			"password_age_max": schema.Int32Attribute{
 				Description:         passwordAgeMaxDescription.Description,
 				MarkdownDescription: passwordAgeMaxDescription.MarkdownDescription,
 				Optional:            true,
 
-				Validators: []validator.Int64{
-					int64validator.AtLeast(attrMinLength),
+				Validators: []validator.Int32{
+					int32validator.AtLeast(attrMinLength),
 				},
 			},
 
-			"password_age_min": schema.Int64Attribute{
+			"password_age_min": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the minimum number of days a password must be used before changing. The value must be a positive, non-zero integer. This property is not enforced when not present.").Description,
 				Optional:    true,
 
-				Validators: []validator.Int64{
-					int64validator.AtLeast(attrMinLength),
+				Validators: []validator.Int32{
+					int32validator.AtLeast(attrMinLength),
 				},
 			},
 
-			"max_repeated_characters": schema.Int64Attribute{
+			"max_repeated_characters": schema.Int32Attribute{
 				Description:         maxRepeatedCharactersDescription.Description,
 				MarkdownDescription: maxRepeatedCharactersDescription.MarkdownDescription,
 				Optional:            true,
 
-				Validators: []validator.Int64{
-					int64validator.Between(maxRepeatedCharactersFixedValue, maxRepeatedCharactersFixedValue),
+				Validators: []validator.Int32{
+					int32validator.Between(maxRepeatedCharactersFixedValue, maxRepeatedCharactersFixedValue),
 				},
 			},
 
-			"min_complexity": schema.Int64Attribute{
+			"min_complexity": schema.Int32Attribute{
 				Description:         minComplexityDescription.Description,
 				MarkdownDescription: minComplexityDescription.MarkdownDescription,
 				Optional:            true,
 
-				Validators: []validator.Int64{
-					int64validator.Between(minComplexityFixedValue, minComplexityFixedValue),
+				Validators: []validator.Int32{
+					int32validator.Between(minComplexityFixedValue, minComplexityFixedValue),
 				},
 			},
 
-			"min_unique_characters": schema.Int64Attribute{
+			"min_unique_characters": schema.Int32Attribute{
 				Description:         minUniqueCharactersDescription.Description,
 				MarkdownDescription: minUniqueCharactersDescription.MarkdownDescription,
 				Optional:            true,
 
-				Validators: []validator.Int64{
-					int64validator.Between(minUniqueCharactersFixedValue, minUniqueCharactersFixedValue),
+				Validators: []validator.Int32{
+					int32validator.Between(minUniqueCharactersFixedValue, minUniqueCharactersFixedValue),
 				},
 			},
 
@@ -438,7 +438,7 @@ func (r *PasswordPolicyResource) Schema(ctx context.Context, req resource.Schema
 				Default: booldefault.StaticBool(false),
 			},
 
-			"population_count": schema.Int64Attribute{
+			"population_count": schema.Int32Attribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that specifies the number of populations associated with the password policy.").Description,
 				Computed:    true,
 			},
@@ -738,11 +738,11 @@ func (p *passwordPolicyResourceModelV1) expand(ctx context.Context) (*management
 		history := management.NewPasswordPolicyHistory()
 
 		if !plan.Count.IsNull() && !plan.Count.IsUnknown() {
-			history.SetCount(int32(plan.Count.ValueInt64()))
+			history.SetCount(plan.Count.ValueInt32())
 		}
 
 		if !plan.RetentionDays.IsNull() && !plan.RetentionDays.IsUnknown() {
-			history.SetRetentionDays(int32(plan.RetentionDays.ValueInt64()))
+			history.SetRetentionDays(plan.RetentionDays.ValueInt32())
 		}
 
 		data.SetHistory(*history)
@@ -761,11 +761,11 @@ func (p *passwordPolicyResourceModelV1) expand(ctx context.Context) (*management
 		length := management.NewPasswordPolicyLength()
 
 		if !plan.Max.IsNull() && !plan.Max.IsUnknown() {
-			length.SetMax(int32(plan.Max.ValueInt64()))
+			length.SetMax(plan.Max.ValueInt32())
 		}
 
 		if !plan.Min.IsNull() && !plan.Min.IsUnknown() {
-			length.SetMin(int32(plan.Min.ValueInt64()))
+			length.SetMin(plan.Min.ValueInt32())
 		}
 
 		data.SetLength(*length)
@@ -784,11 +784,11 @@ func (p *passwordPolicyResourceModelV1) expand(ctx context.Context) (*management
 		lockout := management.NewPasswordPolicyLockout()
 
 		if !plan.DurationSeconds.IsNull() && !plan.DurationSeconds.IsUnknown() {
-			lockout.SetDurationSeconds(int32(plan.DurationSeconds.ValueInt64()))
+			lockout.SetDurationSeconds(plan.DurationSeconds.ValueInt32())
 		}
 
 		if !plan.FailureCount.IsNull() && !plan.FailureCount.IsUnknown() {
-			lockout.SetFailureCount(int32(plan.FailureCount.ValueInt64()))
+			lockout.SetFailureCount(plan.FailureCount.ValueInt32())
 		}
 
 		data.SetLockout(*lockout)
@@ -807,46 +807,46 @@ func (p *passwordPolicyResourceModelV1) expand(ctx context.Context) (*management
 		minCharacters := management.NewPasswordPolicyMinCharacters()
 
 		if !plan.AlphabeticalUppercase.IsNull() && !plan.AlphabeticalUppercase.IsUnknown() {
-			minCharacters.SetABCDEFGHIJKLMNOPQRSTUVWXYZ(int32(plan.AlphabeticalUppercase.ValueInt64()))
+			minCharacters.SetABCDEFGHIJKLMNOPQRSTUVWXYZ(plan.AlphabeticalUppercase.ValueInt32())
 		}
 
 		if !plan.AlphabeticalLowercase.IsNull() && !plan.AlphabeticalLowercase.IsUnknown() {
-			minCharacters.SetAbcdefghijklmnopqrstuvwxyz(int32(plan.AlphabeticalLowercase.ValueInt64()))
+			minCharacters.SetAbcdefghijklmnopqrstuvwxyz(plan.AlphabeticalLowercase.ValueInt32())
 		}
 
 		if !plan.Numeric.IsNull() && !plan.Numeric.IsUnknown() {
-			minCharacters.SetVar0123456789(int32(plan.Numeric.ValueInt64()))
+			minCharacters.SetVar0123456789(plan.Numeric.ValueInt32())
 		}
 
 		if !plan.SpecialCharacters.IsNull() && !plan.SpecialCharacters.IsUnknown() {
-			minCharacters.SetSpecialChar(int32(plan.SpecialCharacters.ValueInt64()))
+			minCharacters.SetSpecialChar(plan.SpecialCharacters.ValueInt32())
 		}
 
 		data.SetMinCharacters(*minCharacters)
 	}
 
 	if !p.PasswordAgeMax.IsNull() && !p.PasswordAgeMax.IsUnknown() {
-		data.SetMaxAgeDays(int32(p.PasswordAgeMax.ValueInt64()))
+		data.SetMaxAgeDays(p.PasswordAgeMax.ValueInt32())
 	}
 
 	if !p.PasswordAgeMin.IsNull() && !p.PasswordAgeMin.IsUnknown() {
-		data.SetMinAgeDays(int32(p.PasswordAgeMin.ValueInt64()))
+		data.SetMinAgeDays(p.PasswordAgeMin.ValueInt32())
 	}
 
 	if !p.MaxRepeatedCharacters.IsNull() && !p.MaxRepeatedCharacters.IsUnknown() {
-		data.SetMaxRepeatedCharacters(int32(p.MaxRepeatedCharacters.ValueInt64()))
+		data.SetMaxRepeatedCharacters(p.MaxRepeatedCharacters.ValueInt32())
 	}
 
 	if !p.MinComplexity.IsNull() && !p.MinComplexity.IsUnknown() {
-		data.SetMinComplexity(int32(p.MinComplexity.ValueInt64()))
+		data.SetMinComplexity(p.MinComplexity.ValueInt32())
 	}
 
 	if !p.MinUniqueCharacters.IsNull() && !p.MinUniqueCharacters.IsUnknown() {
-		data.SetMinUniqueCharacters(int32(p.MinUniqueCharacters.ValueInt64()))
+		data.SetMinUniqueCharacters(p.MinUniqueCharacters.ValueInt32())
 	}
 
 	if !p.MinUniqueCharacters.IsNull() && !p.MinUniqueCharacters.IsUnknown() {
-		data.SetMinUniqueCharacters(int32(p.MinUniqueCharacters.ValueInt64()))
+		data.SetMinUniqueCharacters(p.MinUniqueCharacters.ValueInt32())
 	}
 
 	return data, diags

--- a/internal/service/sso/resource_password_policy_schema_upgrade_0_to_1.go
+++ b/internal/service/sso/resource_password_policy_schema_upgrade_0_to_1.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
@@ -27,30 +27,30 @@ type passwordPolicyResourceModelV0 struct {
 	AccountLockout               types.List                   `tfsdk:"account_lockout"`
 	MinCharacters                types.List                   `tfsdk:"min_characters"`
 	PasswordAge                  types.List                   `tfsdk:"password_age"`
-	MaxRepeatedCharacters        types.Int64                  `tfsdk:"max_repeated_characters"`
-	MinComplexity                types.Int64                  `tfsdk:"min_complexity"`
-	MinUniqueCharacters          types.Int64                  `tfsdk:"min_unique_characters"`
+	MaxRepeatedCharacters        types.Int32                  `tfsdk:"max_repeated_characters"`
+	MinComplexity                types.Int32                  `tfsdk:"min_complexity"`
+	MinUniqueCharacters          types.Int32                  `tfsdk:"min_unique_characters"`
 	NotSimilarToCurrent          types.Bool                   `tfsdk:"not_similar_to_current"`
-	PopulationCount              types.Int64                  `tfsdk:"population_count"`
+	PopulationCount              types.Int32                  `tfsdk:"population_count"`
 }
 
 type passwordPolicyPasswordHistoryResourceModelV0 struct {
-	PriorPasswordCount types.Int64 `tfsdk:"prior_password_count"`
-	RetentionDays      types.Int64 `tfsdk:"retention_days"`
+	PriorPasswordCount types.Int32 `tfsdk:"prior_password_count"`
+	RetentionDays      types.Int32 `tfsdk:"retention_days"`
 }
 
 type passwordPolicyPasswordLengthResourceModelV0 passwordPolicyLengthResourceModelV1
 
 type passwordPolicyAccountLockoutResourceModelV0 struct {
-	DurationSeconds types.Int64 `tfsdk:"duration_seconds"`
-	FailCount       types.Int64 `tfsdk:"fail_count"`
+	DurationSeconds types.Int32 `tfsdk:"duration_seconds"`
+	FailCount       types.Int32 `tfsdk:"fail_count"`
 }
 
 type passwordPolicyMinCharactersResourceModelV0 passwordPolicyMinCharactersResourceModelV1
 
 type passwordPolicyPasswordAgeResourceModelV0 struct {
-	Max types.Int64 `tfsdk:"max"`
-	Min types.Int64 `tfsdk:"min"`
+	Max types.Int32 `tfsdk:"max"`
+	Min types.Int32 `tfsdk:"min"`
 }
 
 func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
@@ -105,15 +105,15 @@ func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]res
 						Default: booldefault.StaticBool(false),
 					},
 
-					"max_repeated_characters": schema.Int64Attribute{
+					"max_repeated_characters": schema.Int32Attribute{
 						Optional: true,
 					},
 
-					"min_complexity": schema.Int64Attribute{
+					"min_complexity": schema.Int32Attribute{
 						Optional: true,
 					},
 
-					"min_unique_characters": schema.Int64Attribute{
+					"min_unique_characters": schema.Int32Attribute{
 						Optional: true,
 					},
 
@@ -124,7 +124,7 @@ func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]res
 						Default: booldefault.StaticBool(false),
 					},
 
-					"population_count": schema.Int64Attribute{
+					"population_count": schema.Int32Attribute{
 						Computed: true,
 					},
 				},
@@ -133,11 +133,11 @@ func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]res
 					"password_history": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"prior_password_count": schema.Int64Attribute{
+								"prior_password_count": schema.Int32Attribute{
 									Optional: true,
 								},
 
-								"retention_days": schema.Int64Attribute{
+								"retention_days": schema.Int32Attribute{
 									Optional: true,
 								},
 							},
@@ -147,18 +147,18 @@ func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]res
 					"password_length": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"max": schema.Int64Attribute{
+								"max": schema.Int32Attribute{
 									Optional: true,
 									Computed: true,
 
-									Default: int64default.StaticInt64(passwordLengthMaxDefault),
+									Default: int32default.StaticInt32(passwordLengthMaxDefault),
 								},
 
-								"min": schema.Int64Attribute{
+								"min": schema.Int32Attribute{
 									Optional: true,
 									Computed: true,
 
-									Default: int64default.StaticInt64(passwordLengthMinDefault),
+									Default: int32default.StaticInt32(passwordLengthMinDefault),
 								},
 							},
 						},
@@ -167,11 +167,11 @@ func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]res
 					"account_lockout": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"duration_seconds": schema.Int64Attribute{
+								"duration_seconds": schema.Int32Attribute{
 									Optional: true,
 								},
 
-								"fail_count": schema.Int64Attribute{
+								"fail_count": schema.Int32Attribute{
 									Optional: true,
 								},
 							},
@@ -181,19 +181,19 @@ func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]res
 					"min_characters": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"alphabetical_uppercase": schema.Int64Attribute{
+								"alphabetical_uppercase": schema.Int32Attribute{
 									Optional: true,
 								},
 
-								"alphabetical_lowercase": schema.Int64Attribute{
+								"alphabetical_lowercase": schema.Int32Attribute{
 									Optional: true,
 								},
 
-								"numeric": schema.Int64Attribute{
+								"numeric": schema.Int32Attribute{
 									Optional: true,
 								},
 
-								"special_characters": schema.Int64Attribute{
+								"special_characters": schema.Int32Attribute{
 									Optional: true,
 								},
 							},
@@ -203,11 +203,11 @@ func (r *PasswordPolicyResource) UpgradeState(ctx context.Context) map[int64]res
 					"password_age": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"max": schema.Int64Attribute{
+								"max": schema.Int32Attribute{
 									Optional: true,
 								},
 
-								"min": schema.Int64Attribute{
+								"min": schema.Int32Attribute{
 									Optional: true,
 								},
 							},
@@ -408,25 +408,25 @@ func (p *passwordPolicyResourceModelV0) schemaUpgradeMinCharactersV0toV1(ctx con
 	}
 }
 
-func (p *passwordPolicyResourceModelV0) schemaUpgradePasswordAgeMaxV0toV1(ctx context.Context) (types.Int64, diag.Diagnostics) {
+func (p *passwordPolicyResourceModelV0) schemaUpgradePasswordAgeMaxV0toV1(ctx context.Context) (types.Int32, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	planAttribute := p.PasswordAge
 
 	if planAttribute.IsNull() {
-		return types.Int64Null(), diags
+		return types.Int32Null(), diags
 	} else if planAttribute.IsUnknown() {
-		return types.Int64Unknown(), diags
+		return types.Int32Unknown(), diags
 	} else {
 		var priorStateData []passwordPolicyPasswordAgeResourceModelV0
 		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
 		diags.Append(d...)
 		if diags.HasError() {
-			return types.Int64Null(), diags
+			return types.Int32Null(), diags
 		}
 
 		if len(priorStateData) == 0 {
-			return types.Int64Null(), diags
+			return types.Int32Null(), diags
 		}
 
 		returnVar := priorStateData[0].Max
@@ -435,25 +435,25 @@ func (p *passwordPolicyResourceModelV0) schemaUpgradePasswordAgeMaxV0toV1(ctx co
 	}
 }
 
-func (p *passwordPolicyResourceModelV0) schemaUpgradePasswordAgeMinV0toV1(ctx context.Context) (types.Int64, diag.Diagnostics) {
+func (p *passwordPolicyResourceModelV0) schemaUpgradePasswordAgeMinV0toV1(ctx context.Context) (types.Int32, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	planAttribute := p.PasswordAge
 
 	if planAttribute.IsNull() {
-		return types.Int64Null(), diags
+		return types.Int32Null(), diags
 	} else if planAttribute.IsUnknown() {
-		return types.Int64Unknown(), diags
+		return types.Int32Unknown(), diags
 	} else {
 		var priorStateData []passwordPolicyPasswordAgeResourceModelV0
 		d := planAttribute.ElementsAs(ctx, &priorStateData, false)
 		diags.Append(d...)
 		if diags.HasError() {
-			return types.Int64Null(), diags
+			return types.Int32Null(), diags
 		}
 
 		if len(priorStateData) == 0 {
-			return types.Int64Null(), diags
+			return types.Int32Null(), diags
 		}
 
 		returnVar := priorStateData[0].Min

--- a/internal/service/sso/resource_resource.go
+++ b/internal/service/sso/resource_resource.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -39,7 +39,7 @@ type ResourceResourceModel struct {
 	Description                    types.String                 `tfsdk:"description"`
 	Type                           types.String                 `tfsdk:"type"`
 	Audience                       types.String                 `tfsdk:"audience"`
-	AccessTokenValiditySeconds     types.Int64                  `tfsdk:"access_token_validity_seconds"`
+	AccessTokenValiditySeconds     types.Int32                  `tfsdk:"access_token_validity_seconds"`
 	ApplicationPermissionsSettings types.Object                 `tfsdk:"application_permissions_settings"`
 	IntrospectEndpointAuthMethod   types.String                 `tfsdk:"introspect_endpoint_auth_method"`
 }
@@ -153,16 +153,16 @@ func (r *ResourceResource) Schema(ctx context.Context, req resource.SchemaReques
 				},
 			},
 
-			"access_token_validity_seconds": schema.Int64Attribute{
+			"access_token_validity_seconds": schema.Int32Attribute{
 				Description:         accessTokenValiditySecondsDescription.Description,
 				MarkdownDescription: accessTokenValiditySecondsDescription.MarkdownDescription,
 				Optional:            true,
 				Computed:            true,
 
-				Default: int64default.StaticInt64(accessTokenValiditySecondsDefault),
+				Default: int32default.StaticInt32(accessTokenValiditySecondsDefault),
 
-				Validators: []validator.Int64{
-					int64validator.Between(accessTokenValiditySecondsMin, accessTokenValiditySecondsMax),
+				Validators: []validator.Int32{
+					int32validator.Between(accessTokenValiditySecondsMin, accessTokenValiditySecondsMax),
 				},
 			},
 
@@ -479,7 +479,7 @@ func (p *ResourceResourceModel) expand(ctx context.Context) (*management.Resourc
 	}
 
 	if !p.AccessTokenValiditySeconds.IsNull() && !p.AccessTokenValiditySeconds.IsUnknown() {
-		data.SetAccessTokenValiditySeconds(int32(p.AccessTokenValiditySeconds.ValueInt64()))
+		data.SetAccessTokenValiditySeconds(p.AccessTokenValiditySeconds.ValueInt32())
 	}
 
 	if !p.IntrospectEndpointAuthMethod.IsNull() && !p.IntrospectEndpointAuthMethod.IsUnknown() {

--- a/internal/service/sso/utils_application.go
+++ b/internal/service/sso/utils_application.go
@@ -190,7 +190,7 @@ func applicationMobileAppOkToTF(ctx context.Context, apiObject *management.Appli
 		"huawei_package_name":      framework.StringOkToTF(apiObject.GetHuaweiPackageNameOk()),
 		"integrity_detection":      integrityDetection,
 		"package_name":             framework.StringOkToTF(apiObject.GetPackageNameOk()),
-		"passcode_refresh_seconds": types.Int64Null(),
+		"passcode_refresh_seconds": types.Int32Null(),
 		"universal_app_link":       framework.StringOkToTF(apiObject.GetUriPrefixOk()),
 	}
 

--- a/internal/service/verify/data_source_verify_policy.go
+++ b/internal/service/verify/data_source_verify_policy.go
@@ -45,7 +45,7 @@ type verifyPolicyDataSourceModel struct {
 
 var (
 	genericTimeoutDataSourceServiceTFObjectTypes = map[string]attr.Type{
-		"duration":  types.Int64Type,
+		"duration":  types.Int32Type,
 		"time_unit": types.StringType,
 	}
 
@@ -55,7 +55,7 @@ var (
 		"fail_expired_id": types.BoolType,
 		"provider_auto":   types.StringType,
 		"provider_manual": types.StringType,
-		"retry_attempts":  types.Int64Type,
+		"retry_attempts":  types.Int32Type,
 	}
 
 	facialComparisonDataSourceServiceTFObjectTypes = map[string]attr.Type{
@@ -66,7 +66,7 @@ var (
 	livenessDataSourceServiceTFObjectTypes = map[string]attr.Type{
 		"verify":         types.StringType,
 		"threshold":      types.StringType,
-		"retry_attempts": types.Int64Type,
+		"retry_attempts": types.Int32Type,
 	}
 
 	deviceDataSourceServiceTFObjectTypes = map[string]attr.Type{
@@ -83,11 +83,11 @@ var (
 	}
 
 	otpAttemptsDataSourceServiceTFObjectTypes = map[string]attr.Type{
-		"count": types.Int64Type,
+		"count": types.Int32Type,
 	}
 
 	otpDeliveriesDataSourceServiceTFObjectTypes = map[string]attr.Type{
-		"count":    types.Int64Type,
+		"count":    types.Int32Type,
 		"cooldown": types.ObjectType{AttrTypes: genericTimeoutDataSourceServiceTFObjectTypes},
 	}
 
@@ -116,7 +116,7 @@ var (
 	}
 
 	textDependentDataSourceServiceTFObjectTypes = map[string]attr.Type{
-		"samples":         types.Int64Type,
+		"samples":         types.Int32Type,
 		"voice_phrase_id": pingonetypes.ResourceIDType{},
 	}
 
@@ -418,7 +418,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 						MarkdownDescription: providerManualDescription.MarkdownDescription,
 						Computed:            true,
 					},
-					"retry_attempts": schema.Int64Attribute{
+					"retry_attempts": schema.Int32Attribute{
 						Description:         retryAttemptsDescription.Description,
 						MarkdownDescription: retryAttemptsDescription.MarkdownDescription,
 						Computed:            true,
@@ -459,7 +459,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 						MarkdownDescription: livenessThresholdDescription.MarkdownDescription,
 						Computed:            true,
 					},
-					"retry_attempts": schema.Int64Attribute{
+					"retry_attempts": schema.Int32Attribute{
 						Description:         retryAttemptsDescription.Description,
 						MarkdownDescription: retryAttemptsDescription.MarkdownDescription,
 						Computed:            true,
@@ -484,7 +484,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 								Description: "OTP attempts configuration.",
 								Computed:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP failures.",
 										Computed:    true,
 									},
@@ -494,7 +494,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 								Description: "OTP delivery configuration.",
 								Computed:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP deliveries.",
 										Computed:    true,
 									},
@@ -502,7 +502,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 										Description: "Cooldown (waiting period between OTP attempts) configuration.",
 										Computed:    true,
 										Attributes: map[string]schema.Attribute{
-											"duration": schema.Int64Attribute{
+											"duration": schema.Int32Attribute{
 												Description:         otpDeliveriesCooldownDurationDescription.Description,
 												MarkdownDescription: otpDeliveriesCooldownDurationDescription.MarkdownDescription,
 												Computed:            true,
@@ -520,7 +520,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 								Description: "The length of time for which the OTP is valid.",
 								Computed:    true,
 								Attributes: map[string]schema.Attribute{
-									"duration": schema.Int64Attribute{
+									"duration": schema.Int32Attribute{
 										Description:         otpLifeTimeEmailDurationDescription.Description,
 										MarkdownDescription: otpLifeTimeEmailDurationDescription.MarkdownDescription,
 										Computed:            true,
@@ -575,7 +575,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 								Description: "OTP attempts configuration.",
 								Computed:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP failures.",
 										Computed:    true,
 									},
@@ -585,7 +585,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 								Description: "OTP delivery configuration.",
 								Computed:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP deliveries.",
 										Computed:    true,
 									},
@@ -593,7 +593,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 										Description: "Cooldown (waiting period between OTP attempts) configuration.",
 										Computed:    true,
 										Attributes: map[string]schema.Attribute{
-											"duration": schema.Int64Attribute{
+											"duration": schema.Int32Attribute{
 												Description:         otpDeliveriesCooldownDurationDescription.Description,
 												MarkdownDescription: otpDeliveriesCooldownDurationDescription.MarkdownDescription,
 												Computed:            true,
@@ -611,7 +611,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 								Description: "The length of time for which the OTP is valid.",
 								Computed:    true,
 								Attributes: map[string]schema.Attribute{
-									"duration": schema.Int64Attribute{
+									"duration": schema.Int32Attribute{
 										Description:         otpLifeTimePhoneDurationDescription.Description,
 										MarkdownDescription: otpLifeTimePhoneDurationDescription.MarkdownDescription,
 										Computed:            true,
@@ -659,7 +659,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 						Computed:    true,
 
 						Attributes: map[string]schema.Attribute{
-							"duration": schema.Int64Attribute{
+							"duration": schema.Int32Attribute{
 								Description:         transactionTimeoutDurationDescription.Description,
 								MarkdownDescription: transactionTimeoutDurationDescription.MarkdownDescription,
 								Computed:            true,
@@ -679,7 +679,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 								Description: "Object for data collection timeout.",
 								Computed:    true,
 								Attributes: map[string]schema.Attribute{
-									"duration": schema.Int64Attribute{
+									"duration": schema.Int32Attribute{
 										Description:         dataCollectionDurationDescription.Description,
 										MarkdownDescription: dataCollectionDurationDescription.MarkdownDescription,
 										Computed:            true,
@@ -731,7 +731,7 @@ func (r *VerifyPolicyDataSource) Schema(ctx context.Context, req datasource.Sche
 						Computed:    true,
 
 						Attributes: map[string]schema.Attribute{
-							"samples": schema.Int64Attribute{
+							"samples": schema.Int32Attribute{
 								Description:         voiceTexttDependentSamplesDescription.Description,
 								MarkdownDescription: voiceTexttDependentSamplesDescription.MarkdownDescription,
 								Computed:            true,
@@ -1012,7 +1012,7 @@ func (p *verifyPolicyDataSourceModel) toStateGovernmentId(apiObject *verify.Gove
 		return types.ObjectNull(governmentIdDataSourceServiceTFObjectTypes), diags
 	}
 
-	retryAttempts := types.Int64Null()
+	retryAttempts := types.Int32Null()
 	if v, ok := apiObject.GetRetryOk(); ok {
 		if t, ok := v.GetAttemptsOk(); ok {
 			retryAttempts = framework.Int32ToTF(*t)
@@ -1062,7 +1062,7 @@ func (p *verifyPolicyDataSourceModel) toStateLiveness(apiObject *verify.Liveness
 		return types.ObjectNull(livenessDataSourceServiceTFObjectTypes), diags
 	}
 
-	retryAttempts := types.Int64Null()
+	retryAttempts := types.Int32Null()
 	if v, ok := apiObject.GetRetryOk(); ok {
 		if t, ok := v.GetAttemptsOk(); ok {
 			retryAttempts = framework.Int32ToTF(*t)

--- a/internal/service/verify/resource_verify_policy.go
+++ b/internal/service/verify/resource_verify_policy.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -28,7 +28,7 @@ import (
 	"github.com/patrickcping/pingone-go-sdk-v2/verify"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
-	int64validatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/int64validator"
+	int32validatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/int32validator"
 	customstringvalidator "github.com/pingidentity/terraform-provider-pingone/internal/framework/stringvalidator"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
 	"github.com/pingidentity/terraform-provider-pingone/internal/utils"
@@ -61,7 +61,7 @@ type governmentIdModel struct {
 	FailExpiredId  types.Bool   `tfsdk:"fail_expired_id"`
 	ProviderAuto   types.String `tfsdk:"provider_auto"`
 	ProviderManual types.String `tfsdk:"provider_manual"`
-	RetryAttempts  types.Int64  `tfsdk:"retry_attempts"`
+	RetryAttempts  types.Int32  `tfsdk:"retry_attempts"`
 }
 
 type facialComparisonModel struct {
@@ -72,11 +72,11 @@ type facialComparisonModel struct {
 type livenessnModel struct {
 	Verify        types.String `tfsdk:"verify"`
 	Threshold     types.String `tfsdk:"threshold"`
-	RetryAttempts types.Int64  `tfsdk:"retry_attempts"`
+	RetryAttempts types.Int32  `tfsdk:"retry_attempts"`
 }
 
 type genericTimeoutModel struct {
-	Duration types.Int64  `tfsdk:"duration"`
+	Duration types.Int32  `tfsdk:"duration"`
 	TimeUnit types.String `tfsdk:"time_unit"`
 }
 
@@ -94,11 +94,11 @@ type otpConfigurationModel struct {
 }
 
 type otpAttemptsModel struct {
-	Count types.Int64 `tfsdk:"count"`
+	Count types.Int32 `tfsdk:"count"`
 }
 
 type otpDeliveriesModel struct {
-	Count    types.Int64  `tfsdk:"count"`
+	Count    types.Int32  `tfsdk:"count"`
 	Cooldown types.Object `tfsdk:"cooldown"`
 }
 
@@ -127,7 +127,7 @@ type voiceModel struct {
 }
 
 type textDependentModel struct {
-	Samples  types.Int64  `tfsdk:"samples"`
+	Samples  types.Int32  `tfsdk:"samples"`
 	PhraseId types.String `tfsdk:"voice_phrase_id"`
 }
 
@@ -139,7 +139,7 @@ type referenceDataModel struct {
 
 var (
 	genericTimeoutServiceTFObjectTypes = map[string]attr.Type{
-		"duration":  types.Int64Type,
+		"duration":  types.Int32Type,
 		"time_unit": types.StringType,
 	}
 
@@ -149,7 +149,7 @@ var (
 		"fail_expired_id": types.BoolType,
 		"provider_auto":   types.StringType,
 		"provider_manual": types.StringType,
-		"retry_attempts":  types.Int64Type,
+		"retry_attempts":  types.Int32Type,
 	}
 
 	facialComparisonServiceTFObjectTypes = map[string]attr.Type{
@@ -160,7 +160,7 @@ var (
 	livenessServiceTFObjectTypes = map[string]attr.Type{
 		"verify":         types.StringType,
 		"threshold":      types.StringType,
-		"retry_attempts": types.Int64Type,
+		"retry_attempts": types.Int32Type,
 	}
 
 	deviceServiceTFObjectTypes = map[string]attr.Type{
@@ -177,11 +177,11 @@ var (
 	}
 
 	otpAttemptsServiceTFObjectTypes = map[string]attr.Type{
-		"count": types.Int64Type,
+		"count": types.Int32Type,
 	}
 
 	otpDeliveriesServiceTFObjectTypes = map[string]attr.Type{
-		"count":    types.Int64Type,
+		"count":    types.Int32Type,
 		"cooldown": types.ObjectType{AttrTypes: genericTimeoutServiceTFObjectTypes},
 	}
 
@@ -210,7 +210,7 @@ var (
 	}
 
 	textDependentServiceTFObjectTypes = map[string]attr.Type{
-		"samples":         types.Int64Type,
+		"samples":         types.Int32Type,
 		"voice_phrase_id": types.StringType,
 	}
 
@@ -499,7 +499,7 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 						"fail_expired_id": types.BoolValue(defaultBoolFalse),
 						"provider_auto":   types.StringValue(string(defaultProviderAuto)),
 						"provider_manual": types.StringValue(string(defaultProviderManual)),
-						"retry_attempts":  types.Int64Null(),
+						"retry_attempts":  types.Int32Null(),
 					},
 				)),
 
@@ -555,12 +555,12 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 							stringvalidator.OneOf(utils.EnumSliceToStringSlice(verify.AllowedEnumProviderManualEnumValues)...),
 						},
 					},
-					"retry_attempts": schema.Int64Attribute{
+					"retry_attempts": schema.Int32Attribute{
 						Description:         retryAttemptsDescription.Description,
 						MarkdownDescription: retryAttemptsDescription.MarkdownDescription,
 						Optional:            true,
-						Validators: []validator.Int64{
-							int64validator.Between(attrMinRetryAttempts, attrMaxRetryAttempts),
+						Validators: []validator.Int32{
+							int32validator.Between(attrMinRetryAttempts, attrMaxRetryAttempts),
 						},
 					},
 				},
@@ -613,7 +613,7 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 					map[string]attr.Value{
 						"verify":         types.StringValue(string(defaultVerify)),
 						"threshold":      types.StringValue(string(defaultThreshold)),
-						"retry_attempts": types.Int64Null(),
+						"retry_attempts": types.Int32Null(),
 					},
 				)),
 
@@ -634,12 +634,12 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 							stringvalidator.OneOf(utils.EnumSliceToStringSlice(verify.AllowedEnumThresholdEnumValues)...),
 						},
 					},
-					"retry_attempts": schema.Int64Attribute{
+					"retry_attempts": schema.Int32Attribute{
 						Description:         retryAttemptsDescription.Description,
 						MarkdownDescription: retryAttemptsDescription.MarkdownDescription,
 						Optional:            true,
-						Validators: []validator.Int64{
-							int64validator.Between(attrMinRetryAttempts, attrMaxRetryAttempts),
+						Validators: []validator.Int32{
+							int32validator.Between(attrMinRetryAttempts, attrMaxRetryAttempts),
 						},
 					},
 				},
@@ -654,13 +654,13 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 
 				Default: objectdefault.StaticValue(func() basetypes.ObjectValue {
 					o := map[string]attr.Value{
-						"count": types.Int64Value(defaultOTPAttemptsCount),
+						"count": types.Int32Value(defaultOTPAttemptsCount),
 					}
 					attemptsObjValue, d := types.ObjectValue(otpAttemptsServiceTFObjectTypes, o)
 					resp.Diagnostics.Append(d...)
 
 					o = map[string]attr.Value{
-						"duration":  types.Int64Value(defaultOTPEmailDuration),
+						"duration":  types.Int32Value(defaultOTPEmailDuration),
 						"time_unit": types.StringValue(string(defaultOTPEmailTimeUnit)),
 					}
 					lifetimeObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
@@ -674,14 +674,14 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 					resp.Diagnostics.Append(d...)
 
 					o = map[string]attr.Value{
-						"duration":  types.Int64Value(defaultOTPCooldownDuration),
+						"duration":  types.Int32Value(defaultOTPCooldownDuration),
 						"time_unit": types.StringValue(string(defaultOTPCooldownTimeUnit)),
 					}
 					cooldownObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
 					resp.Diagnostics.Append(d...)
 
 					o = map[string]attr.Value{
-						"count":    types.Int64Value(defaultOTPDeliveryCount),
+						"count":    types.Int32Value(defaultOTPDeliveryCount),
 						"cooldown": cooldownObjValue,
 					}
 					deliveriesObjValue, d := types.ObjectValue(otpDeliveriesServiceTFObjectTypes, o)
@@ -722,7 +722,7 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "OTP attempts configuration.",
 								Required:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP failures.",
 										Required:    true,
 									},
@@ -732,7 +732,7 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "OTP delivery configuration.",
 								Required:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP deliveries.",
 										Required:    true,
 									},
@@ -740,23 +740,23 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 										Description: "Cooldown (waiting period between OTP attempts) configuration.",
 										Required:    true,
 										Attributes: map[string]schema.Attribute{
-											"duration": schema.Int64Attribute{
+											"duration": schema.Int32Attribute{
 												Description:         otpDeliveriesCooldownDurationDescription.Description,
 												MarkdownDescription: otpDeliveriesCooldownDurationDescription.MarkdownDescription,
 												Required:            true,
-												Validators: []validator.Int64{
-													int64validator.Any(
-														int64validator.All(
-															int64validator.Between(attrMinDuration, attrMaxDurationMinutes),
-															int64validatorinternal.RegexMatchesPathValue(
+												Validators: []validator.Int32{
+													int32validator.Any(
+														int32validator.All(
+															int32validator.Between(attrMinDuration, attrMaxDurationMinutes),
+															int32validatorinternal.RegexMatchesPathValue(
 																regexp.MustCompile(`MINUTES`),
 																fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationMinutes),
 																path.MatchRelative().AtParent().AtName("time_unit"),
 															),
 														),
-														int64validator.All(
-															int64validator.Between(attrMinDuration, attrMaxDurationSeconds),
-															int64validatorinternal.RegexMatchesPathValue(
+														int32validator.All(
+															int32validator.Between(attrMinDuration, attrMaxDurationSeconds),
+															int32validatorinternal.RegexMatchesPathValue(
 																regexp.MustCompile(`SECONDS`),
 																fmt.Sprintf("If `time_unit` is `SECONDS`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationSeconds),
 																path.MatchRelative().AtParent().AtName("time_unit"),
@@ -781,23 +781,23 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "The length of time for which the OTP is valid.",
 								Required:    true,
 								Attributes: map[string]schema.Attribute{
-									"duration": schema.Int64Attribute{
+									"duration": schema.Int32Attribute{
 										Description:         otpLifeTimeEmailDurationDescription.Description,
 										MarkdownDescription: otpLifeTimeEmailDurationDescription.MarkdownDescription,
 										Required:            true,
-										Validators: []validator.Int64{
-											int64validator.Any(
-												int64validator.All(
-													int64validator.Between(attrMinLifetimeDurationMinutes, attrMaxLifetimeDurationMinutes),
-													int64validatorinternal.RegexMatchesPathValue(
+										Validators: []validator.Int32{
+											int32validator.Any(
+												int32validator.All(
+													int32validator.Between(attrMinLifetimeDurationMinutes, attrMaxLifetimeDurationMinutes),
+													int32validatorinternal.RegexMatchesPathValue(
 														regexp.MustCompile(`MINUTES`),
 														fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", attrMinLifetimeDurationMinutes, attrMaxLifetimeDurationMinutes),
 														path.MatchRelative().AtParent().AtName("time_unit"),
 													),
 												),
-												int64validator.All(
-													int64validator.Between(attrMinLifetimeDurationSeconds, attrMaxLifetimeDurationSeconds),
-													int64validatorinternal.RegexMatchesPathValue(
+												int32validator.All(
+													int32validator.Between(attrMinLifetimeDurationSeconds, attrMaxLifetimeDurationSeconds),
+													int32validatorinternal.RegexMatchesPathValue(
 														regexp.MustCompile(`SECONDS`),
 														fmt.Sprintf("If `time_unit` is `SECONDS`, the allowed duration range is %d - %d.", attrMinLifetimeDurationSeconds, attrMaxLifetimeDurationSeconds),
 														path.MatchRelative().AtParent().AtName("time_unit"),
@@ -867,13 +867,13 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 
 				Default: objectdefault.StaticValue(func() basetypes.ObjectValue {
 					o := map[string]attr.Value{
-						"count": types.Int64Value(defaultOTPAttemptsCount),
+						"count": types.Int32Value(defaultOTPAttemptsCount),
 					}
 					attemptsObjValue, d := types.ObjectValue(otpAttemptsServiceTFObjectTypes, o)
 					resp.Diagnostics.Append(d...)
 
 					o = map[string]attr.Value{
-						"duration":  types.Int64Value(defaultOTPPhoneDuration),
+						"duration":  types.Int32Value(defaultOTPPhoneDuration),
 						"time_unit": types.StringValue(string(defaultOTPPhoneTimeUnit)),
 					}
 					lifetimeObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
@@ -887,14 +887,14 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 					resp.Diagnostics.Append(d...)
 
 					o = map[string]attr.Value{
-						"duration":  types.Int64Value(defaultOTPCooldownDuration),
+						"duration":  types.Int32Value(defaultOTPCooldownDuration),
 						"time_unit": types.StringValue(string(defaultOTPCooldownTimeUnit)),
 					}
 					cooldownObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
 					resp.Diagnostics.Append(d...)
 
 					o = map[string]attr.Value{
-						"count":    types.Int64Value(defaultOTPDeliveryCount),
+						"count":    types.Int32Value(defaultOTPDeliveryCount),
 						"cooldown": cooldownObjValue,
 					}
 					deliveriesObjValue, d := types.ObjectValue(otpDeliveriesServiceTFObjectTypes, o)
@@ -935,7 +935,7 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "OTP attempts configuration.",
 								Required:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP failures.",
 										Required:    true,
 									},
@@ -945,7 +945,7 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "OTP delivery configuration.",
 								Required:    true,
 								Attributes: map[string]schema.Attribute{
-									"count": schema.Int64Attribute{
+									"count": schema.Int32Attribute{
 										Description: "Allowed maximum number of OTP deliveries.",
 										Required:    true,
 									},
@@ -953,23 +953,23 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 										Description: "Cooldown (waiting period between OTP attempts) configuration.",
 										Required:    true,
 										Attributes: map[string]schema.Attribute{
-											"duration": schema.Int64Attribute{
+											"duration": schema.Int32Attribute{
 												Description:         otpDeliveriesCooldownDurationDescription.Description,
 												MarkdownDescription: otpDeliveriesCooldownDurationDescription.MarkdownDescription,
 												Required:            true,
-												Validators: []validator.Int64{
-													int64validator.Any(
-														int64validator.All(
-															int64validator.Between(attrMinDuration, attrMaxDurationMinutes),
-															int64validatorinternal.RegexMatchesPathValue(
+												Validators: []validator.Int32{
+													int32validator.Any(
+														int32validator.All(
+															int32validator.Between(attrMinDuration, attrMaxDurationMinutes),
+															int32validatorinternal.RegexMatchesPathValue(
 																regexp.MustCompile(`MINUTES`),
 																fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationMinutes),
 																path.MatchRelative().AtParent().AtName("time_unit"),
 															),
 														),
-														int64validator.All(
-															int64validator.Between(attrMinDuration, attrMaxDurationSeconds),
-															int64validatorinternal.RegexMatchesPathValue(
+														int32validator.All(
+															int32validator.Between(attrMinDuration, attrMaxDurationSeconds),
+															int32validatorinternal.RegexMatchesPathValue(
 																regexp.MustCompile(`SECONDS`),
 																fmt.Sprintf("If `time_unit` is `SECONDS`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationSeconds),
 																path.MatchRelative().AtParent().AtName("time_unit"),
@@ -994,23 +994,23 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "The length of time for which the OTP is valid.",
 								Required:    true,
 								Attributes: map[string]schema.Attribute{
-									"duration": schema.Int64Attribute{
+									"duration": schema.Int32Attribute{
 										Description:         otpLifeTimePhoneDurationDescription.Description,
 										MarkdownDescription: otpLifeTimePhoneDurationDescription.MarkdownDescription,
 										Required:            true,
-										Validators: []validator.Int64{
-											int64validator.Any(
-												int64validator.All(
-													int64validator.Between(attrMinLifetimeDurationMinutes, attrMaxLifetimeDurationMinutes),
-													int64validatorinternal.RegexMatchesPathValue(
+										Validators: []validator.Int32{
+											int32validator.Any(
+												int32validator.All(
+													int32validator.Between(attrMinLifetimeDurationMinutes, attrMaxLifetimeDurationMinutes),
+													int32validatorinternal.RegexMatchesPathValue(
 														regexp.MustCompile(`MINUTES`),
 														fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", attrMinLifetimeDurationMinutes, attrMaxLifetimeDurationMinutes),
 														path.MatchRelative().AtParent().AtName("time_unit"),
 													),
 												),
-												int64validator.All(
-													int64validator.Between(attrMinLifetimeDurationSeconds, attrMaxLifetimeDurationSeconds),
-													int64validatorinternal.RegexMatchesPathValue(
+												int32validator.All(
+													int32validator.Between(attrMinLifetimeDurationSeconds, attrMaxLifetimeDurationSeconds),
+													int32validatorinternal.RegexMatchesPathValue(
 														regexp.MustCompile(`SECONDS`),
 														fmt.Sprintf("If `time_unit` is `SECONDS`, the allowed duration range is %d - %d.", attrMinLifetimeDurationSeconds, attrMaxLifetimeDurationSeconds),
 														path.MatchRelative().AtParent().AtName("time_unit"),
@@ -1117,23 +1117,23 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 						Optional:    true,
 
 						Attributes: map[string]schema.Attribute{
-							"duration": schema.Int64Attribute{
+							"duration": schema.Int32Attribute{
 								Description:         transactionTimeoutDurationDescription.Description,
 								MarkdownDescription: transactionTimeoutDurationDescription.MarkdownDescription,
 								Required:            true,
-								Validators: []validator.Int64{
-									int64validator.Any(
-										int64validator.All(
-											int64validator.Between(attrMinDuration, attrMaxDurationMinutes),
-											int64validatorinternal.RegexMatchesPathValue(
+								Validators: []validator.Int32{
+									int32validator.Any(
+										int32validator.All(
+											int32validator.Between(attrMinDuration, attrMaxDurationMinutes),
+											int32validatorinternal.RegexMatchesPathValue(
 												regexp.MustCompile(`MINUTES`),
 												fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationMinutes),
 												path.MatchRelative().AtParent().AtName("time_unit"),
 											),
 										),
-										int64validator.All(
-											int64validator.Between(attrMinDuration, attrMaxDurationSeconds),
-											int64validatorinternal.RegexMatchesPathValue(
+										int32validator.All(
+											int32validator.Between(attrMinDuration, attrMaxDurationSeconds),
+											int32validatorinternal.RegexMatchesPathValue(
 												regexp.MustCompile(`SECONDS`),
 												fmt.Sprintf("If `time_unit` is `SECONDS`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationSeconds),
 												path.MatchRelative().AtParent().AtName("time_unit"),
@@ -1161,26 +1161,26 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: "Object for data collection timeout.",
 								Required:    true,
 								Attributes: map[string]schema.Attribute{
-									"duration": schema.Int64Attribute{
+									"duration": schema.Int32Attribute{
 										Description:         dataCollectionDurationDescription.Description,
 										MarkdownDescription: dataCollectionDurationDescription.MarkdownDescription,
 										Required:            true,
-										Validators: []validator.Int64{
-											int64validatorinternal.IsLessThanEqualToPathValue(
+										Validators: []validator.Int32{
+											int32validatorinternal.IsLessThanEqualToPathValue(
 												path.MatchRoot("transaction").AtName("timeout").AtName("duration"),
 											),
-											int64validator.Any(
-												int64validator.All(
-													int64validator.Between(attrMinDuration, attrMaxDurationMinutes),
-													int64validatorinternal.RegexMatchesPathValue(
+											int32validator.Any(
+												int32validator.All(
+													int32validator.Between(attrMinDuration, attrMaxDurationMinutes),
+													int32validatorinternal.RegexMatchesPathValue(
 														regexp.MustCompile(`MINUTES`),
 														fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationMinutes),
 														path.MatchRelative().AtParent().AtName("time_unit"),
 													),
 												),
-												int64validator.All(
-													int64validator.Between(attrMinDuration, attrMaxDurationSeconds),
-													int64validatorinternal.RegexMatchesPathValue(
+												int32validator.All(
+													int32validator.Between(attrMinDuration, attrMaxDurationSeconds),
+													int32validatorinternal.RegexMatchesPathValue(
 														regexp.MustCompile(`SECONDS`),
 														fmt.Sprintf("If `time_unit` is `SECONDS`, the allowed duration range is %d - %d.", attrMinDuration, attrMaxDurationSeconds),
 														path.MatchRelative().AtParent().AtName("time_unit"),
@@ -1217,7 +1217,7 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 
 				Default: objectdefault.StaticValue(func() basetypes.ObjectValue {
 					o := map[string]attr.Value{
-						"samples":         types.Int64Value(defaultVoiceSamples),
+						"samples":         types.Int32Value(defaultVoiceSamples),
 						"voice_phrase_id": types.StringValue(defaultVoicePhraseId),
 					}
 					textDependentObjValue, d := types.ObjectValue(textDependentServiceTFObjectTypes, o)
@@ -1282,18 +1282,18 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 						Default: objectdefault.StaticValue(types.ObjectValueMust(
 							textDependentServiceTFObjectTypes,
 							map[string]attr.Value{
-								"samples":         types.Int64Value(defaultVoiceSamples),
+								"samples":         types.Int32Value(defaultVoiceSamples),
 								"voice_phrase_id": types.StringValue(defaultVoicePhraseId),
 							},
 						)),
 
 						Attributes: map[string]schema.Attribute{
-							"samples": schema.Int64Attribute{
+							"samples": schema.Int32Attribute{
 								Description:         voiceTexttDependentSamplesDescription.Description,
 								MarkdownDescription: voiceTexttDependentSamplesDescription.MarkdownDescription,
 								Required:            true,
-								Validators: []validator.Int64{
-									int64validator.Between(attrMinVoiceSamples, attrMaxVoiceSamples),
+								Validators: []validator.Int32{
+									int32validator.Between(attrMinVoiceSamples, attrMaxVoiceSamples),
 								},
 							},
 							"voice_phrase_id": schema.StringAttribute{
@@ -1832,7 +1832,7 @@ func (p *governmentIdModel) expandgovernmentIdModel() (*verify.GovernmentIdConfi
 
 	retryAttempts := verify.NewObjectRetryWithDefaults()
 	if !p.RetryAttempts.IsNull() && !p.RetryAttempts.IsUnknown() {
-		retryAttempts.SetAttempts(int32(p.RetryAttempts.ValueInt64()))
+		retryAttempts.SetAttempts(p.RetryAttempts.ValueInt32())
 		verifyGovernmentId.SetRetry(*retryAttempts)
 	}
 
@@ -1882,7 +1882,7 @@ func (p *livenessnModel) expandLivenessModel() (*verify.LivenessConfiguration, d
 
 	retryAttempts := verify.NewObjectRetryWithDefaults()
 	if !p.RetryAttempts.IsNull() && !p.RetryAttempts.IsUnknown() {
-		retryAttempts.SetAttempts(int32(p.RetryAttempts.ValueInt64()))
+		retryAttempts.SetAttempts(p.RetryAttempts.ValueInt32())
 		verifyLiveness.SetRetry(*retryAttempts)
 	}
 
@@ -1932,7 +1932,7 @@ func (p *transactionModel) expandTransactionModel(ctx context.Context) (*verify.
 		}
 
 		if !genericTimeout.Duration.IsNull() && !genericTimeout.Duration.IsUnknown() {
-			dataCollectionTimeout.SetDuration(int32(genericTimeout.Duration.ValueInt64()))
+			dataCollectionTimeout.SetDuration(genericTimeout.Duration.ValueInt32())
 		}
 
 		transactionDataCollection := verify.NewTransactionConfigurationDataCollection(*dataCollectionTimeout)
@@ -1952,7 +1952,7 @@ func (p *transactionModel) expandTransactionModel(ctx context.Context) (*verify.
 
 		transactionTimeout := verify.NewTransactionConfigurationTimeoutWithDefaults()
 		transactionTimeout.SetTimeUnit(verify.EnumTimeUnit(genericTimeout.TimeUnit.ValueString()))
-		transactionTimeout.SetDuration(int32(genericTimeout.Duration.ValueInt64()))
+		transactionTimeout.SetDuration(genericTimeout.Duration.ValueInt32())
 
 		transactionSettings.SetTimeout(*transactionTimeout)
 	}
@@ -2005,7 +2005,7 @@ func (p *deviceModel) expandDevice(ctx context.Context) (*verify.OTPDeviceConfig
 		}
 		otpAttempts := verify.NewOTPDeviceConfigurationOtpAttemptsWithDefaults()
 		if !attempts.Count.IsNull() && !attempts.Count.IsUnknown() {
-			otpAttempts.SetCount(int32(attempts.Count.ValueInt64()))
+			otpAttempts.SetCount(attempts.Count.ValueInt32())
 		}
 		otpSettings.SetAttempts(*otpAttempts)
 
@@ -2021,7 +2021,7 @@ func (p *deviceModel) expandDevice(ctx context.Context) (*verify.OTPDeviceConfig
 		}
 		otpDeliveries := verify.NewOTPDeviceConfigurationOtpDeliveriesWithDefaults()
 		if !deliveries.Count.IsNull() && !deliveries.Count.IsUnknown() {
-			otpDeliveries.SetCount(int32(deliveries.Count.ValueInt64()))
+			otpDeliveries.SetCount(deliveries.Count.ValueInt32())
 		}
 
 		if !deliveries.Cooldown.IsNull() && !deliveries.Cooldown.IsUnknown() {
@@ -2037,7 +2037,7 @@ func (p *deviceModel) expandDevice(ctx context.Context) (*verify.OTPDeviceConfig
 
 			deliveriesCooldown := verify.NewOTPDeviceConfigurationOtpDeliveriesCooldownWithDefaults()
 			if !cooldown.Duration.IsNull() && !cooldown.Duration.IsUnknown() {
-				deliveriesCooldown.SetDuration(int32(cooldown.Duration.ValueInt64()))
+				deliveriesCooldown.SetDuration(cooldown.Duration.ValueInt32())
 			}
 			if !cooldown.TimeUnit.IsNull() && !cooldown.TimeUnit.IsUnknown() {
 				deliveriesCooldown.SetTimeUnit(verify.EnumTimeUnit(cooldown.TimeUnit.ValueString()))
@@ -2063,7 +2063,7 @@ func (p *deviceModel) expandDevice(ctx context.Context) (*verify.OTPDeviceConfig
 		}
 
 		if !genericTimeout.Duration.IsNull() && !genericTimeout.Duration.IsUnknown() {
-			otpLifeTime.SetDuration(int32(genericTimeout.Duration.ValueInt64()))
+			otpLifeTime.SetDuration(genericTimeout.Duration.ValueInt32())
 		}
 		otpSettings.SetLifeTime(*otpLifeTime)
 
@@ -2142,7 +2142,7 @@ func (p *voiceModel) expandVoiceModel(ctx context.Context) (*verify.VoiceConfigu
 		}
 
 		if !textDependent.Samples.IsNull() && !textDependent.Samples.IsUnknown() {
-			textDependentObject.SetSamples(int32(textDependent.Samples.ValueInt64()))
+			textDependentObject.SetSamples(textDependent.Samples.ValueInt32())
 		}
 		voiceSettings.SetTextDependent(*textDependentObject)
 	}
@@ -2236,7 +2236,7 @@ func (p *verifyPolicyResourceModel) toStateGovernmentId(apiObject *verify.Govern
 		return types.ObjectNull(governmentIdServiceTFObjectTypes), diags
 	}
 
-	retryAttempts := types.Int64Null()
+	retryAttempts := types.Int32Null()
 	if v, ok := apiObject.GetRetryOk(); ok {
 		if t, ok := v.GetAttemptsOk(); ok {
 			retryAttempts = framework.Int32ToTF(*t)
@@ -2286,7 +2286,7 @@ func (p *verifyPolicyResourceModel) toStateLiveness(apiObject *verify.LivenessCo
 		return types.ObjectNull(livenessServiceTFObjectTypes), diags
 	}
 
-	retryAttempts := types.Int64Null()
+	retryAttempts := types.Int32Null()
 	if v, ok := apiObject.GetRetryOk(); ok {
 		if t, ok := v.GetAttemptsOk(); ok {
 			retryAttempts = framework.Int32ToTF(*t)


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

Change 64 bit data types to 32 bit and remove unnecessary type conversion to align with the API
- `Int64Type` -> `Int32Type`
- `Float64Type` -> `Float32Type`

changelog not needed

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing

Deferred to GH actions