### PR TITLE
`pingone_risk_predictor`: Support multiple root level conditions for composite predictors

### DIFF
--- a/.changelog/952.txt
+++ b/.changelog/952.txt
@@ -2,6 +2,6 @@
 `resource/pingone_risk_predictor`: Support multiple root level conditions for composite predictors.
 ```
 
-```release-note:note
-`resource/pingone_risk_predictor`: Deprecated the `predictor_composite.composition` field.  This field will be removed in the next major release. Use the `predictor_composite.compositions` field going forward.
+```release-note:breaking-change
+`resource/pingone_risk_predictor`: To ensure correct composite predictor and Terraform behaviours, the `predictor_composite.composition` field has been removed and replaced with `predictor_composite.compositions` field.
 ```

--- a/.changelog/952.txt
+++ b/.changelog/952.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+`resource/pingone_risk_predictor`: Support multiple root level conditions for composite predictors.
+```
+
+```release-note:note
+`resource/pingone_risk_predictor`: Deprecated the `predictor_composite.composition` field.  This field will be removed in the next major release. Use the `predictor_composite.compositions` field going forward.
+```

--- a/docs/resources/risk_predictor.md
+++ b/docs/resources/risk_predictor.md
@@ -92,32 +92,34 @@ resource "pingone_risk_predictor" "my_awesome_composite_predictor" {
   compact_name   = "myAwesomeCompositePredictor"
 
   predictor_composite = {
-    composition = {
-      level = "HIGH"
+    compositions = [
+      {
+        level = "HIGH"
 
-      condition_json = jsonencode({
-        "not" : {
-          "or" : [{
-            "equals" : 0,
-            "value" : "$${details.counters.predictorLevels.medium}",
-            "type" : "VALUE_COMPARISON"
-            }, {
-            "equals" : "High",
-            "value" : "$${details.${pingone_risk_predictor.my_awesome_geovelocity_anomaly_predictor.compact_name}.level}",
-            "type" : "VALUE_COMPARISON"
-            }, {
-            "and" : [{
-              "equals" : "High",
-              "value" : "$${details.${pingone_risk_predictor.my_awesome_anonymous_network_predictor.compact_name}.level}",
+        condition_json = jsonencode({
+          "not" : {
+            "or" : [{
+              "equals" : 0,
+              "value" : "$${details.counters.predictorLevels.medium}",
               "type" : "VALUE_COMPARISON"
+              }, {
+              "equals" : "High",
+              "value" : "$${details.${pingone_risk_predictor.my_awesome_geovelocity_anomaly_predictor.compact_name}.level}",
+              "type" : "VALUE_COMPARISON"
+              }, {
+              "and" : [{
+                "equals" : "High",
+                "value" : "$${details.${pingone_risk_predictor.my_awesome_anonymous_network_predictor.compact_name}.level}",
+                "type" : "VALUE_COMPARISON"
+              }],
+              "type" : "AND"
             }],
-            "type" : "AND"
-          }],
-          "type" : "OR"
-        },
-        "type" : "NOT"
-      })
-    }
+            "type" : "OR"
+          },
+          "type" : "NOT"
+        })
+      }
+    ]
   }
 }
 ```
@@ -503,12 +505,26 @@ Optional:
 <a id="nestedatt--predictor_composite"></a>
 ### Nested Schema for `predictor_composite`
 
-Required:
+Optional:
 
