### PR TITLE
pingone_gateway resource description bug fix

### DIFF
--- a/.changelog/1038.txt
+++ b/.changelog/1038.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/pingone_gateway`: Correctly include `description` when supplied for `RADIUS` and `LDAP` types.
+```
+
+```release-note:bug
+`resource/pingone_gateway`: Remove unneeded PingOne resource ID validation for `radius_davinci_policy_id` when using `RADIUS` type.
+```

--- a/.changelog/1038.txt
+++ b/.changelog/1038.txt
@@ -3,5 +3,5 @@
 ```
 
 ```release-note:bug
-`resource/pingone_gateway`: Remove unneeded PingOne resource ID validation for `radius_davinci_policy_id` when using `RADIUS` type.
+`resource/pingone_gateway`: Corrected `radius_davinci_policy_id` format validation.
 ```

--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -149,7 +149,7 @@ resource "pingone_gateway" "my_awesome_api_gateway" {
 - `follow_referrals` (Boolean) For LDAP gateways only: A boolean that, when set to true, PingOne sends LDAP queries per referrals it receives from the LDAP servers.  Defaults to `false`.
 - `kerberos` (Attributes) For LDAP gateways only: A single object that specifies Kerberos connection details. (see [below for nested schema](#nestedatt--kerberos))
 - `radius_clients` (Attributes Set) For RADIUS gateways only: A set of objects describing RADIUS client connections. (see [below for nested schema](#nestedatt--radius_clients))
-- `radius_davinci_policy_id` (String) For RADIUS gateways only: A string that specifies the ID of the DaVinci flow policy to use.
+- `radius_davinci_policy_id` (String) For RADIUS gateways only: A string that specifies the ID of the DaVinci flow policy to use. Must be a valid DaVinci resource ID.
 - `radius_default_shared_secret` (String, Sensitive) For RADIUS gateways only: A string that specifies the value to use for the shared secret if the shared secret is not provided for one or more of the RADIUS clients specified.
 - `radius_network_policy_server` (Attributes) For RADIUS gateways only: A single object that allows configuration of the RADIUS gateway to authenticate using the MS-CHAP v2 protocol. (see [below for nested schema](#nestedatt--radius_network_policy_server))
 - `servers` (Set of String) For LDAP gateways only: A set of LDAP server host name and port number combinations (for example, [`ds1.bxretail.org:636`, `ds2.bxretail.org:636`]).

--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -149,7 +149,7 @@ resource "pingone_gateway" "my_awesome_api_gateway" {
 - `follow_referrals` (Boolean) For LDAP gateways only: A boolean that, when set to true, PingOne sends LDAP queries per referrals it receives from the LDAP servers.  Defaults to `false`.
 - `kerberos` (Attributes) For LDAP gateways only: A single object that specifies Kerberos connection details. (see [below for nested schema](#nestedatt--kerberos))
 - `radius_clients` (Attributes Set) For RADIUS gateways only: A set of objects describing RADIUS client connections. (see [below for nested schema](#nestedatt--radius_clients))
-- `radius_davinci_policy_id` (String) For RADIUS gateways only: A string that specifies the ID of the DaVinci flow policy to use.  Must be a valid PingOne resource ID.
+- `radius_davinci_policy_id` (String) For RADIUS gateways only: A string that specifies the ID of the DaVinci flow policy to use.
 - `radius_default_shared_secret` (String, Sensitive) For RADIUS gateways only: A string that specifies the value to use for the shared secret if the shared secret is not provided for one or more of the RADIUS clients specified.
 - `radius_network_policy_server` (Attributes) For RADIUS gateways only: A single object that allows configuration of the RADIUS gateway to authenticate using the MS-CHAP v2 protocol. (see [below for nested schema](#nestedatt--radius_network_policy_server))
 - `servers` (Set of String) For LDAP gateways only: A set of LDAP server host name and port number combinations (for example, [`ds1.bxretail.org:636`, `ds2.bxretail.org:636`]).

--- a/internal/service/base/resource_gateway_schema_upgrade_0_to_1.go
+++ b/internal/service/base/resource_gateway_schema_upgrade_0_to_1.go
@@ -37,9 +37,9 @@ type gatewayResourceModelV0 struct {
 	UserType                              types.Set    `tfsdk:"user_type"`
 
 	// Radius
-	RadiusClient              types.Set                    `tfsdk:"radius_client"`
-	RadiusDavinciPolicyId     pingonetypes.ResourceIDValue `tfsdk:"radius_davinci_policy_id"`
-	RadiusDefaultSharedSecret types.String                 `tfsdk:"radius_default_shared_secret"`
+	RadiusClient              types.Set    `tfsdk:"radius_client"`
+	RadiusDavinciPolicyId     types.String `tfsdk:"radius_davinci_policy_id"`
+	RadiusDefaultSharedSecret types.String `tfsdk:"radius_default_shared_secret"`
 }
 
 type gatewayUserTypeResourceModelV0 struct {

--- a/internal/service/base/resource_gateway_schema_upgrade_0_to_1.go
+++ b/internal/service/base/resource_gateway_schema_upgrade_0_to_1.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/davincitypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
 )
 
@@ -37,9 +38,9 @@ type gatewayResourceModelV0 struct {
 	UserType                              types.Set    `tfsdk:"user_type"`
 
 	// Radius
-	RadiusClient              types.Set    `tfsdk:"radius_client"`
-	RadiusDavinciPolicyId     types.String `tfsdk:"radius_davinci_policy_id"`
-	RadiusDefaultSharedSecret types.String `tfsdk:"radius_default_shared_secret"`
+	RadiusClient              types.Set                    `tfsdk:"radius_client"`
+	RadiusDavinciPolicyId     davincitypes.ResourceIDValue `tfsdk:"radius_davinci_policy_id"`
+	RadiusDefaultSharedSecret types.String                 `tfsdk:"radius_default_shared_secret"`
 }
 
 type gatewayUserTypeResourceModelV0 struct {

--- a/internal/service/base/resource_gateway_test.go
+++ b/internal/service/base/resource_gateway_test.go
@@ -378,7 +378,7 @@ func TestAccGateway_LDAP(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 			resource.TestCheckResourceAttr(resourceFullName, "name", name),
-			resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+			resource.TestCheckResourceAttr(resourceFullName, "description", "My test gateway"),
 			resource.TestCheckResourceAttr(resourceFullName, "enabled", "true"),
 			resource.TestCheckResourceAttr(resourceFullName, "type", "LDAP"),
 			resource.TestCheckResourceAttr(resourceFullName, "bind_dn", "ou=test1,dc=example,dc=com"),
@@ -424,7 +424,7 @@ func TestAccGateway_LDAP(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 			resource.TestCheckResourceAttr(resourceFullName, "name", name),
-			resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+			resource.TestCheckResourceAttr(resourceFullName, "description", "My test gateway"),
 			resource.TestCheckResourceAttr(resourceFullName, "enabled", "true"),
 			resource.TestCheckResourceAttr(resourceFullName, "type", "LDAP"),
 			resource.TestCheckResourceAttr(resourceFullName, "bind_dn", "ou=test1,dc=example,dc=com"),
@@ -555,10 +555,10 @@ func TestAccGateway_RADIUS(t *testing.T) {
 			resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 			resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 			resource.TestCheckResourceAttr(resourceFullName, "name", name),
-			resource.TestCheckNoResourceAttr(resourceFullName, "description"),
+			resource.TestCheckResourceAttr(resourceFullName, "description", "My test gateway"),
 			resource.TestCheckResourceAttr(resourceFullName, "enabled", "false"),
 			resource.TestCheckResourceAttr(resourceFullName, "type", "RADIUS"),
-			resource.TestMatchResourceAttr(resourceFullName, "radius_davinci_policy_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "radius_davinci_policy_id", "ee8470a281614d76a7afa8505a2da084"),
 			resource.TestCheckResourceAttr(resourceFullName, "radius_default_shared_secret", "sharedsecret123"),
 			resource.TestCheckResourceAttr(resourceFullName, "radius_clients.#", "2"),
 			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "radius_clients.*", map[string]string{
@@ -583,7 +583,7 @@ func TestAccGateway_RADIUS(t *testing.T) {
 			resource.TestCheckNoResourceAttr(resourceFullName, "description"),
 			resource.TestCheckResourceAttr(resourceFullName, "enabled", "false"),
 			resource.TestCheckResourceAttr(resourceFullName, "type", "RADIUS"),
-			resource.TestMatchResourceAttr(resourceFullName, "radius_davinci_policy_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "radius_davinci_policy_id", "ee8470a281614d76a7afa8505a2da084"),
 			resource.TestCheckResourceAttr(resourceFullName, "radius_default_shared_secret", "sharedsecret123"),
 			resource.TestCheckResourceAttr(resourceFullName, "radius_clients.#", "1"),
 
@@ -850,6 +850,8 @@ resource "pingone_gateway" "%[2]s" {
   enabled        = true
   type           = "LDAP"
 
+  description = "My test gateway"
+
   bind_dn       = "ou=test1,dc=example,dc=com"
   bind_password = "dummyPasswordValue1"
 
@@ -946,6 +948,7 @@ resource "pingone_gateway" "%[2]s" {
   name           = "%[3]s"
   enabled        = true
   type           = "LDAP"
+  description    = "My test gateway"
 
   bind_dn       = "ou=test1,dc=example,dc=com"
   bind_password = "dummyPasswordValue1"
@@ -1039,10 +1042,11 @@ resource "pingone_gateway" "%[2]s" {
   name           = "%[3]s"
   enabled        = false
   type           = "RADIUS"
+  description    = "My test gateway"
 
   radius_default_shared_secret = "sharedsecret123"
 
-  radius_davinci_policy_id = "ee8470a2-8161-4d76-a7af-a8505a2da084" // dummy ID
+  radius_davinci_policy_id = "ee8470a281614d76a7afa8505a2da084" // dummy ID
 
   radius_clients = [
     {
@@ -1075,7 +1079,7 @@ resource "pingone_gateway" "%[2]s" {
 
   radius_default_shared_secret = "sharedsecret123"
 
-  radius_davinci_policy_id = "ee8470a2-8161-4d76-a7af-a8505a2da085" // dummy ID
+  radius_davinci_policy_id = "ee8470a281614d76a7afa8505a2da084" // dummy ID
 
   radius_clients = [
     {
@@ -1096,7 +1100,7 @@ resource "pingone_gateway" "%[2]s" {
   enabled        = false
   type           = "RADIUS"
 
-  radius_davinci_policy_id = "ee8470a2-8161-4d76-a7af-a8505a2da085" // dummy ID
+  radius_davinci_policy_id = "ee8470a281614d76a7afa8505a2da084" // dummy ID
 
   radius_clients = [
     {
@@ -1118,7 +1122,7 @@ resource "pingone_gateway" "%[2]s" {
   enabled        = false
   type           = "RADIUS"
 
-  radius_davinci_policy_id = "ee8470a2-8161-4d76-a7af-a8505a2da085" // dummy ID
+  radius_davinci_policy_id = "ee8470a281614d76a7afa8505a2da084" // dummy ID
 
   radius_clients = [
     {


### PR DESCRIPTION
### Change Description
FIX: 
* `unexpected new value: .description: was cty.StringVal("My test gateway."), but now null.`
*  corrected validation for `radius_davinci_policy_id` when using `RADIUS` type

### Testing Shell Command
```shell
TF_ACC=1 go test -v -timeout 240s -run "TestAccGateway_RADIUS|TestAccGateway_LDAP" -count=1 ./internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccGateway_LDAP
=== PAUSE TestAccGateway_LDAP
=== RUN   TestAccGateway_RADIUS
=== PAUSE TestAccGateway_RADIUS
=== RUN   TestAccGateway_RADIUSSharedSecrets
=== PAUSE TestAccGateway_RADIUSSharedSecrets
=== CONT  TestAccGateway_LDAP
=== CONT  TestAccGateway_RADIUSSharedSecrets
=== CONT  TestAccGateway_RADIUS
--- PASS: TestAccGateway_RADIUS (17.26s)
--- PASS: TestAccGateway_RADIUSSharedSecrets (17.64s)
--- PASS: TestAccGateway_LDAP (28.93s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/base	29.741s
```

</details>