### PR TITLE
Update pingone_notification_settings and pingone_notification_settings resource documentation

### DIFF
--- a/.changelog/1027.txt
+++ b/.changelog/1027.txt
@@ -1,0 +1,7 @@
+```release-note:note
+`resource/pingone_notification_settings`: Updated Example Usage documentation to include both Ping-hosted smtp and Twilio examples.
+```
+
+```release-note:note
+`resource/pingone_notification_settings_email`: Added documentation note to recommend use of `pingone_notification_settings` when using Ping-hosted SMTP email service.
+```

--- a/.changelog/1027.txt
+++ b/.changelog/1027.txt
@@ -1,5 +1,5 @@
 ```release-note:note
-`resource/pingone_notification_settings`: Updated Example Usage documentation to include both Ping-hosted smtp and Twilio examples.
+`resource/pingone_notification_settings`: Updated Example Usage documentation to include both Ping-hosted SMTP and Twilio examples.
 ```
 
 ```release-note:note

--- a/docs/resources/notification_settings.md
+++ b/docs/resources/notification_settings.md
@@ -11,7 +11,27 @@ Resource to manage the notifications settings in a PingOne environment.
 
 ~> Only one `pingone_notification_settings` resource should be configured for an environment.  If multiple `pingone_notification_settings` resource definitions exist in HCL code, these are likely to conflict with each other on apply.
 
-## Example Usage
+## Example Usage - Ping-Hosted SMTP
+
+```terraform
+resource "pingone_environment" "my_environment" {
+  # ...
+}
+
+resource "pingone_notification_settings" "my_awesome_ping_smtp_notification_settings" {
+  environment_id = pingone_environment.my_environment.id
+
+  from = {
+    email_address = "noreply@pingidentity.com"
+  }
+
+  reply_to = {
+    email_address = "noreply@pingidentity.com"
+  }
+}
+```
+
+## Example Usage - Custom Twilio
 
 ```terraform
 resource "pingone_environment" "my_environment" {
@@ -34,7 +54,7 @@ resource "pingone_phone_delivery_settings" "my_awesome_custom_twilio_provider" {
   }
 }
 
-resource "pingone_notification_settings" "my_awesome_notification_settings" {
+resource "pingone_notification_settings" "my_awesome_twilio_notification_settings" {
   environment_id = pingone_environment.my_environment.id
 
   provider_fallback_chain = [

--- a/docs/resources/notification_settings_email.md
+++ b/docs/resources/notification_settings_email.md
@@ -9,7 +9,7 @@ description: |-
 
 Resource to manage the email sender settings in a PingOne environment.
 
-~> Only one `pingone_notification_settings_email` resource should be configured for an environment.  If multiple `pingone_notification_settings_email` resource definitions exist in HCL code, these are likely to conflict with each other on apply.
+~> Only one `pingone_notification_settings_email` resource should be configured for an environment.  If multiple `pingone_notification_settings_email` resource definitions exist in HCL code, these are likely to conflict with each other on apply. The `pingone_notification_settings` resource should be used if using the Ping-hosted SMTP email service.
 
 ## Example Usage
 

--- a/examples/resources/pingone_notification_settings/resource-custom-twilio.tf
+++ b/examples/resources/pingone_notification_settings/resource-custom-twilio.tf
@@ -18,7 +18,7 @@ resource "pingone_phone_delivery_settings" "my_awesome_custom_twilio_provider" {
   }
 }
 
-resource "pingone_notification_settings" "my_awesome_notification_settings" {
+resource "pingone_notification_settings" "my_awesome_twilio_notification_settings" {
   environment_id = pingone_environment.my_environment.id
 
   provider_fallback_chain = [

--- a/examples/resources/pingone_notification_settings/resource-ping-smtp.tf
+++ b/examples/resources/pingone_notification_settings/resource-ping-smtp.tf
@@ -1,0 +1,15 @@
+resource "pingone_environment" "my_environment" {
+  # ...
+}
+
+resource "pingone_notification_settings" "my_awesome_ping_smtp_notification_settings" {
+  environment_id = pingone_environment.my_environment.id
+
+  from = {
+    email_address = "noreply@pingidentity.com"
+  }
+
+  reply_to = {
+    email_address = "noreply@pingidentity.com"
+  }
+}

--- a/templates/resources/notification_settings.md.tmpl
+++ b/templates/resources/notification_settings.md.tmpl
@@ -11,11 +11,13 @@ description: |-
 
 ~> Only one `pingone_notification_settings` resource should be configured for an environment.  If multiple `pingone_notification_settings` resource definitions exist in HCL code, these are likely to conflict with each other on apply.
 
-{{ if .HasExample -}}
-## Example Usage
+## Example Usage - Ping-Hosted SMTP
 
-{{ tffile (printf "%s%s%s" "examples/resources/" .Name "/resource.tf") }}
-{{- end }}
+{{ tffile (printf "%s%s%s" "examples/resources/" .Name "/resource-ping-smtp.tf") }}
+
+## Example Usage - Custom Twilio
+
+{{ tffile (printf "%s%s%s" "examples/resources/" .Name "/resource-custom-twilio.tf") }}
 
 {{ .SchemaMarkdown | trimspace }}
 

--- a/templates/resources/notification_settings_email.md.tmpl
+++ b/templates/resources/notification_settings_email.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 {{ .Description | trimspace }}
 
-~> Only one `pingone_notification_settings_email` resource should be configured for an environment.  If multiple `pingone_notification_settings_email` resource definitions exist in HCL code, these are likely to conflict with each other on apply.
+~> Only one `pingone_notification_settings_email` resource should be configured for an environment.  If multiple `pingone_notification_settings_email` resource definitions exist in HCL code, these are likely to conflict with each other on apply. The `pingone_notification_settings` resource should be used if using the Ping-hosted SMTP email service.
 
 {{ if .HasExample -}}
 ## Example Usage


### PR DESCRIPTION
### Change Description
* Update/Add `pingone_notification_settings` resource Example Usage documentation to include both Ping-hosted smtp and Twilio examples.
* Add documentation note `pingone_notification_settings_email` to recommend usage of `pingone_notification_settings` when using Ping-hosted smtp email service.

### Required SDK Upgrades
N/A

### Testing Shell Command
N/A

### Testing Results
N/A