### PR TITLE
Fix pingone_admin_security resource validation for identity_provider

### DIFF
--- a/.changelog/1028.txt
+++ b/.changelog/1028.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_administrator_security`: Fix invalid configuration error when configuring an `EXTERNAL` authentication method
+```

--- a/go.work.sum
+++ b/go.work.sum
@@ -913,6 +913,7 @@ google.golang.org/genproto/googleapis/api v0.0.0-20241202173237-19429a94021a/go.
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20240125205218-1f4bbc51befe/go.mod h1:SCz6T5xjNXM4QFPRwxHcfChp7V+9DcXR3ay2TkHR8Tg=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20240903143218-8af14fe29dc1/go.mod h1:q0eWNnCW04EJlyrmLT+ZHsjuoUiZ36/eAEdCCezZoco=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20250127172529-29210b9bc287/go.mod h1:7VGktjvijnuhf2AobFqsoaBGnG8rImcxqoL+QPBPRq4=
+google.golang.org/genproto/googleapis/bytestream v0.0.0-20250219182151-9fdb1cabc7b2/go.mod h1:35wIojE/F1ptq1nfNDNjtowabHoMSA2qQs7+smpCO5s=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98/go.mod h1:TUfxEVdsvPg18p6AslUXFoLdpED4oBnGwyqk3dV1XzM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17/go.mod h1:oQ5rr10WTTMvP4A36n8JpR1OrO1BEiV4f78CneXZxkA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a/go.mod h1:5uTbfoYQed2U9p3KIj2/Zzm02PYhndfdmML0qC3q3FU=

--- a/internal/service/sso/resource_administrator_security.go
+++ b/internal/service/sso/resource_administrator_security.go
@@ -35,7 +35,7 @@ func (r *administratorSecurityResource) ModifyPlan(ctx context.Context, req reso
 		)
 	}
 
-	if plan.AuthenticationMethod.ValueString() == "EXTERNAL" || plan.AuthenticationMethod.ValueString() == "HYBRID" &&
+	if (plan.AuthenticationMethod.ValueString() == "EXTERNAL" || plan.AuthenticationMethod.ValueString() == "HYBRID") &&
 		plan.IdentityProvider.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("identity_provider"),

--- a/internal/service/sso/resource_administrator_security_gen_test.go
+++ b/internal/service/sso/resource_administrator_security_gen_test.go
@@ -325,7 +325,7 @@ resource "pingone_identity_provider" "%[3]s-idp" {
 }
 
 resource "pingone_administrator_security" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
+  environment_id        = pingone_environment.%[2]s.id
   authentication_method = "HYBRID"
   mfa_status            = "ENFORCE"
   identity_provider = {
@@ -353,7 +353,7 @@ resource "pingone_identity_provider" "%[3]s-idp" {
 }
 
 resource "pingone_administrator_security" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
+  environment_id        = pingone_environment.%[2]s.id
   authentication_method = "EXTERNAL"
   mfa_status            = "ENFORCE"
   identity_provider = {

--- a/internal/service/sso/resource_administrator_security_gen_test.go
+++ b/internal/service/sso/resource_administrator_security_gen_test.go
@@ -44,7 +44,7 @@ func TestAccAdministratorSecurity_RemovalDrift(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test removal of the environment
 			{
-				Config: administratorSecurity_NewEnvHCL(environmentName, licenseID, resourceName),
+				Config: administratorSecurity_NewEnvHCLPingOne(environmentName, licenseID, resourceName),
 				Check:  administratorSecurity_GetIDs(resourceFullName, &environmentId),
 			},
 			{
@@ -73,12 +73,35 @@ func TestAccAdministratorSecurity_MinimalMaximal(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				// Create the resource with a minimal model
-				Config: administratorSecurity_MinimalHCL(resourceName),
-				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName),
+				// Create with a complete model, then destroy
+				Config: administratorSecurity_CompleteHCL(resourceName),
+				Check:  administratorSecurity_CheckComputedValuesComplete(resourceName),
 			},
 			{
-				// Update to a complete model
+				Config:  administratorSecurity_CompleteHCL(resourceName),
+				Destroy: true,
+			},
+			{
+				// Create the resource with a minimal model, then destroy
+				Config: administratorSecurity_MinimalHCL(resourceName),
+				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName, "PINGONE"),
+			},
+			{
+				Config:  administratorSecurity_MinimalHCL(resourceName),
+				Destroy: true,
+			},
+			{
+				// Create again with a complete model
+				Config: administratorSecurity_CompleteHCL(resourceName),
+				Check:  administratorSecurity_CheckComputedValuesComplete(resourceName),
+			},
+			{
+				// Back to minimal model
+				Config: administratorSecurity_MinimalHCL(resourceName),
+				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName, "PINGONE"),
+			},
+			{
+				// Back to complete model
 				Config: administratorSecurity_CompleteHCL(resourceName),
 				Check:  administratorSecurity_CheckComputedValuesComplete(resourceName),
 			},
@@ -99,16 +122,11 @@ func TestAccAdministratorSecurity_MinimalMaximal(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				// Back to minimal model
-				Config: administratorSecurity_MinimalHCL(resourceName),
-				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName),
-			},
 		},
 	})
 }
 
