### PR TITLE
Correct `pingone_application_flow_policy_assignment` HCL example

### DIFF
--- a/.changelog/1053.txt
+++ b/.changelog/1053.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/pingone_application_flow_policy_assignment`: Corrected documented HCL example to avoid deprecated fields on the DaVinci provider's `davinci_application` resource.
+```

--- a/docs/resources/application_flow_policy_assignment.md
+++ b/docs/resources/application_flow_policy_assignment.md
@@ -26,55 +26,35 @@ resource "pingone_application" "my_application" {
   # ...
 }
 
-resource "davinci_application" "davinci_app" {
+resource "davinci_flow" "authentication" {
+  # ...
+}
+
+resource "davinci_application" "awesome_dv_app" {
   environment_id = pingone_environment.my_environment.id
 
   name = "Awesome DaVinci Application"
+}
 
-  oauth {
-    enabled = true
-    values {
-      allowed_grants                = ["authorizationCode"]
-      allowed_scopes                = ["openid", "profile"]
-      enabled                       = true
-      enforce_signed_request_openid = false
-      redirect_uris                 = [var.redirect_uri]
-    }
-  }
+resource "davinci_application_flow_policy" "authentication_flow_policy" {
+  environment_id = pingone_environment.my_environment.id
+  application_id = davinci_application.awesome_dv_app.id
 
-  policy {
-    name   = "Flow Policy"
-    status = "enabled"
-    policy_flow {
-      flow_id    = var.davinci_flow_id
-      version_id = -1
-      weight     = 100
-    }
-  }
+  name   = "Authentication"
+  status = "enabled"
 
-  policy {
-    name   = "Second Flow Policy"
-    status = "enabled"
-    policy_flow {
-      flow_id    = var.second_davinci_flow_id
-      version_id = -1
-      weight     = 100
-    }
-  }
-
-  saml {
-    values {
-      enabled                = false
-      enforce_signed_request = false
-    }
+  policy_flow {
+    flow_id    = davinci_flow.authentication.id
+    version_id = -1
+    weight     = 100
   }
 }
 
-resource "pingone_application_flow_policy_assignment" "foo" {
+resource "pingone_application_flow_policy_assignment" "authentication_davinci_flow_policy_assignment" {
   environment_id = pingone_environment.my_environment.id
   application_id = pingone_application.my_application.id
 
-  flow_policy_id = davinci_application.davinci_app.policy.* [index(davinci_application.davinci_app.policy[*].name, "Flow Policy")].policy_id
+  flow_policy_id = davinci_application_flow_policy.authentication_flow_policy.id
 
   priority = 1
 }

--- a/examples/resources/pingone_application_flow_policy_assignment/resource.tf
+++ b/examples/resources/pingone_application_flow_policy_assignment/resource.tf
@@ -6,55 +6,35 @@ resource "pingone_application" "my_application" {
   # ...
 }
 
-resource "davinci_application" "davinci_app" {
+resource "davinci_flow" "authentication" {
+  # ...
+}
+
+resource "davinci_application" "awesome_dv_app" {
   environment_id = pingone_environment.my_environment.id
 
   name = "Awesome DaVinci Application"
+}
 
-  oauth {
-    enabled = true
-    values {
-      allowed_grants                = ["authorizationCode"]
-      allowed_scopes                = ["openid", "profile"]
-      enabled                       = true
-      enforce_signed_request_openid = false
-      redirect_uris                 = [var.redirect_uri]
-    }
-  }
+resource "davinci_application_flow_policy" "authentication_flow_policy" {
+  environment_id = pingone_environment.my_environment.id
+  application_id = davinci_application.awesome_dv_app.id
 
-  policy {
-    name   = "Flow Policy"
-    status = "enabled"
-    policy_flow {
-      flow_id    = var.davinci_flow_id
-      version_id = -1
-      weight     = 100
-    }
-  }
+  name   = "Authentication"
+  status = "enabled"
 
-  policy {
-    name   = "Second Flow Policy"
-    status = "enabled"
-    policy_flow {
-      flow_id    = var.second_davinci_flow_id
-      version_id = -1
-      weight     = 100
-    }
-  }
-
-  saml {
-    values {
-      enabled                = false
-      enforce_signed_request = false
-    }
+  policy_flow {
+    flow_id    = davinci_flow.authentication.id
+    version_id = -1
+    weight     = 100
   }
 }
 
-resource "pingone_application_flow_policy_assignment" "foo" {
+resource "pingone_application_flow_policy_assignment" "authentication_davinci_flow_policy_assignment" {
   environment_id = pingone_environment.my_environment.id
   application_id = pingone_application.my_application.id
 
-  flow_policy_id = davinci_application.davinci_app.policy.* [index(davinci_application.davinci_app.policy[*].name, "Flow Policy")].policy_id
+  flow_policy_id = davinci_application_flow_policy.authentication_flow_policy.id
 
   priority = 1
 }


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_application_flow_policy_assignment`: Corrected documented HCL example to avoid deprecated fields on the DaVinci provider's `davinci_application` resource.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing

N/a - no acceptance tests impacted