### PR TITLE
Draft: allow region override, and fix inconsistent result with overridden region in pingone_environment

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -28,6 +28,7 @@ func (c *Config) APIClient(ctx context.Context, version string) (*Client, error)
 		EnvironmentID:        &c.EnvironmentID,
 		AccessToken:          &c.AccessToken,
 		RegionCode:           c.RegionCode,
+		OverridenRegion:      c.OverridenRegion,
 		APIHostnameOverride:  c.APIHostnameOverride,
 		AuthHostnameOverride: c.AuthHostnameOverride,
 		UserAgentSuffix:      &userAgent,

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -2,7 +2,10 @@
 
 package client
 
-import "github.com/patrickcping/pingone-go-sdk-v2/management"
+import (
+	"github.com/patrickcping/pingone-go-sdk-v2/management"
+	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
+)
 
 type Config struct {
 	ClientID             string
@@ -10,6 +13,7 @@ type Config struct {
 	EnvironmentID        string
 	AccessToken          string
 	RegionCode           *management.EnumRegionCode
+	OverridenRegion      *model.RegionMapping
 	APIHostnameOverride  *string
 	AuthHostnameOverride *string
 	ProxyURL             *string

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
+	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	"github.com/pingidentity/terraform-provider-pingone/internal/client"
 	pingone "github.com/pingidentity/terraform-provider-pingone/internal/client"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
@@ -282,6 +283,14 @@ func (p *pingOneProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if !data.RegionCode.IsNull() && !data.RegionCode.IsUnknown() {
 		regionCode := management.EnumRegionCode(data.RegionCode.ValueString())
 		config.RegionCode = &regionCode
+	}
+	urlSuffixOverride := os.Getenv("PINGONE_TERRAFORM_REGION_URL_SUFFIX_OVERRIDE")
+	apiCodeOverride := os.Getenv("PINGONE_TERRAFORM_REGION_OVERRIDE")
+	if urlSuffixOverride != "" && apiCodeOverride != "" {
+		config.OverridenRegion = &model.RegionMapping{
+			URLSuffix: urlSuffixOverride,
+			APICode:   management.EnumRegionCode(apiCodeOverride),
+		}
 	}
 
 	if !data.HTTPProxy.IsNull() {

--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
+	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	client "github.com/pingidentity/terraform-provider-pingone/internal/client"
 	"github.com/pingidentity/terraform-provider-pingone/internal/service/authorize"
 	"github.com/pingidentity/terraform-provider-pingone/internal/service/base"
@@ -179,6 +180,14 @@ func configure(version string) func(context.Context, *schema.ResourceData) (inte
 		if v, ok := d.Get("region_code").(string); ok && v != "" {
 			regionCode := management.EnumRegionCode(v)
 			config.RegionCode = &regionCode
+		}
+		urlSuffixOverride := os.Getenv("PINGONE_TERRAFORM_REGION_URL_SUFFIX_OVERRIDE")
+		apiCodeOverride := os.Getenv("PINGONE_TERRAFORM_REGION_OVERRIDE")
+		if urlSuffixOverride != "" && apiCodeOverride != "" {
+			config.OverridenRegion = &model.RegionMapping{
+				URLSuffix: urlSuffixOverride,
+				APICode:   management.EnumRegionCode(apiCodeOverride),
+			}
 		}
 
 		config.GlobalOptions = &client.GlobalOptions{

--- a/internal/service/base/resource_environment.go
+++ b/internal/service/base/resource_environment.go
@@ -1028,7 +1028,15 @@ func (p *environmentResourceModel) toState(environmentApiObject *management.Envi
 	p.Name = framework.StringOkToTF(environmentApiObject.GetNameOk())
 	p.Description = framework.StringOkToTF(environmentApiObject.GetDescriptionOk())
 	p.Type = framework.EnumOkToTF(environmentApiObject.GetTypeOk())
-	p.Region = framework.EnumOkToTF(environmentApiObject.GetRegionOk())
+
+	region, ok := environmentApiObject.GetRegionOk()
+	if !ok || region == nil {
+		p.Region = types.StringNull()
+	} else if region.EnumRegionCode != nil {
+		p.Region = types.StringValue(string(*region.EnumRegionCode))
+	} else {
+		p.Region = types.StringPointerValue(region.String)
+	}
 
 	if v, ok := environmentApiObject.GetLicenseOk(); ok {
 		p.LicenseId = framework.PingOneResourceIDOkToTF(v.GetIdOk())


### PR DESCRIPTION
### Change Description
Allow overriding the region that the provider uses. This relies on the `PINGONE_TERRAFORM_REGION_OVERRIDE` and `PINGONE_TERRAFORM_REGION_URL_SUFFIX_OVERRIDE` variables

### Required SDK Upgrades
`github.com/patrickcping/pingone-go-sdk-v2` will need updated to support this. I have an example of the required change to that project in my fork - https://github.com/henryrecker-pingidentity/pingone-go-sdk-v2/pull/1/files 

### Testing Results
TBD