### PR TITLE
Update TestAccEnvironment_NonCompatibleRegion regex

### DIFF
--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -233,7 +233,7 @@ func TestAccEnvironment_NonCompatibleRegion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccEnvironmentConfig_MinimalWithRegion(resourceName, name, region, licenseID),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Incompatible environment region for the organization tenant\.  Allowed regions: \[%[1]s(?: [A-Z]{2})?|(?: [A-Z]{2})?%[1]s\]\.`, model.FindRegionByAPICode(management.EnumRegionCode(os.Getenv("PINGONE_REGION_CODE"))).APICode)),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Allowed regions: \[%[1]s(?: [A-Z]{2})?|(?: [A-Z]{2})?%[1]s\]\.`, model.FindRegionByAPICode(management.EnumRegionCode(os.Getenv("PINGONE_REGION_CODE"))).APICode)),
 			},
 		},
 	})

--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -233,7 +233,7 @@ func TestAccEnvironment_NonCompatibleRegion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccEnvironmentConfig_MinimalWithRegion(resourceName, name, region, licenseID),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Incompatible environment region for the organization tenant.  Allowed regions: \[%s\].`, model.FindRegionByAPICode(management.EnumRegionCode(os.Getenv("PINGONE_REGION_CODE"))).APICode)),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Incompatible environment region for the organization tenant\.  Allowed regions: \[%[1]s(?: [A-Z]{2})?|(?: [A-Z]{2})?%[1]s\]\.`, model.FindRegionByAPICode(management.EnumRegionCode(os.Getenv("PINGONE_REGION_CODE"))).APICode)),
 			},
 		},
 	})


### PR DESCRIPTION
### Change Description
The TestAccEnvironment_NonCompatibleRegion acceptance test is failing in the AP region because, unlike other regions, it returns 2 region codes ([AP AU]) rather than one [NA], [EU], etc.

This change updates the regex line in the test to account for this possibility, and will match
- [AU]
- [NA]
- [AU AP]
- [AP AU]
- [AU XX]
- [XX AU]

### Required SDK Upgrades
none

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
go test -timeout 30s -run ^TestAccEnvironment_NonCompatibleRegion$ github.com/pingidentity/terraform-provider-pingone/internal/service/base -v
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccEnvironment_NonCompatibleRegion
=== PAUSE TestAccEnvironment_NonCompatibleRegion
=== CONT  TestAccEnvironment_NonCompatibleRegion
--- PASS: TestAccEnvironment_NonCompatibleRegion (3.84s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/base	4.264s
```

</details>