### PR TITLE
`pingone_risk_predictor`: Add the `predictor_bot_detection.include_repeated_events_without_sdk` field

### DIFF
--- a/docs/resources/risk_predictor.md
+++ b/docs/resources/risk_predictor.md
@@ -495,6 +495,10 @@ Optional:
 <a id="nestedatt--predictor_bot_detection"></a>
 ### Nested Schema for `predictor_bot_detection`
 
+Optional:
+
+- `include_repeated_events_without_sdk` (Boolean) A boolean that specifies whether to expand the range of bot activity that PingOne Protect can detect.
+
 
 <a id="nestedatt--predictor_composite"></a>
 ### Nested Schema for `predictor_composite`

--- a/internal/service/risk/resource_risk_predictor_test.go
+++ b/internal/service/risk/resource_risk_predictor_test.go
@@ -567,14 +567,14 @@ func TestAccRiskPredictor_Bot_Detection(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "type", "BOT"),
 		resource.TestCheckResourceAttr(resourceFullName, "deletable", "true"),
 		resource.TestCheckResourceAttr(resourceFullName, "default.result.level", "MEDIUM"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_bot_detection.#", "0"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_bot_detection.include_repeated_events_without_sdk", "true"),
 	)
 
 	minimalCheck := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceFullName, "type", "BOT"),
 		resource.TestCheckResourceAttr(resourceFullName, "deletable", "true"),
 		resource.TestCheckNoResourceAttr(resourceFullName, "default.result.level"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_bot_detection.#", "0"),
+		resource.TestCheckNoResourceAttr(resourceFullName, "predictor_bot_detection.include_repeated_events_without_sdk"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -652,7 +652,7 @@ func TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceFullName, "type", "BOT"),
 		resource.TestCheckResourceAttr(resourceFullName, "deletable", "false"),
 		resource.TestCheckResourceAttr(resourceFullName, "default.result.level", "MEDIUM"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_bot_detection.#", "0"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_bot_detection.include_repeated_events_without_sdk", "true"),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -2494,7 +2494,9 @@ resource "pingone_risk_predictor" "%[2]s" {
     }
   }
 
-  predictor_bot_detection = {}
+  predictor_bot_detection = {
+    include_repeated_events_without_sdk = true
+  }
 
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
@@ -2529,7 +2531,9 @@ resource "pingone_risk_predictor" "%[2]s" {
     }
   }
 
-  predictor_bot_detection = {}
+  predictor_bot_detection = {
+    include_repeated_events_without_sdk = true
+  }
 
 }`, acctest.GenericSandboxEnvironment(), resourceName, name, compactName)
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_risk_predictor`: Added the `predictor_bot_detection.include_repeated_events_without_sdk` field to choose whether to expand the range of bot activity that PingOne Protect can detect.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccRiskPredictor_Bot github.com/pingidentity/terraform-provider-pingone/internal/service/risk
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccRiskPredictor_Bot_Detection
=== PAUSE TestAccRiskPredictor_Bot_Detection
=== RUN   TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_Bot_Detection
=== CONT  TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable (5.92s)
--- PASS: TestAccRiskPredictor_Bot_Detection (23.04s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/risk        24.185s
```

</details>