-func TestAccAdministratorSecurity_NewEnv(t *testing.T) {
+func TestAccAdministratorSecurity_NewEnvPingOne(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
@@ -127,17 +145,74 @@ func TestAccAdministratorSecurity_NewEnv(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: administratorSecurity_NewEnvHCL(environmentName, licenseID, resourceName),
-				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName),
+				Config: administratorSecurity_NewEnvHCLPingOne(environmentName, licenseID, resourceName),
+				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName, "PINGONE"),
 			},
 		},
 	})
 }
+
+func TestAccAdministratorSecurity_NewEnvHybrid(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+
+	environmentName := acctest.ResourceNameGenEnvironment()
+
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNewEnvironment(t)
+			acctest.PreCheckNoFeatureFlag(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: administratorSecurity_NewEnvHCLHybrid(environmentName, licenseID, resourceName),
+				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName, "HYBRID"),
+			},
+		},
+	})
+}
+
+func TestAccAdministratorSecurity_NewEnvExternal(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+
+	environmentName := acctest.ResourceNameGenEnvironment()
+
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNewEnvironment(t)
+			acctest.PreCheckNoFeatureFlag(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: administratorSecurity_NewEnvHCLExternal(environmentName, licenseID, resourceName),
+				Check:  administratorSecurity_CheckComputedValuesMinimal(resourceName, "EXTERNAL"),
+			},
+		},
+	})
+}
+
 func TestAccAdministratorSecurity_BadParameters(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_administrator_security.%s", resourceName)
+
+	environmentName := acctest.ResourceNameGenEnvironment()
+
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -149,7 +224,7 @@ func TestAccAdministratorSecurity_BadParameters(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: administratorSecurity_MinimalHCL(resourceName),
+				Config: administratorSecurity_NewEnvHCLPingOne(environmentName, licenseID, resourceName),
 			},
 			// Errors
 			{
@@ -221,7 +296,7 @@ resource "pingone_administrator_security" "%[2]s" {
 `, acctest.GenericSandboxEnvironment(), resourceName)
 }
 
-func administratorSecurity_NewEnvHCL(environmentName, licenseID, resourceName string) string {
+func administratorSecurity_NewEnvHCLPingOne(environmentName, licenseID, resourceName string) string {
 	return fmt.Sprintf(`
 		%[1]s
 
@@ -233,13 +308,69 @@ resource "pingone_administrator_security" "%[3]s" {
 `, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
 }
 
+func administratorSecurity_NewEnvHCLHybrid(environmentName, licenseID, resourceName string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_identity_provider" "%[3]s-idp" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[3]s-idp"
+  enabled        = true
+
+  microsoft = {
+    client_id     = "dummyclientid1"
+    client_secret = "dummyclientsecret1"
+    tenant_id     = "dummytenantid1"
+  }
+}
+
+resource "pingone_administrator_security" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  authentication_method = "HYBRID"
+  mfa_status            = "ENFORCE"
+  identity_provider = {
+    id = pingone_identity_provider.%[3]s-idp.id
+  }
+  recovery = false
+}
+`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+}
+
+func administratorSecurity_NewEnvHCLExternal(environmentName, licenseID, resourceName string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_identity_provider" "%[3]s-idp" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[3]s-idp"
+  enabled        = true
+
+  microsoft = {
+    client_id     = "dummyclientid1"
+    client_secret = "dummyclientsecret1"
+    tenant_id     = "dummytenantid1"
+  }
+}
+
+resource "pingone_administrator_security" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  authentication_method = "EXTERNAL"
+  mfa_status            = "ENFORCE"
+  identity_provider = {
+    id = pingone_identity_provider.%[3]s-idp.id
+  }
+  recovery = false
+}
+`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+}
+
 // Validate any computed values when applying minimal HCL
-func administratorSecurity_CheckComputedValuesMinimal(resourceName string) resource.TestCheckFunc {
+func administratorSecurity_CheckComputedValuesMinimal(resourceName, authMethod string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_administrator_security.%s", resourceName), "allowed_methods.email", `{"enabled":true}`),
 		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_administrator_security.%s", resourceName), "allowed_methods.fido2", `{"enabled":true}`),
 		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_administrator_security.%s", resourceName), "allowed_methods.totp", `{"enabled":true}`),
-		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_administrator_security.%s", resourceName), "authentication_method", "PINGONE"),
+		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_administrator_security.%s", resourceName), "authentication_method", authMethod),
 		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_administrator_security.%s", resourceName), "has_fido2_capabilities", "true"),
 		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_administrator_security.%s", resourceName), "is_pingid_in_bom", "false"),
 	)


### PR DESCRIPTION
### Change Description
Fix validation of `identity_provider` in the `pingone_admin_security` resource

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccAdministratorSecurity_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
% TF_ACC=1 go test -v -timeout 3000s -run ^TestAccAdministratorSecurity_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
=== RUN   TestAccAdministratorSecurity_RemovalDrift
=== PAUSE TestAccAdministratorSecurity_RemovalDrift
=== RUN   TestAccAdministratorSecurity_MinimalMaximal
--- PASS: TestAccAdministratorSecurity_MinimalMaximal (22.94s)
=== RUN   TestAccAdministratorSecurity_NewEnvPingOne
=== PAUSE TestAccAdministratorSecurity_NewEnvPingOne
=== RUN   TestAccAdministratorSecurity_NewEnvHybrid
=== PAUSE TestAccAdministratorSecurity_NewEnvHybrid
=== RUN   TestAccAdministratorSecurity_NewEnvExternal
=== PAUSE TestAccAdministratorSecurity_NewEnvExternal
=== RUN   TestAccAdministratorSecurity_BadParameters
--- PASS: TestAccAdministratorSecurity_BadParameters (4.32s)
=== CONT  TestAccAdministratorSecurity_RemovalDrift
=== CONT  TestAccAdministratorSecurity_NewEnvHybrid
=== CONT  TestAccAdministratorSecurity_NewEnvExternal
=== CONT  TestAccAdministratorSecurity_NewEnvPingOne
--- PASS: TestAccAdministratorSecurity_NewEnvPingOne (39.84s)
--- PASS: TestAccAdministratorSecurity_NewEnvHybrid (40.14s)
--- PASS: TestAccAdministratorSecurity_NewEnvExternal (40.43s)
--- PASS: TestAccAdministratorSecurity_RemovalDrift (66.28s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/sso	94.442s
```

</details>