### PR TITLE
correct radius_davinci_policy_id type in pingone_gateway data source

### DIFF
--- a/.changelog/1042.txt
+++ b/.changelog/1042.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`data-source/pingone_gateway`: Corrected the type of `radius_davinci_policy_id`, resulting in format validation that no longer incorrectly enforces dash characters.
+```

--- a/docs/data-sources/gateway.md
+++ b/docs/data-sources/gateway.md
@@ -45,7 +45,7 @@ data "pingone_gateway" "example_by_id" {
 - `id` (String) The ID of this resource.
 - `kerberos` (Attributes) For LDAP gateways only: A single object that specifies Kerberos connection details. (see [below for nested schema](#nestedatt--kerberos))
 - `radius_clients` (Attributes Set) For RADIUS gateways only: A collection of RADIUS clients. (see [below for nested schema](#nestedatt--radius_clients))
-- `radius_davinci_policy_id` (String) For RADIUS gateways only: The ID of the DaVinci flow policy to use.
+- `radius_davinci_policy_id` (String) For RADIUS gateways only: The ID of the PingOne DaVinci flow policy to use.
 - `radius_default_shared_secret` (String, Sensitive) For RADIUS gateways only: Value to use for the shared secret if the shared secret is not provided for one or more of the RADIUS clients specified.
 - `radius_network_policy_server` (Attributes) For RADIUS gateways only: A single object that allows configuration of the RADIUS gateway to authenticate using the MS-CHAP v2 protocol. (see [below for nested schema](#nestedatt--radius_network_policy_server))
 - `servers` (Set of String) For LDAP gateways only: A list of LDAP server host name and port number combinations (for example, [`ds1.bxretail.org:636`, `ds2.bxretail.org:636`]).

--- a/internal/service/base/data_source_gateway.go
+++ b/internal/service/base/data_source_gateway.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
+	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/davincitypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
 )
@@ -45,7 +46,7 @@ type gatewayDataSourceModel struct {
 
 	// Radius
 	RadiusClients             types.Set                    `tfsdk:"radius_clients"`
-	RadiusDavinciPolicyId     pingonetypes.ResourceIDValue `tfsdk:"radius_davinci_policy_id"`
+	RadiusDavinciPolicyId     davincitypes.ResourceIDValue `tfsdk:"radius_davinci_policy_id"`
 	RadiusDefaultSharedSecret types.String                 `tfsdk:"radius_default_shared_secret"`
 	RadiusNetworkPolicyServer types.Object                 `tfsdk:"radius_network_policy_server"`
 }
@@ -331,10 +332,10 @@ func (r *GatewayDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 
 			// RADIUS
 			"radius_davinci_policy_id": schema.StringAttribute{
-				Description: framework.SchemaAttributeDescriptionFromMarkdown("For RADIUS gateways only: The ID of the DaVinci flow policy to use.").Description,
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("For RADIUS gateways only: The ID of the PingOne DaVinci flow policy to use.").Description,
 				Computed:    true,
 
-				CustomType: pingonetypes.ResourceIDType{},
+				CustomType: davincitypes.ResourceIDType{},
 			},
 			"radius_default_shared_secret": schema.StringAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("For RADIUS gateways only: Value to use for the shared secret if the shared secret is not provided for one or more of the RADIUS clients specified.").Description,
@@ -555,7 +556,7 @@ func (p *gatewayDataSourceModel) toState(ctx context.Context, apiObject interfac
 		p.UserTypes = types.MapNull(types.ObjectType{AttrTypes: gatewayUserTypesTFObjectTypes})
 
 		// Radius
-		p.RadiusDavinciPolicyId = pingonetypes.NewResourceIDNull()
+		p.RadiusDavinciPolicyId = davincitypes.NewResourceIDNull()
 		p.RadiusDefaultSharedSecret = types.StringNull()
 		p.RadiusClients = types.SetNull(types.ObjectType{AttrTypes: gatewayRadiusClientsTFObjectTypes})
 		p.RadiusNetworkPolicyServer = types.ObjectNull(gatewayRadiusNetworkPolicyServerTFObjectTypes)
@@ -597,7 +598,7 @@ func (p *gatewayDataSourceModel) toState(ctx context.Context, apiObject interfac
 		diags.Append(d...)
 
 		// Radius
-		p.RadiusDavinciPolicyId = pingonetypes.NewResourceIDNull()
+		p.RadiusDavinciPolicyId = davincitypes.NewResourceIDNull()
 		p.RadiusDefaultSharedSecret = types.StringNull()
 		p.RadiusClients = types.SetNull(types.ObjectType{AttrTypes: gatewayRadiusClientsTFObjectTypes})
 		p.RadiusNetworkPolicyServer = types.ObjectNull(gatewayRadiusNetworkPolicyServerTFObjectTypes)
@@ -624,7 +625,7 @@ func (p *gatewayDataSourceModel) toState(ctx context.Context, apiObject interfac
 		// Radius
 		if dv, ok := t.GetDavinciOk(); ok {
 			if policy, ok := dv.GetPolicyOk(); ok {
-				p.RadiusDavinciPolicyId = framework.PingOneResourceIDOkToTF(policy.GetIdOk())
+				p.RadiusDavinciPolicyId = framework.DaVinciResourceIDOkToTF(policy.GetIdOk())
 			}
 		}
 		p.RadiusDefaultSharedSecret = framework.StringOkToTF(t.GetDefaultSharedSecretOk())

--- a/internal/service/base/data_source_gateway_test.go
+++ b/internal/service/base/data_source_gateway_test.go
@@ -87,7 +87,7 @@ func TestAccGatewayDataSource_FindRADIUSGatewayByID(t *testing.T) {
 
 					resource.TestCheckResourceAttr(dataSourceFullName, "enabled", "false"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "type", "RADIUS"),
-					resource.TestMatchResourceAttr(dataSourceFullName, "radius_davinci_policy_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(dataSourceFullName, "radius_davinci_policy_id", verify.P1DVResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(dataSourceFullName, "radius_default_shared_secret", "sharedsecret123"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "radius_clients.#", "2"),
 
@@ -131,7 +131,7 @@ func TestAccGatewayDataSource_FindRADIUSGatewayByName(t *testing.T) {
 					resource.TestCheckNoResourceAttr(dataSourceFullName, "description"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "enabled", "false"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "type", "RADIUS"),
-					resource.TestMatchResourceAttr(dataSourceFullName, "radius_davinci_policy_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(dataSourceFullName, "radius_davinci_policy_id", verify.P1DVResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(dataSourceFullName, "radius_default_shared_secret", "sharedsecret123"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "radius_clients.#", "1"),
 
@@ -330,7 +330,7 @@ resource "pingone_gateway" "%[2]s" {
 
   radius_default_shared_secret = "sharedsecret123"
 
-  radius_davinci_policy_id = "ee8470a2-8161-4d76-a7af-a8505a2da084" // dummy ID
+  radius_davinci_policy_id = "ee8470a281614d76a7afa8505a2da084" // dummy ID
 
   radius_clients = [
     {
@@ -362,7 +362,7 @@ resource "pingone_gateway" "%[2]s" {
 
   radius_default_shared_secret = "sharedsecret123"
 
-  radius_davinci_policy_id = "ee8470a2-8161-4d76-a7af-a8505a2da085" // dummy ID
+  radius_davinci_policy_id = "ee8470a281614d76a7afa8505a2da085" // dummy ID
 
   radius_clients = [
     {


### PR DESCRIPTION
### Change Description
FIX: 
*  corrected validation for `radius_davinci_policy_id` when using `RADIUS` type in `pingone_gateway` data source

### Testing Shell Command
```shell
TF_ACC=1 go test -v -timeout 240s -run "TestAccGatewayDataSource_FindRADIUS" -count=1 ./internal/service/base
```

### Testing Results
<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccGatewayDataSource_FindRADIUSGatewayByID
=== PAUSE TestAccGatewayDataSource_FindRADIUSGatewayByID
=== RUN   TestAccGatewayDataSource_FindRADIUSGatewayByName
=== PAUSE TestAccGatewayDataSource_FindRADIUSGatewayByName
=== CONT  TestAccGatewayDataSource_FindRADIUSGatewayByID
=== CONT  TestAccGatewayDataSource_FindRADIUSGatewayByName
--- PASS: TestAccGatewayDataSource_FindRADIUSGatewayByID (4.03s)
--- PASS: TestAccGatewayDataSource_FindRADIUSGatewayByName (4.13s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/base	4.624s
```

</details>