-- `composition` (Attributes) Contains the composition of risk factors you want to use, and the condition logic that determines when or whether a risk factor is applied. (see [below for nested schema](#nestedatt--predictor_composite--composition))
+- `composition` (Attributes, Deprecated) The `composition` attribute is deprecated. Use the `compositions` attribute instead. This field will be removed in the next major release. Contains the composition of risk factors you want to use, and the condition logic that determines when or whether a risk factor is applied.  Exactly one of the following must be defined: `composition`, `compositions`. (see [below for nested schema](#nestedatt--predictor_composite--composition))
+- `compositions` (Attributes List) A list of compositions of risk factors you want to use, and the condition logic that determines when or whether a risk factor is applied.  The minimum number of compositions is 1 and the maximum number of compositions is 3.  Exactly one of the following must be defined: `composition`, `compositions`. (see [below for nested schema](#nestedatt--predictor_composite--compositions))
 
 <a id="nestedatt--predictor_composite--composition"></a>
 ### Nested Schema for `predictor_composite.composition`
+
+Required:
+
+- `condition_json` (String) A string that specifies the condition logic for the composite risk predictor. The value must be a valid JSON string.
+- `level` (String) A string that specifies the risk level for the composite risk predictor.  Options are `HIGH`, `LOW`, `MEDIUM`.
+
+Read-Only:
+
+- `condition` (String) A string that specifies the condition logic for the composite risk predictor as applied to the service.
+
+
+<a id="nestedatt--predictor_composite--compositions"></a>
+### Nested Schema for `predictor_composite.compositions`
 
 Required:
 

--- a/docs/resources/risk_predictor.md
+++ b/docs/resources/risk_predictor.md
@@ -505,23 +505,9 @@ Optional:
 <a id="nestedatt--predictor_composite"></a>
 ### Nested Schema for `predictor_composite`
 
-Optional:
-
-- `composition` (Attributes, Deprecated) The `composition` attribute is deprecated. Use the `compositions` attribute instead. This field will be removed in the next major release. Contains the composition of risk factors you want to use, and the condition logic that determines when or whether a risk factor is applied.  Exactly one of the following must be defined: `composition`, `compositions`. (see [below for nested schema](#nestedatt--predictor_composite--composition))
-- `compositions` (Attributes List) A list of compositions of risk factors you want to use, and the condition logic that determines when or whether a risk factor is applied.  The minimum number of compositions is 1 and the maximum number of compositions is 3.  Exactly one of the following must be defined: `composition`, `compositions`. (see [below for nested schema](#nestedatt--predictor_composite--compositions))
-
-<a id="nestedatt--predictor_composite--composition"></a>
-### Nested Schema for `predictor_composite.composition`
-
 Required:
 
-- `condition_json` (String) A string that specifies the condition logic for the composite risk predictor. The value must be a valid JSON string.
-- `level` (String) A string that specifies the risk level for the composite risk predictor.  Options are `HIGH`, `LOW`, `MEDIUM`.
-
-Read-Only:
-
-- `condition` (String) A string that specifies the condition logic for the composite risk predictor as applied to the service.
-
+- `compositions` (Attributes List) A list of compositions of risk factors you want to use, and the condition logic that determines when or whether a risk factor is applied.  The minimum number of compositions is 1 and the maximum number of compositions is 3. (see [below for nested schema](#nestedatt--predictor_composite--compositions))
 
 <a id="nestedatt--predictor_composite--compositions"></a>
 ### Nested Schema for `predictor_composite.compositions`

--- a/examples/resources/pingone_risk_predictor/resource-composite.tf
+++ b/examples/resources/pingone_risk_predictor/resource-composite.tf
@@ -20,31 +20,33 @@ resource "pingone_risk_predictor" "my_awesome_composite_predictor" {
   compact_name   = "myAwesomeCompositePredictor"
 
   predictor_composite = {
-    composition = {
-      level = "HIGH"
+    compositions = [
+      {
+        level = "HIGH"
 
-      condition_json = jsonencode({
-        "not" : {
-          "or" : [{
-            "equals" : 0,
-            "value" : "$${details.counters.predictorLevels.medium}",
-            "type" : "VALUE_COMPARISON"
-            }, {
-            "equals" : "High",
-            "value" : "$${details.${pingone_risk_predictor.my_awesome_geovelocity_anomaly_predictor.compact_name}.level}",
-            "type" : "VALUE_COMPARISON"
-            }, {
-            "and" : [{
-              "equals" : "High",
-              "value" : "$${details.${pingone_risk_predictor.my_awesome_anonymous_network_predictor.compact_name}.level}",
+        condition_json = jsonencode({
+          "not" : {
+            "or" : [{
+              "equals" : 0,
+              "value" : "$${details.counters.predictorLevels.medium}",
               "type" : "VALUE_COMPARISON"
+              }, {
+              "equals" : "High",
+              "value" : "$${details.${pingone_risk_predictor.my_awesome_geovelocity_anomaly_predictor.compact_name}.level}",
+              "type" : "VALUE_COMPARISON"
+              }, {
+              "and" : [{
+                "equals" : "High",
+                "value" : "$${details.${pingone_risk_predictor.my_awesome_anonymous_network_predictor.compact_name}.level}",
+                "type" : "VALUE_COMPARISON"
+              }],
+              "type" : "AND"
             }],
-            "type" : "AND"
-          }],
-          "type" : "OR"
-        },
-        "type" : "NOT"
-      })
-    }
+            "type" : "OR"
+          },
+          "type" : "NOT"
+        })
+      }
+    ]
   }
 }

--- a/internal/service/risk/resource_risk_predictor_test.go
+++ b/internal/service/risk/resource_risk_predictor_test.go
@@ -2720,12 +2720,12 @@ resource "pingone_risk_predictor" "%[2]s" {
 
   predictor_composite = {
     compositions = [
-	{
-      level = "LOW"
+      {
+        level = "LOW"
 
-      condition_json = jsonencode({})
-    }
-	  ]
+        condition_json = jsonencode({})
+      }
+    ]
   }
 
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)

--- a/internal/service/risk/resource_risk_predictor_test.go
+++ b/internal/service/risk/resource_risk_predictor_test.go
@@ -193,12 +193,26 @@ func TestAccRiskPredictor_Composite(t *testing.T) {
 	fullCheck1 := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceFullName, "type", "COMPOSITE"),
 		resource.TestCheckResourceAttr(resourceFullName, "deletable", "true"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.composition.condition_json", "{\"not\":{\"or\":[{\"equals\":0,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.geoVelocity.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"AND\"}],\"type\":\"OR\"},\"type\":\"NOT\"}"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.composition.condition", "{\"not\":{\"or\":[{\"equals\":0,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.geoVelocity.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"AND\"}],\"type\":\"OR\"},\"type\":\"NOT\"}"),
-		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.composition.level", "HIGH"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.0.condition_json", "{\"not\":{\"or\":[{\"equals\":0,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.geoVelocity.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"AND\"}],\"type\":\"OR\"},\"type\":\"NOT\"}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.0.condition", "{\"not\":{\"or\":[{\"equals\":0,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.geoVelocity.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"AND\"}],\"type\":\"OR\"},\"type\":\"NOT\"}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.0.level", "HIGH"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.1.condition_json", "{\"and\":[{\"equals\":5,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"low\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"and\":[{\"equals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"or\":[{\"notEquals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}]}]}]}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.1.condition", "{\"and\":[{\"equals\":5,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"Low\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"or\":[{\"notEquals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"OR\"}],\"type\":\"AND\"}],\"type\":\"AND\"}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.1.level", "LOW"),
 	)
 
 	fullCheck2 := resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(resourceFullName, "type", "COMPOSITE"),
+		resource.TestCheckResourceAttr(resourceFullName, "deletable", "true"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.0.condition_json", "{\"and\":[{\"equals\":5,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"low\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"and\":[{\"equals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"or\":[{\"notEquals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}]}]}]}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.0.condition", "{\"and\":[{\"equals\":5,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"Low\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"or\":[{\"notEquals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"OR\"}],\"type\":\"AND\"}],\"type\":\"AND\"}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.0.level", "LOW"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.1.condition_json", "{\"not\":{\"or\":[{\"equals\":0,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.geoVelocity.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"AND\"}],\"type\":\"OR\"},\"type\":\"NOT\"}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.1.condition", "{\"not\":{\"or\":[{\"equals\":0,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.geoVelocity.level}\"},{\"and\":[{\"equals\":\"High\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}],\"type\":\"AND\"}],\"type\":\"OR\"},\"type\":\"NOT\"}"),
+		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.compositions.1.level", "HIGH"),
+	)
+
+	backwardCompatibilityCheck := resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(resourceFullName, "type", "COMPOSITE"),
 		resource.TestCheckResourceAttr(resourceFullName, "deletable", "true"),
 		resource.TestCheckResourceAttr(resourceFullName, "predictor_composite.composition.condition_json", "{\"and\":[{\"equals\":5,\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.counters.predictorLevels.medium}\"},{\"equals\":\"low\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"and\":[{\"equals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"},{\"or\":[{\"notEquals\":\"high\",\"type\":\"VALUE_COMPARISON\",\"value\":\"${details.anonymousNetwork.level}\"}]}]}]}"),
@@ -270,6 +284,30 @@ func TestAccRiskPredictor_Composite(t *testing.T) {
 			{
 				Config:      testAccRiskPredictorConfig_Composite_InvalidJSON(resourceName, name),
 				ExpectError: regexp.MustCompile(`Cannot parse the condition input JSON`),
+			},
+			// Backward compatibility
+			{
+				Config: testAccRiskPredictorConfig_Composite_Deprecated(resourceName, name),
+				Check:  backwardCompatibilityCheck,
+			},
+			{
+				ResourceName: resourceFullName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceFullName]
+						if !ok {
+							return "", fmt.Errorf("Resource Not found: %s", resourceFullName)
+						}
+
+						return fmt.Sprintf("%s/%s", rs.Primary.Attributes["environment_id"], rs.Primary.ID), nil
+					}
+				}(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRiskPredictorConfig_Composite_Full_1(resourceName, name),
+				Check:  fullCheck1,
 			},
 		},
 	})
@@ -2550,38 +2588,156 @@ resource "pingone_risk_predictor" "%[2]s" {
   description  = "When my wife is upset, I let her colour in my black and white tattoos.  She just needs a shoulder to crayon.."
 
   predictor_composite = {
-    composition = {
-      level = "HIGH"
+    compositions = [
+      {
+        level = "HIGH"
 
-      condition_json = jsonencode({
-        "not" : {
-          "or" : [{
-            "equals" : 0,
-            "value" : "$${details.counters.predictorLevels.medium}",
-            "type" : "VALUE_COMPARISON"
-            }, {
-            "equals" : "High",
-            "value" : "$${details.geoVelocity.level}",
-            "type" : "VALUE_COMPARISON"
-            }, {
-            "and" : [{
-              "equals" : "High",
-              "value" : "$${details.anonymousNetwork.level}",
+        condition_json = jsonencode({
+          "not" : {
+            "or" : [{
+              "equals" : 0,
+              "value" : "$${details.counters.predictorLevels.medium}",
               "type" : "VALUE_COMPARISON"
+              }, {
+              "equals" : "High",
+              "value" : "$${details.geoVelocity.level}",
+              "type" : "VALUE_COMPARISON"
+              }, {
+              "and" : [{
+                "equals" : "High",
+                "value" : "$${details.anonymousNetwork.level}",
+                "type" : "VALUE_COMPARISON"
+              }],
+              "type" : "AND"
             }],
-            "type" : "AND"
-          }],
-          "type" : "OR"
-        },
-        "type" : "NOT"
-      })
-    }
+            "type" : "OR"
+          },
+          "type" : "NOT"
+        })
+      },
+      {
+        level = "LOW"
+
+        condition_json = jsonencode({
+          "and" : [
+            {
+              "value" : "$${details.counters.predictorLevels.medium}",
+              "equals" : 5,
+              "type" : "VALUE_COMPARISON"
+            },
+            {
+              "value" : "$${details.anonymousNetwork.level}",
+              "equals" : "low",
+              "type" : "VALUE_COMPARISON"
+            },
+            {
+              "and" : [
+                {
+                  "value" : "$${details.anonymousNetwork.level}",
+                  "equals" : "high",
+                  "type" : "VALUE_COMPARISON"
+                },
+                {
+                  "or" : [
+                    {
+                      "value" : "$${details.anonymousNetwork.level}",
+                      "notEquals" : "high",
+                      "type" : "VALUE_COMPARISON"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        })
+      }
+    ]
   }
 
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
 func testAccRiskPredictorConfig_Composite_Full_2(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_risk_predictor" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name         = "%[3]s"
+  compact_name = "%[3]s1"
+
+  predictor_composite = {
+    compositions = [
+      {
+        level = "LOW"
+
+        condition_json = jsonencode({
+          "and" : [
+            {
+              "value" : "$${details.counters.predictorLevels.medium}",
+              "equals" : 5,
+              "type" : "VALUE_COMPARISON"
+            },
+            {
+              "value" : "$${details.anonymousNetwork.level}",
+              "equals" : "low",
+              "type" : "VALUE_COMPARISON"
+            },
+            {
+              "and" : [
+                {
+                  "value" : "$${details.anonymousNetwork.level}",
+                  "equals" : "high",
+                  "type" : "VALUE_COMPARISON"
+                },
+                {
+                  "or" : [
+                    {
+                      "value" : "$${details.anonymousNetwork.level}",
+                      "notEquals" : "high",
+                      "type" : "VALUE_COMPARISON"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        })
+      },
+      {
+        level = "HIGH"
+
+        condition_json = jsonencode({
+          "not" : {
+            "or" : [{
+              "equals" : 0,
+              "value" : "$${details.counters.predictorLevels.medium}",
+              "type" : "VALUE_COMPARISON"
+              }, {
+              "equals" : "High",
+              "value" : "$${details.geoVelocity.level}",
+              "type" : "VALUE_COMPARISON"
+              }, {
+              "and" : [{
+                "equals" : "High",
+                "value" : "$${details.anonymousNetwork.level}",
+                "type" : "VALUE_COMPARISON"
+              }],
+              "type" : "AND"
+            }],
+            "type" : "OR"
+          },
+          "type" : "NOT"
+        })
+      },
+    ]
+  }
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccRiskPredictorConfig_Composite_Deprecated(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `pingone_risk_predictor`: Support multiple root level conditions for composite predictors

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccRiskPredictor_ github.com/pingidentity/terraform-provider-pingone/internal/service/risk
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccRiskPredictor_RemovalDrift
=== PAUSE TestAccRiskPredictor_RemovalDrift
=== RUN   TestAccRiskPredictor_NewEnv
=== PAUSE TestAccRiskPredictor_NewEnv
=== RUN   TestAccRiskPredictor_Full
=== PAUSE TestAccRiskPredictor_Full
=== RUN   TestAccRiskPredictor_Composite
=== PAUSE TestAccRiskPredictor_Composite
=== RUN   TestAccRiskPredictor_Adversary_In_The_Middle
=== PAUSE TestAccRiskPredictor_Adversary_In_The_Middle
=== RUN   TestAccRiskPredictor_Adversary_In_The_Middle_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Adversary_In_The_Middle_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Anonymous_Network
=== PAUSE TestAccRiskPredictor_Anonymous_Network
=== RUN   TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Bot_Detection
=== PAUSE TestAccRiskPredictor_Bot_Detection
=== RUN   TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Geovelocity
=== PAUSE TestAccRiskPredictor_Geovelocity
=== RUN   TestAccRiskPredictor_Geovelocity_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Geovelocity_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_IP_Reputation
=== PAUSE TestAccRiskPredictor_IP_Reputation
=== RUN   TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_CustomMap_BetweenRanges
=== PAUSE TestAccRiskPredictor_CustomMap_BetweenRanges
=== RUN   TestAccRiskPredictor_CustomMap_IPRanges
=== PAUSE TestAccRiskPredictor_CustomMap_IPRanges
=== RUN   TestAccRiskPredictor_CustomMap_StringList
=== PAUSE TestAccRiskPredictor_CustomMap_StringList
=== RUN   TestAccRiskPredictor_NewDevice
=== PAUSE TestAccRiskPredictor_NewDevice
=== RUN   TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Email_Reputation
=== PAUSE TestAccRiskPredictor_Email_Reputation
=== RUN   TestAccRiskPredictor_Email_Reputation_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Email_Reputation_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_SuspiciousDevice
=== PAUSE TestAccRiskPredictor_SuspiciousDevice
=== RUN   TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_UserLocationAnomaly
=== PAUSE TestAccRiskPredictor_UserLocationAnomaly
=== RUN   TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_Velocity
=== PAUSE TestAccRiskPredictor_Velocity
=== RUN   TestAccRiskPredictor_Velocity_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_Velocity_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_UserRiskBehavior
=== PAUSE TestAccRiskPredictor_UserRiskBehavior
=== RUN   TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable
=== PAUSE TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable
=== RUN   TestAccRiskPredictor_BadParameters
=== PAUSE TestAccRiskPredictor_BadParameters
=== CONT  TestAccRiskPredictor_RemovalDrift
=== CONT  TestAccRiskPredictor_SuspiciousDevice
=== CONT  TestAccRiskPredictor_Geovelocity_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_CustomMap_StringList
=== CONT  TestAccRiskPredictor_Email_Reputation
=== CONT  TestAccRiskPredictor_Velocity_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_NewDevice_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_NewDevice
=== CONT  TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_UserLocationAnomaly
=== CONT  TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_Email_Reputation_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_Bot_Detection
=== CONT  TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable
=== NAME  TestAccRiskPredictor_Velocity_OverwriteUndeletable
    resource_risk_predictor_test.go:2015: STAGING-21856
--- SKIP: TestAccRiskPredictor_Velocity_OverwriteUndeletable (0.00s)
=== CONT  TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable
=== CONT  TestAccRiskPredictor_Velocity
=== CONT  TestAccRiskPredictor_Anonymous_Network
=== NAME  TestAccRiskPredictor_Velocity
    resource_risk_predictor_test.go:1883: STAGING-21856
--- SKIP: TestAccRiskPredictor_Velocity (0.00s)
=== CONT  TestAccRiskPredictor_BadParameters
--- PASS: TestAccRiskPredictor_SuspiciousDevice_OverwriteUndeletable (20.17s)
=== CONT  TestAccRiskPredictor_Adversary_In_The_Middle_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_Email_Reputation_OverwriteUndeletable (20.19s)
=== CONT  TestAccRiskPredictor_Adversary_In_The_Middle
--- PASS: TestAccRiskPredictor_NewDevice_OverwriteUndeletable (20.41s)
=== CONT  TestAccRiskPredictor_UserRiskBehavior
--- PASS: TestAccRiskPredictor_Geovelocity_OverwriteUndeletable (20.59s)
=== CONT  TestAccRiskPredictor_Full
--- PASS: TestAccRiskPredictor_UserLocationAnomaly_OverwriteUndeletable (22.87s)
=== CONT  TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_Bot_Detection_OverwriteUndeletable (23.11s)
=== CONT  TestAccRiskPredictor_CustomMap_BetweenRanges
--- PASS: TestAccRiskPredictor_BadParameters (30.97s)
=== CONT  TestAccRiskPredictor_CustomMap_IPRanges
--- PASS: TestAccRiskPredictor_Adversary_In_The_Middle_OverwriteUndeletable (19.66s)
=== CONT  TestAccRiskPredictor_NewEnv
--- PASS: TestAccRiskPredictor_Anonymous_Network_OverwriteUndeletable (17.73s)
=== CONT  TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable
--- PASS: TestAccRiskPredictor_IP_Reputation_OverwriteUndeletable (14.53s)
=== CONT  TestAccRiskPredictor_IP_Reputation
--- PASS: TestAccRiskPredictor_Email_Reputation (65.63s)
=== CONT  TestAccRiskPredictor_Geovelocity
--- PASS: TestAccRiskPredictor_CustomMap_StringList (66.00s)
=== CONT  TestAccRiskPredictor_Composite
--- PASS: TestAccRiskPredictor_Anonymous_Network (66.20s)
--- PASS: TestAccRiskPredictor_UserLocationAnomaly (66.32s)
--- PASS: TestAccRiskPredictor_SuspiciousDevice (67.04s)
--- PASS: TestAccRiskPredictor_Bot_Detection (67.78s)
--- PASS: TestAccRiskPredictor_NewDevice (67.93s)
--- PASS: TestAccRiskPredictor_Adversary_In_The_Middle (55.08s)
--- PASS: TestAccRiskPredictor_Full (54.86s)
--- PASS: TestAccRiskPredictor_CustomMap_BetweenRanges (54.44s)
--- PASS: TestAccRiskPredictor_CustomMap_IPRanges (51.24s)
--- PASS: TestAccRiskPredictor_NewEnv (45.81s)
=== NAME  TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable
    resource_risk_predictor_test.go:2209: Step 4/9 error: Error running apply: exit status 1
        
        Error: Error when calling `CreateRiskPredictor`: The request will exceed your quota.
        
          with pingone_risk_predictor.fuieshtgno,
          on terraform_plugin_test.tf line 17, in resource "pingone_risk_predictor" "fuieshtgno":
          17: resource "pingone_risk_predictor" "fuieshtgno" {
        
        PingOne Error Details:
        ID:             5186c1dc-4b9b-4d35-bfd6-d23854d4037a
        Code:           REQUEST_LIMITED
        Message:        The request will exceed your quota.
        Details:
          - Code:       QUOTA_EXCEEDED
            Message:    The max number of predictors for that type type has been reached.
            Data:
        
--- FAIL: TestAccRiskPredictor_UserRiskBehavior_OverwriteUndeletable (92.37s)
--- PASS: TestAccRiskPredictor_IP_Reputation (38.37s)
--- PASS: TestAccRiskPredictor_RemovalDrift (95.16s)
--- PASS: TestAccRiskPredictor_Geovelocity (34.35s)
--- PASS: TestAccRiskPredictor_Composite (35.06s)
=== NAME  TestAccRiskPredictor_UserRiskBehavior
    resource_risk_predictor_test.go:2107: Step 4/9 error: Error running apply: exit status 1
        
        Error: Error when calling `CreateRiskPredictor`: The request will exceed your quota.
        
          with pingone_risk_predictor.uvaorgnfjt,
          on terraform_plugin_test.tf line 17, in resource "pingone_risk_predictor" "uvaorgnfjt":
          17: resource "pingone_risk_predictor" "uvaorgnfjt" {
        
        PingOne Error Details:
        ID:             194ac43b-5b9a-4b2c-983b-88cadf639309
        Code:           REQUEST_LIMITED
        Message:        The request will exceed your quota.
        Details:
          - Code:       QUOTA_EXCEEDED
            Message:    The max number of predictors for that type type has been reached.
            Data:
        
--- FAIL: TestAccRiskPredictor_UserRiskBehavior (89.08s)
FAIL
FAIL    github.com/pingidentity/terraform-provider-pingone/internal/service/risk        111.935s
FAIL
```

</details>