### PR TITLE
Fix pingone_custom_domain_verify resource: early verification failure with NXDOMAIN

### DIFF
--- a/.changelog/1026.txt
+++ b/.changelog/1026.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_custom_domain_verify`: Fix early verification failure of NXDOMAIN.
+```


### PR DESCRIPTION
### Change Description
Updated pingone_custom_domain_verify resource retry logic to use [previously working SDK method](https://github.com/pingidentity/terraform-provider-pingone/blob/f28c27189fa8bcc677f09f8572abcd2f32501350/internal/service/base/resource_custom_domain_verify.go#L159).

### Required SDK Upgrades
N/A

### Testing Shell Command
```shell
TF_ACC=1 go test -v -timeout 240s -run ^TestAccCustomDomainVerify_CannotVerifyNXDOMAIN ./internal/service/base --count=1
```

### Testing Results
<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccCustomDomainVerify_CannotVerifyNXDOMAIN
=== PAUSE TestAccCustomDomainVerify_CannotVerifyNXDOMAIN
=== CONT  TestAccCustomDomainVerify_CannotVerifyNXDOMAIN
--- PASS: TestAccCustomDomainVerify_CannotVerifyNXDOMAIN (36.22s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        36.838s
```

</details>