### PR TITLE
Require replacement for application_id attribute in pingone_digital_wallet_application resource

### DIFF
--- a/internal/service/credentials/resource_digital_wallet_application.go
+++ b/internal/service/credentials/resource_digital_wallet_application.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/patrickcping/pingone-go-sdk-v2/credentials"
@@ -74,6 +76,9 @@ func (r *DigitalWalletApplicationResource) Schema(ctx context.Context, req resou
 				Required:    true,
 
 				CustomType: pingonetypes.ResourceIDType{},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
 			"app_open_url": schema.StringAttribute{


### PR DESCRIPTION
### Change Description
This change fixes TestAccDigitalWalletApplication_Full test failure, which began consistently on this test run https://github.com/pingidentity/terraform-provider-pingone/actions/runs/14324295886, and was failing locally as well

It appears that any other resources that refer to a parent application force replacement when the id of that parent application changes, but this one does not. This caused a test failure when a replacement was forced in the parent application while also making a change to the digital wallet application in the same apply.

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccDigitalWalletApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/credentials
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccDigitalWalletApplication_RemovalDrift
=== PAUSE TestAccDigitalWalletApplication_RemovalDrift
=== RUN   TestAccDigitalWalletApplication_NewEnv
=== PAUSE TestAccDigitalWalletApplication_NewEnv
=== RUN   TestAccDigitalWalletApplication_Full
=== PAUSE TestAccDigitalWalletApplication_Full
=== RUN   TestAccDigitalWalletApplication_InvalidNativeApplication
=== PAUSE TestAccDigitalWalletApplication_InvalidNativeApplication
=== RUN   TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== PAUSE TestAccDigitalWalletApplication_InvalidAppOpenUrl
=== RUN   TestAccDigitalWalletApplication_BadParameters
=== PAUSE TestAccDigitalWalletApplication_BadParameters
=== CONT  TestAccDigitalWalletApplication_RemovalDrift
=== CONT  TestAccDigitalWalletApplication_BadParameters
=== CONT  TestAccDigitalWalletApplication_InvalidNativeApplication
=== CONT  TestAccDigitalWalletApplication_Full
=== CONT  TestAccDigitalWalletApplication_NewEnv
=== CONT  TestAccDigitalWalletApplication_InvalidAppOpenUrl
--- PASS: TestAccDigitalWalletApplication_InvalidAppOpenUrl (2.88s)
--- PASS: TestAccDigitalWalletApplication_InvalidNativeApplication (5.35s)
--- PASS: TestAccDigitalWalletApplication_BadParameters (8.78s)
--- PASS: TestAccDigitalWalletApplication_Full (18.57s)
--- PASS: TestAccDigitalWalletApplication_NewEnv (42.17s)
--- PASS: TestAccDigitalWalletApplication_RemovalDrift (76.70s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/credentials	77.420s
```

</details>