### PR TITLE
`resource/pingone_risk_predictor`: Add the `predictor_device.should_validate_payload_signature` field

### DIFF
--- a/.changelog/938.txt
+++ b/.changelog/938.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_risk_predictor`: Added the `predictor_device.should_validate_payload_signature` field to enforce requirement that the Signals SDK payload be provided as a signed JWT for suspicious device predictors.
+```

--- a/docs/resources/risk_predictor.md
+++ b/docs/resources/risk_predictor.md
@@ -647,6 +647,7 @@ Optional:
 
 - `activation_at` (String) A string that represents a date on which the learning process for the device predictor should be restarted.  Can only be configured where the `detect` parameter is `NEW_DEVICE`. This can be used in conjunction with the fallback setting (`default.result.level`) to force strong authentication when moving the predictor to production. The date should be in an RFC3339 format. Note that activation date uses UTC time.
 - `detect` (String) A string that represents the type of device detection to use.  Options are `NEW_DEVICE` (to configure a model based on new devices), `SUSPICIOUS_DEVICE` (to configure a model based on detection of suspicious devices).  Defaults to `NEW_DEVICE`.
+- `should_validate_payload_signature` (Boolean) Relevant only for Suspicious Device predictors. A boolean that, if set to `true`, then any risk policies that include this predictor will require that the Signals SDK payload be provided as a signed JWT whose signature will be verified before proceeding with risk evaluation. You instruct the Signals SDK to provide the payload as a signed JWT by using the `universalDeviceIdentification` flag during initialization of the SDK, or by selecting the relevant setting for the `skrisk` component in DaVinci flows.
 
 
 <a id="nestedatt--predictor_email_reputation"></a>

--- a/internal/service/risk/resource_risk_predictor_test.go
+++ b/internal/service/risk/resource_risk_predictor_test.go
@@ -1274,6 +1274,7 @@ func TestAccRiskPredictor_NewDevice(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default.result.level", "MEDIUM"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.detect", "NEW_DEVICE"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.activation_at", activationAt),
+		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_device.should_validate_payload_signature"),
 	)
 
 	minimalCheck := resource.ComposeTestCheckFunc(
@@ -1282,6 +1283,7 @@ func TestAccRiskPredictor_NewDevice(t *testing.T) {
 		resource.TestCheckNoResourceAttr(resourceFullName, "default.result.level"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.detect", "NEW_DEVICE"),
 		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_device.activation_at"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_device.should_validate_payload_signature"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -1364,6 +1366,7 @@ func TestAccRiskPredictor_NewDevice_OverwriteUndeletable(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default.result.level", "MEDIUM"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.detect", "NEW_DEVICE"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.activation_at", activationAt),
+		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_device.should_validate_payload_signature"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -1548,6 +1551,7 @@ func TestAccRiskPredictor_SuspiciousDevice(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "default.result.level", "MEDIUM"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.detect", "SUSPICIOUS_DEVICE"),
 		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_device.activation_at"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.should_validate_payload_signature", "true"),
 	)
 
 	minimalCheck := resource.ComposeTestCheckFunc(
@@ -1556,6 +1560,7 @@ func TestAccRiskPredictor_SuspiciousDevice(t *testing.T) {
 		resource.TestCheckNoResourceAttr(resourceFullName, "default.result.level"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_device.detect", "SUSPICIOUS_DEVICE"),
 		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_device.activation_at"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_device.should_validate_payload_signature"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -3132,7 +3137,8 @@ resource "pingone_risk_predictor" "%[2]s" {
   }
 
   predictor_device = {
-    detect = "SUSPICIOUS_DEVICE"
+    detect                            = "SUSPICIOUS_DEVICE"
+    should_validate_payload_signature = true
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_risk_predictor`: Added the `predictor_device.should_validate_payload_signature` field to enforce requirement that the Signals SDK payload be provided as a signed JWT for suspicious device predictors.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccRiskPredictor_.+Device github.com/pingidentity/terraform-provider-pingone/internal/service/risk
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccRiskPredictor_NewDevice
=== PAUSE TestAccRiskPredictor_NewDevice
=== RUN   TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_SuspiciousDevice
=== PAUSE TestAccRiskPredictor_SuspiciousDevice
=== RUN   TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_NewDevice
=== CONT  TestAccRiskPredictor_SuspiciousDevice
=== CONT  TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_NewDevice_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable (6.63s)
--- PASS: TestAccRiskPredictor_NewDevice_OverwriteUndeletable (6.64s)
--- PASS: TestAccRiskPredictor_NewDevice (24.93s)
--- PASS: TestAccRiskPredictor_SuspiciousDevice (27.02s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/risk        28.168s
```

</details>