### PR TITLE
Fixed the handling of otp default values in the email and phone property objects when verify set to DISABLED.

### DIFF
--- a/.changelog/967.txt
+++ b/.changelog/967.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/pingone_verify_policy: Fixed the handling of otp default values in the email and phone property objects when verify set to DISABLED.
+```

--- a/.changelog/967.txt
+++ b/.changelog/967.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/pingone_verify_policy: Fixed the handling of otp default values in the email and phone property objects when verify set to DISABLED.
+`resource/pingone_verify_policy`: Fixed the handling of otp default values in the email and phone property objects when verify set to DISABLED.
 ```

--- a/internal/service/verify/resource_verify_policy.go
+++ b/internal/service/verify/resource_verify_policy.go
@@ -717,6 +717,55 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 					"otp": schema.SingleNestedAttribute{
 						Description: "SMS/Voice/Email one-time password (OTP) configuration.",
 						Optional:    true,
+						Computed:    true,
+
+						Default: objectdefault.StaticValue(func() basetypes.ObjectValue {
+							o := map[string]attr.Value{
+								"count": types.Int32Value(defaultOTPAttemptsCount),
+							}
+							attemptsObjValue, d := types.ObjectValue(otpAttemptsServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"duration":  types.Int32Value(defaultOTPEmailDuration),
+								"time_unit": types.StringValue(string(defaultOTPEmailTimeUnit)),
+							}
+							lifetimeObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"template_name": types.StringValue(defaultNotificationTemplate),
+								"variant_name":  types.StringNull(),
+							}
+							notificationObjValue, d := types.ObjectValue(otpNotificationServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"duration":  types.Int32Value(defaultOTPCooldownDuration),
+								"time_unit": types.StringValue(string(defaultOTPCooldownTimeUnit)),
+							}
+							cooldownObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"count":    types.Int32Value(defaultOTPDeliveryCount),
+								"cooldown": cooldownObjValue,
+							}
+							deliveriesObjValue, d := types.ObjectValue(otpDeliveriesServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"attempts":     attemptsObjValue,
+								"lifetime":     lifetimeObjValue,
+								"deliveries":   deliveriesObjValue,
+								"notification": notificationObjValue,
+							}
+							otpObjValue, d := types.ObjectValue(otpServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							return otpObjValue
+						}()),
+
 						Attributes: map[string]schema.Attribute{
 							"attempts": schema.SingleNestedAttribute{
 								Description: "OTP attempts configuration.",
@@ -930,6 +979,55 @@ func (r *VerifyPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 					"otp": schema.SingleNestedAttribute{
 						Description: "SMS/Voice/Email one-time password (OTP) configuration.",
 						Optional:    true,
+						Computed:    true,
+
+						Default: objectdefault.StaticValue(func() basetypes.ObjectValue {
+							o := map[string]attr.Value{
+								"count": types.Int32Value(defaultOTPAttemptsCount),
+							}
+							attemptsObjValue, d := types.ObjectValue(otpAttemptsServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"duration":  types.Int32Value(defaultOTPPhoneDuration),
+								"time_unit": types.StringValue(string(defaultOTPPhoneTimeUnit)),
+							}
+							lifetimeObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"template_name": types.StringValue(defaultNotificationTemplate),
+								"variant_name":  types.StringNull(),
+							}
+							notificationObjValue, d := types.ObjectValue(otpNotificationServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"duration":  types.Int32Value(defaultOTPCooldownDuration),
+								"time_unit": types.StringValue(string(defaultOTPCooldownTimeUnit)),
+							}
+							cooldownObjValue, d := types.ObjectValue(genericTimeoutServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"count":    types.Int32Value(defaultOTPDeliveryCount),
+								"cooldown": cooldownObjValue,
+							}
+							deliveriesObjValue, d := types.ObjectValue(otpDeliveriesServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							o = map[string]attr.Value{
+								"attempts":     attemptsObjValue,
+								"lifetime":     lifetimeObjValue,
+								"deliveries":   deliveriesObjValue,
+								"notification": notificationObjValue,
+							}
+							otpObjValue, d := types.ObjectValue(otpServiceTFObjectTypes, o)
+							resp.Diagnostics.Append(d...)
+
+							return otpObjValue
+						}()),
+
 						Attributes: map[string]schema.Attribute{
 							"attempts": schema.SingleNestedAttribute{
 								Description: "OTP attempts configuration.",

--- a/internal/service/verify/resource_verify_policy_test.go
+++ b/internal/service/verify/resource_verify_policy_test.go
@@ -327,6 +327,10 @@ func TestAccVerifyPolicy_Full(t *testing.T) {
 				Check:  minimalPolicy,
 			},
 			{
+				Config: testAccVerifyPolicy_MinimalDisabledDevice(resourceName, updatedName),
+				Check:  minimalPolicy,
+			},
+			{
 				Config: testAccVerifyPolicy_UpdateTimeUnits(resourceName, updatedName),
 				Check:  updateTimeUnitsPolicy,
 			},
@@ -595,6 +599,29 @@ resource "pingone_verify_policy" "%[2]s" {
 
   government_id = {
     verify = "REQUIRED"
+  }
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccVerifyPolicy_MinimalDisabledDevice(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+resource "pingone_verify_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  description    = "Description for %[3]s"
+
+  government_id = {
+    verify = "REQUIRED"
+  }
+
+  email = {
+    verify = "DISABLED"
+  }
+
+  phone = {
+    verify = "DISABLED"
   }
 
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
resource/pingone_verify_policy: Fixed the handling of otp default values in the email and phone property objects when verify set to DISABLED.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->
None.

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_LOG=DEBUG TF_LOG_PATH=`pwd`/output.log TF_ACC=1 go test -v -timeout 240s  github.com/pingidentity/terraform-provider-pingone/internal/service/verify
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccVerifyPoliciesDataSource_NoFilter
=== PAUSE TestAccVerifyPoliciesDataSource_NoFilter
=== RUN   TestAccVerifyPolicyDataSource_All
=== PAUSE TestAccVerifyPolicyDataSource_All
=== RUN   TestAccVerifyPolicyDataSource_FailureChecks
=== PAUSE TestAccVerifyPolicyDataSource_FailureChecks
=== RUN   TestAccVerifyVoicePhraseContentDataSource_All
=== PAUSE TestAccVerifyVoicePhraseContentDataSource_All
=== RUN   TestAccVerifyVoicePhraseContentDataSource_FailureChecks
=== PAUSE TestAccVerifyVoicePhraseContentDataSource_FailureChecks
=== RUN   TestAccVerifyVoicePhraseContentsDataSource_NoFilter
=== PAUSE TestAccVerifyVoicePhraseContentsDataSource_NoFilter
=== RUN   TestAccVerifyVoicePhraseDataSource_All
=== PAUSE TestAccVerifyVoicePhraseDataSource_All
=== RUN   TestAccVerifyVoicePhraseDataSource_FailureChecks
=== PAUSE TestAccVerifyVoicePhraseDataSource_FailureChecks
=== RUN   TestAccVerifyPolicy_RemovalDrift
=== PAUSE TestAccVerifyPolicy_RemovalDrift
=== RUN   TestAccVerifyPolicy_NewEnv
=== PAUSE TestAccVerifyPolicy_NewEnv
=== RUN   TestAccVerifyPolicy_Full
=== PAUSE TestAccVerifyPolicy_Full
=== RUN   TestAccVerifyPolicy_ValidationChecks
=== PAUSE TestAccVerifyPolicy_ValidationChecks
=== RUN   TestAccVerifyPolicy_BadParameters
=== PAUSE TestAccVerifyPolicy_BadParameters
=== RUN   TestAccVerifyVoicePhraseContent_RemovalDrift
=== PAUSE TestAccVerifyVoicePhraseContent_RemovalDrift
=== RUN   TestAccVerifyVoicePhraseContent_NewEnv
=== PAUSE TestAccVerifyVoicePhraseContent_NewEnv
=== RUN   TestAccVerifyVoicePhraseContent_Full
=== PAUSE TestAccVerifyVoicePhraseContent_Full
=== RUN   TestAccVerifyVoicePhraseContent_BadParameters
=== PAUSE TestAccVerifyVoicePhraseContent_BadParameters
=== RUN   TestAccVerifyVoicePhrase_RemovalDrift
=== PAUSE TestAccVerifyVoicePhrase_RemovalDrift
=== RUN   TestAccVerifyVoicePhrase_NewEnv
=== PAUSE TestAccVerifyVoicePhrase_NewEnv
=== RUN   TestAccVerifyVoicePhrase_Full
=== PAUSE TestAccVerifyVoicePhrase_Full
=== RUN   TestAccVerifyVoicePhrase_BadParameters
=== PAUSE TestAccVerifyVoicePhrase_BadParameters
=== CONT  TestAccVerifyPoliciesDataSource_NoFilter
=== CONT  TestAccVerifyPolicy_ValidationChecks
=== CONT  TestAccVerifyVoicePhraseContent_BadParameters
=== CONT  TestAccVerifyVoicePhrase_Full
=== CONT  TestAccVerifyVoicePhrase_BadParameters
=== CONT  TestAccVerifyVoicePhrase_NewEnv
=== CONT  TestAccVerifyVoicePhrase_RemovalDrift
=== CONT  TestAccVerifyPolicy_Full
=== CONT  TestAccVerifyPolicy_NewEnv
=== CONT  TestAccVerifyPolicy_RemovalDrift
--- PASS: TestAccVerifyPolicy_ValidationChecks (0.86s)
=== CONT  TestAccVerifyVoicePhraseDataSource_FailureChecks
--- PASS: TestAccVerifyVoicePhraseDataSource_FailureChecks (1.32s)
=== CONT  TestAccVerifyVoicePhraseDataSource_All
--- PASS: TestAccVerifyVoicePhrase_BadParameters (5.46s)
=== CONT  TestAccVerifyVoicePhraseContentsDataSource_NoFilter
--- PASS: TestAccVerifyVoicePhraseContent_BadParameters (6.00s)
=== CONT  TestAccVerifyVoicePhraseContentDataSource_FailureChecks
--- PASS: TestAccVerifyVoicePhraseDataSource_All (7.88s)
=== CONT  TestAccVerifyVoicePhraseContentDataSource_All
--- PASS: TestAccVerifyVoicePhrase_Full (15.87s)
=== CONT  TestAccVerifyPolicyDataSource_FailureChecks
--- PASS: TestAccVerifyPolicy_Full (21.39s)
=== CONT  TestAccVerifyPolicyDataSource_All
--- PASS: TestAccVerifyVoicePhrase_NewEnv (39.79s)
=== CONT  TestAccVerifyVoicePhraseContent_NewEnv
--- PASS: TestAccVerifyPolicy_NewEnv (39.85s)
=== CONT  TestAccVerifyVoicePhraseContent_Full
--- PASS: TestAccVerifyVoicePhraseContentDataSource_FailureChecks (35.90s)
=== CONT  TestAccVerifyVoicePhraseContent_RemovalDrift
--- PASS: TestAccVerifyPoliciesDataSource_NoFilter (42.60s)
=== CONT  TestAccVerifyPolicy_BadParameters
--- PASS: TestAccVerifyPolicy_BadParameters (4.84s)
--- PASS: TestAccVerifyVoicePhraseContentsDataSource_NoFilter (42.02s)
--- PASS: TestAccVerifyVoicePhraseContentDataSource_All (41.88s)
--- PASS: TestAccVerifyPolicyDataSource_FailureChecks (38.47s)
--- PASS: TestAccVerifyVoicePhraseContent_Full (19.54s)
--- PASS: TestAccVerifyVoicePhrase_RemovalDrift (69.69s)
--- PASS: TestAccVerifyPolicy_RemovalDrift (70.14s)
--- PASS: TestAccVerifyVoicePhraseContent_NewEnv (39.34s)
--- PASS: TestAccVerifyVoicePhraseContent_RemovalDrift (75.11s)
--- PASS: TestAccVerifyPolicyDataSource_All (123.96s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/verify      145.994s
```

</details>