### PR TITLE
Corrected url validation to include `localhost` and custom port combinations

### DIFF
--- a/.changelog/1054.txt
+++ b/.changelog/1054.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix URL validators (most notably on the `pingone_application` resource) to allow localhost URLs, and/or URLs with a defined port number.
+```

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -23,7 +23,7 @@ var IPv4IPv6Regexp = regexp.MustCompile(fmt.Sprintf(`%s|%s`, IPv4RegexpFull.Stri
 var HexColorCode = regexp.MustCompile(`^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$`)
 
 var IsDomain = regexp.MustCompile(`^(?:[\w-]+\.)+[a-z]{2,}$`)
-var urlRegexStringWithoutProtocol = `(?:[\w-]+\.)+[a-z]{2,}(?:\/[\w.-]+)*(?:\/[\w\:.-]+)?\/?(?:\?.*)?$`
+var urlRegexStringWithoutProtocol = `(?:(?:[\w-]+\.)+[a-z]{2,}|localhost)(?:\:[\d]{1,})*(?:\/[\w.-]+)*(?:\/[\w\:.-]+)?\/?(?:\?.*)?$`
 var IsURLWithHTTPorHTTPS = regexp.MustCompile(fmt.Sprintf(`^http[s]{0,1}:\/\/%s`, urlRegexStringWithoutProtocol))
 var IsURLWithHTTPS = regexp.MustCompile(fmt.Sprintf(`^https:\/\/%s`, urlRegexStringWithoutProtocol))
 var IsTwoCharCountryCode = regexp.MustCompile(`^(A(D|E|F|G|I|L|M|N|O|R|S|T|Q|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|Q|L|M|N|O|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|Q|P|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|T|V|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$`)

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -10,19 +10,26 @@ import (
 var (
 	urlsWithoutProtocol = []string{
 		"www.my-test-domain.%s",
+		"www.my-test-domain.%s:3000",
 		"test1234.my-test-domain.%s",
 		"test1234.www.my-test-domain.%s",
 		"test-1234.www.subdomain.my-test-domain.%s",
 		"my-test-domain.%s",
 		"my-test-domain.%s/",
+		"my-test-domain.%s:3000/",
 		"my-test-domain.%s/path",
+		"my-test-domain.%s:3000/path",
 		"my-test-domain.%s/path/",
 		"my-test-domain.%s/path?query",
+		"my-test-domain.%s:3000/path?query",
 		"my-test-domain.%s/path?query=value",
+		"my-test-domain.%s:3000/path?query=value&query2=value2",
 		"my-test-domain.%s/path?query=value&query2=value2",
 		"my-test-domain.%s/path?query=value&query2=value2#fragment",
+		"my-test-domain.%s:3000/path?query=value&query2=value2#fragment",
 		"my-test-domain.%s/path-1.2.3",
 		"my-test-domain.%s/path-1.2.3/",
+		"my-test-domain.%s:3000/path-1.2.3/",
 		"my-test-domain.%s/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/",
 	}
 
@@ -40,6 +47,45 @@ var (
 		"com.br",
 	}
 )
+
+func TestRegex_Localhost(t *testing.T) {
+
+	localhostURLsWithoutProtocol := []string{
+		"localhost",
+		"localhost:3000",
+		"localhost/",
+		"localhost:3000/",
+		"localhost/path",
+		"localhost:3000/path",
+		"localhost/path/",
+		"localhost/path?query",
+		"localhost:3000/path?query",
+		"localhost/path?query=value",
+		"localhost:3000/path?query=value&query2=value2",
+		"localhost/path?query=value&query2=value2",
+		"localhost/path?query=value&query2=value2#fragment",
+		"localhost:3000/path?query=value&query2=value2#fragment",
+		"localhost/path-1.2.3",
+		"localhost/path-1.2.3/",
+		"localhost:3000/path-1.2.3/",
+		"localhost/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/path-1.2.3/",
+	}
+	protocols := []string{
+		"https",
+		"http",
+	}
+
+	for _, protocol := range protocols {
+		for _, url := range localhostURLsWithoutProtocol {
+			parsedUrl := fmt.Sprintf("%s://%s", protocol, url)
+			t.Run(parsedUrl, func(t *testing.T) {
+				if !IsURLWithHTTPorHTTPS.MatchString(parsedUrl) {
+					t.Errorf("IsURLWithHTTPorHTTPS failed to match %q", parsedUrl)
+				}
+			})
+		}
+	}
+}
 
 func TestRegex_IsURLWithHTTPS_Positive(t *testing.T) {
 


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

Issues in the schema regex validators using `IsURLWithHTTPorHTTPS` and `IsURLWithHTTPS` regex strings meant that URLs that should allow `localhost` were not being allowed, neither any URL with a port defined in the URL (see attached issue).

This bug fix allows URLs to have `localhost` as the hostname and custom ports to be applied, as the console permits.

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
go test -run ^TestRegex_ ./internal/verify
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
ok      github.com/pingidentity/terraform-provider-pingone/internal/verify      0.578s
```

</details>