### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,15 @@ updates:
     schedule:
       # Check for updates to Go modules every week
       interval: "weekly"
+    groups:
+      # Group terraform-plugin-framework dependencies together
+      terraform:
+        applies-to: version-updates
+        patterns:
+          - "*terraform-plugin-*"
+        update-types:
+          - "patch"
+          - "minor"
 
   # Maintain dependencies for Go modules for tools
   - package-ecosystem: "gomod"
@@ -22,3 +31,27 @@ updates:
     schedule:
       # Check for updates to Go modules every week
       interval: "weekly"
+    groups:
+      # Group all linting tools together
+      linters:
+        applies-to: version-updates
+        patterns:
+          - "*tfproviderlint*"
+          - "*golangci-lint*"
+          - "*terrafmt*"
+          - "*tflint*"
+          - "*impi*"
+        update-types:
+          - "minor"
+    # Ignore patches for linters, only update for minor versions
+    ignore:
+      - dependency-name: "*tfproviderlint*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "*golangci-lint*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "*terrafmt*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "*tflint*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "*impi*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Group dependabot updates for linters and plugin-framework dependencies to simplify pull requests, and ignore patch updates for linters