### PR TITLE
Fix `service_endpoints` and `global_options` provider parameters when defined explicitly in the HCL provider configuration

### DIFF
--- a/.changelog/998.txt
+++ b/.changelog/998.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix `service_endpoints` and `global_options` provider parameters when defined explicitly in the HCL provider configuration.
+```

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -192,19 +192,22 @@ func configure(version string) func(context.Context, *schema.ResourceData) (inte
 		}
 
 		if v, ok := d.Get("service_endpoints").([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			if v, ok := d.Get("auth_hostname").(string); ok && v != "" {
+			vp := v[0].(map[string]interface{})
+			if v, ok := vp["auth_hostname"].(string); ok && v != "" {
 				config.AuthHostnameOverride = &v
 			}
 
-			if v, ok := d.Get("api_hostname").(string); ok && v != "" {
+			if v, ok := vp["api_hostname"].(string); ok && v != "" {
 				config.APIHostnameOverride = &v
 			}
 		}
 
 		if v, ok := d.Get("global_options").([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			if v, ok := d.Get("population").([]interface{}); ok && len(v) > 0 && v[0] != nil {
-				if v, ok := d.Get("contains_users_force_delete").(bool); ok {
-					config.GlobalOptions.Population.ContainsUsersForceDelete = v
+			vp := v[0].(map[string]interface{})
+			if v1, ok := vp["population"].([]interface{}); ok && len(v1) > 0 && v1[0] != nil {
+				v1p := v[0].(map[string]interface{})
+				if v2, ok := v1p["contains_users_force_delete"].(bool); ok {
+					config.GlobalOptions.Population.ContainsUsersForceDelete = v2
 				}
 			}
 		}

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -192,7 +192,11 @@ func configure(version string) func(context.Context, *schema.ResourceData) (inte
 		}
 
 		if v, ok := d.Get("service_endpoints").([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			vp := v[0].(map[string]interface{})
+			vp, ok := v[0].(map[string]interface{})
+			if !ok {
+				return nil, diag.Errorf("service_endpoints must be a map.  This is always an error in the provider code, please raise an issue with the provider maintainers.")
+			}
+
 			if v, ok := vp["auth_hostname"].(string); ok && v != "" {
 				config.AuthHostnameOverride = &v
 			}
@@ -203,9 +207,17 @@ func configure(version string) func(context.Context, *schema.ResourceData) (inte
 		}
 
 		if v, ok := d.Get("global_options").([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			vp := v[0].(map[string]interface{})
+			vp, ok := v[0].(map[string]interface{})
+			if !ok {
+				return nil, diag.Errorf("global_options must be a map.  This is always an error in the provider code, please raise an issue with the provider maintainers.")
+			}
+
 			if v1, ok := vp["population"].([]interface{}); ok && len(v1) > 0 && v1[0] != nil {
-				v1p := v[0].(map[string]interface{})
+				v1p, ok := v1[0].(map[string]interface{})
+				if !ok {
+					return nil, diag.Errorf("global_options.population must be a map.  This is always an error in the provider code, please raise an issue with the provider maintainers.")
+				}
+
 				if v2, ok := v1p["contains_users_force_delete"].(bool); ok {
 					config.GlobalOptions.Population.ContainsUsersForceDelete = v2
 				}


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- **Bug**: Fix `service_endpoints` and `global_options` provider parameters when defined explicitly in the HCL provider configuration.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing

Manually tested (No acceptance tests created for this use case)