### PR TITLE
`resource/pingone_form`: Field ordering and type deprecations

### DIFF
--- a/docs/resources/form.md
+++ b/docs/resources/form.md
@@ -30,14 +30,41 @@ resource "pingone_form" "my_awesome_form" {
   components = {
     fields = [
       {
-        type = "TEXTBLOB"
+        type = "SLATE_TEXTBLOB"
 
         position = {
           row = 0
           col = 0
         }
 
-        content = "<h2>Sign On</h2><hr>"
+        content = jsonencode(
+          [
+            {
+              "children" : [
+                {
+                  "text" : "Sign On"
+                }
+              ],
+              "type" : "heading-1"
+            },
+            {
+              "type" : "divider",
+              "children" : [
+                {
+                  "text" : ""
+                }
+              ]
+            },
+            {
+              "type" : "paragraph",
+              "children" : [
+                {
+                  "text" : ""
+                }
+              ]
+            }
+          ]
+        )
       },
       {
         type = "ERROR_DISPLAY"
@@ -195,7 +222,7 @@ resource "pingone_form" "my_awesome_form" {
 
 Required:
 
-- `fields` (Attributes Set) A set of objects that specifies the form fields that make up the form. (see [below for nested schema](#nestedatt--components--fields))
+- `fields` (Attributes List) An ordered list of objects that specifies the form fields that make up the form. (see [below for nested schema](#nestedatt--components--fields))
 
 <a id="nestedatt--components--fields"></a>
 ### Nested Schema for `components.fields`
@@ -203,13 +230,13 @@ Required:
 Required:
 
 - `position` (Attributes) A single object that specifies the position of the form field in the form.  The combination of `col` and `row` must be unique between form fields. (see [below for nested schema](#nestedatt--components--fields--position))
-- `type` (String) A string that specifies the type of form field.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`, `TEXTBLOB`.
+- `type` (String) A string that specifies the type of form field.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`, `TEXTBLOB`.  The `TEXTBLOB` form field type has been deprecated and will be removed in a future release.
 
 Optional:
 
 - `alignment` (String) **Required** when the `type` is one of `QR_CODE`, `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA alignment.  Options are `CENTER`, `LEFT`, `RIGHT`.
 - `attribute_disabled` (Boolean) Optional when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `TEXT`.  A boolean that specifies whether the linked directory attribute is disabled.
-- `content` (String) Optional when the `type` is one of `SLATE_TEXTBLOB`, `TEXTBLOB`.  A string that specifies the field's content (for example, HTML when the field type is `TEXTBLOB`.)
+- `content` (String) Optional when the `type` is one of `SLATE_TEXTBLOB`, `TEXTBLOB`.  A string that specifies the field's content (for example, escaped JSON string when the field type is `SLATE_TEXTBLOB` - use `jsonencode` to convert JSON to escaped JSON string.)
 - `key` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `QR_CODE`, `RADIO`, `TEXT`.  A string that specifies an identifier for the field component.
 - `label` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `SUBMIT_BUTTON`, `TEXT`.  A string that specifies the field label.
 - `label_mode` (String) Optional when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `TEXT`.  A string that specifies how the field is rendered.  Options are `DEFAULT`, `FLOAT`.

--- a/examples/resources/pingone_form/resource.tf
+++ b/examples/resources/pingone_form/resource.tf
@@ -16,14 +16,41 @@ resource "pingone_form" "my_awesome_form" {
   components = {
     fields = [
       {
-        type = "TEXTBLOB"
+        type = "SLATE_TEXTBLOB"
 
         position = {
           row = 0
           col = 0
         }
 
-        content = "<h2>Sign On</h2><hr>"
+        content = jsonencode(
+          [
+            {
+              "children" : [
+                {
+                  "text" : "Sign On"
+                }
+              ],
+              "type" : "heading-1"
+            },
+            {
+              "type" : "divider",
+              "children" : [
+                {
+                  "text" : ""
+                }
+              ]
+            },
+            {
+              "type" : "paragraph",
+              "children" : [
+                {
+                  "text" : ""
+                }
+              ]
+            }
+          ]
+        )
       },
       {
         type = "ERROR_DISPLAY"

--- a/internal/service/base/resource_form.go
+++ b/internal/service/base/resource_form.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -53,7 +53,7 @@ type formResourceModel struct {
 }
 
 type formComponentsResourceModel struct {
-	Fields types.Set `tfsdk:"fields"`
+	Fields types.List `tfsdk:"fields"`
 }
 
 type formComponentsFieldResourceModel struct {
@@ -136,7 +136,7 @@ type formComponentsFieldsSchemaDef struct {
 var (
 	// Form Components
 	formComponentsTFObjectTypes = map[string]attr.Type{
-		"fields": types.SetType{ElemType: types.ObjectType{
+		"fields": types.ListType{ElemType: types.ObjectType{
 			AttrTypes: formComponentsFieldsTFObjectTypes,
 		}},
 	}
@@ -487,7 +487,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 	)
 
 	componentsFieldsDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"A set of objects that specifies the form fields that make up the form.",
+		"An ordered list of objects that specifies the form fields that make up the form.",
 	)
 
 	componentsFieldsPositionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -508,7 +508,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 
 	componentsFieldsTypeDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the type of form field.",
-	).AllowedValuesEnum(supportedFormFieldTypes)
+	).AllowedValuesEnum(supportedFormFieldTypes).AppendMarkdownString(fmt.Sprintf("The `%s` form field type has been deprecated and will be removed in a future release.", string(management.ENUMFORMFIELDTYPE_TEXTBLOB)))
 
 	componentsFieldsAttributeDisabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		formFieldValidationDocumentation("attribute_disabled"),
@@ -519,7 +519,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 	componentsFieldsContentDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		formFieldValidationDocumentation("content"),
 	).AppendMarkdownString(
-		fmt.Sprintf("A string that specifies the field's content (for example, HTML when the field type is `%s`.)", string(management.ENUMFORMFIELDTYPE_TEXTBLOB)),
+		fmt.Sprintf("A string that specifies the field's content (for example, escaped JSON string when the field type is `%s` - use `jsonencode` to convert JSON to escaped JSON string.)", string(management.ENUMFORMFIELDTYPE_SLATE_TEXTBLOB)),
 	)
 
 	componentsFieldsKeyDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -776,7 +776,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Required:            true,
 
 				Attributes: map[string]schema.Attribute{
-					"fields": schema.SetNestedAttribute{
+					"fields": schema.ListNestedAttribute{
 						Description:         componentsFieldsDescription.Description,
 						MarkdownDescription: componentsFieldsDescription.MarkdownDescription,
 						Required:            true,
@@ -1129,8 +1129,8 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 							},
 						},
 
-						Validators: []validator.Set{
-							setvalidator.SizeAtLeast(attrMinLength),
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(attrMinLength),
 						},
 					},
 				},
@@ -1667,8 +1667,17 @@ func (p *formResourceModel) validate(ctx context.Context, allowUnknowns bool) di
 					continue
 				}
 
-				if !field.Type.IsNull() && !field.Type.IsUnknown() && field.Type.Equal(types.StringValue(string(management.ENUMFORMFIELDTYPE_SUBMIT_BUTTON))) {
-					hasSubmitButton = true
+				if !field.Type.IsNull() && !field.Type.IsUnknown() {
+					if field.Type.Equal(types.StringValue(string(management.ENUMFORMFIELDTYPE_SUBMIT_BUTTON))) {
+						hasSubmitButton = true
+					}
+					if field.Type.Equal(types.StringValue(string(management.ENUMFORMFIELDTYPE_TEXTBLOB))) {
+						diags.AddAttributeWarning(
+							path.Root("components").AtName("fields"),
+							"Deprecated form field type",
+							fmt.Sprintf("The %s form field type has been deprecated and will be removed in a future release.", field.Type.ValueString()),
+						)
+					}
 				}
 
 				// Validate Position conflicts
@@ -2688,13 +2697,13 @@ func formComponentsOkToTF(apiObject *management.FormComponents, ok bool) (basety
 	return objValue, diags
 }
 
-func formComponentsFieldsOkToTF(apiObject []management.FormField, ok bool) (basetypes.SetValue, diag.Diagnostics) {
+func formComponentsFieldsOkToTF(apiObject []management.FormField, ok bool) (basetypes.ListValue, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	tfObjType := types.ObjectType{AttrTypes: formComponentsFieldsTFObjectTypes}
 
 	if !ok || apiObject == nil {
-		return types.SetNull(tfObjType), diags
+		return types.ListNull(tfObjType), diags
 	}
 
 	objectList := []attr.Value{}
@@ -3029,7 +3038,7 @@ func formComponentsFieldsOkToTF(apiObject []management.FormField, ok bool) (base
 		objectList = append(objectList, objValue)
 	}
 
-	returnVar, d := types.SetValue(tfObjType, objectList)
+	returnVar, d := types.ListValue(tfObjType, objectList)
 	diags.Append(d...)
 
 	return returnVar, diags

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -201,97 +201,67 @@ func TestAccForm_Multiple(t *testing.T) {
 		Config: testAccFormConfig_MultipleStep1(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "10"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":                       "PASSWORD",
-				"position.row":               "3",
-				"position.col":               "0",
-				"position.width":             "",
-				"key":                        "user.password",
-				"label":                      "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.label\",\"defaultTranslation\":\"Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"required":                   "true",
-				"attribute_disabled":         "false",
-				"show_password_requirements": "false",
-				// "validation.type":            "NONE",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":               "TEXT",
-				"position.row":       "2",
-				"position.col":       "0",
-				"position.width":     "",
-				"key":                "user.username",
-				"label":              "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.username.label\",\"defaultTranslation\":\"Enter your email address\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"required":           "true",
-				"attribute_disabled": "false",
-				"validation.type":    "NONE",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "SLATE_TEXTBLOB",
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"content":        "[{\"children\":[{\"text\":\"Sign On\"}],\"type\":\"heading-1\"},{\"type\":\"divider\",\"children\":[{\"text\":\"\"}]},{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "FLOW_LINK",
-				"position.row":   "7",
-				"position.col":   "0",
-				"position.width": "",
-				"key":            "issues",
-				"label":          "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Issues signing on?\"}]}]",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "FLOW_LINK",
-				"position.row":   "7",
-				"position.col":   "1",
-				"position.width": "",
-				"key":            "register",
-				"label":          "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Create your account\"}]}]",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":                    "FLOW_BUTTON",
-				"position.row":            "5",
-				"position.col":            "1",
-				"position.width":          "",
-				"key":                     "passkey",
-				"label":                   "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Use your Passkey\"}]}]",
-				"styles.alignment":        "CENTER",
-				"styles.background_color": "#FFF",
-				"styles.border_color":     "#4462ED",
-				"styles.enabled":          "true",
-				"styles.height":           "36",
-				"styles.padding.bottom":   "5",
-				"styles.padding.left":     "0",
-				"styles.padding.right":    "0",
-				"styles.padding.top":      "5",
-				"styles.text_color":       "#4462ED",
-				"styles.width":            "100",
-				"styles.width_unit":       "PERCENT",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "ERROR_DISPLAY",
-				"position.row":   "1",
-				"position.col":   "0",
-				"position.width": "",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "SUBMIT_BUTTON",
-				"position.row":   "5",
-				"position.col":   "0",
-				"position.width": "",
-				"label":          "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text.signOn\",\"defaultTranslation\":\"Sign On\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "DIVIDER",
-				"position.row":   "4",
-				"position.col":   "0",
-				"position.width": "",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "DIVIDER",
-				"position.row":   "6",
-				"position.col":   "0",
-				"position.width": "",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "PASSWORD"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "user.password"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.label\",\"defaultTranslation\":\"Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.show_password_requirements", "false"),
+			// "validation.type":            "NONE",
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.type", "TEXT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.row", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.key", "user.username"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.username.label\",\"defaultTranslation\":\"Enter your email address\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.validation.type", "NONE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.type", "SLATE_TEXTBLOB"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.content", "[{\"children\":[{\"text\":\"Sign On\"}],\"type\":\"heading-1\"},{\"type\":\"divider\",\"children\":[{\"text\":\"\"}]},{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.type", "FLOW_LINK"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.position.row", "7"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.key", "issues"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Issues signing on?\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.type", "FLOW_BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.position.row", "5"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.position.col", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.key", "passkey"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Use your Passkey\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.alignment", "CENTER"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.background_color", "#FFF"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.border_color", "#4462ED"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.enabled", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.height", "36"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.padding.bottom", "5"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.padding.left", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.padding.right", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.padding.top", "5"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.text_color", "#4462ED"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.width", "100"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.4.styles.width_unit", "PERCENT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.5.type", "FLOW_LINK"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.5.position.row", "7"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.5.position.col", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.5.key", "register"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.5.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Create your account\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.6.type", "SUBMIT_BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.6.position.row", "5"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.6.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.6.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text.signOn\",\"defaultTranslation\":\"Sign On\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.7.type", "ERROR_DISPLAY"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.7.position.row", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.7.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.8.type", "DIVIDER"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.8.position.row", "4"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.8.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.9.type", "DIVIDER"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.9.position.row", "6"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.9.position.col", "0"),
 		),
 	}
 
@@ -299,36 +269,24 @@ func TestAccForm_Multiple(t *testing.T) {
 		Config: testAccFormConfig_MultipleStep2(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "4"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "TEXTBLOB",
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"content":        "<h2>Sign On</h2><hr>",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "ERROR_DISPLAY",
-				"position.row":   "1",
-				"position.col":   "0",
-				"position.width": "",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":            "TEXT",
-				"position.row":    "2",
-				"position.col":    "0",
-				"position.width":  "",
-				"key":             "user.username",
-				"label":           "[{\"children\":[{\"text\":\"\"},{\"children\":[{\"text\":\"\"}],\"defaultTranslation\":\"Username\",\"inline\":true,\"key\":\"fields.user.username.label\",\"type\":\"i18n\"},{\"text\":\"\"}],\"type\":\"paragraph\"}]",
-				"required":        "true",
-				"validation.type": "NONE",
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"type":           "SUBMIT_BUTTON",
-				"position.row":   "3",
-				"position.col":   "0",
-				"position.width": "",
-				"label":          "[{\"children\":[{\"text\":\"\"},{\"children\":[{\"text\":\"\"}],\"defaultTranslation\":\"Sign On\",\"inline\":true,\"key\":\"button.text.signOn\",\"type\":\"i18n\"},{\"text\":\"\"}],\"type\":\"paragraph\"}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "ERROR_DISPLAY"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.type", "TEXT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.row", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.key", "user.username"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.label", "[{\"children\":[{\"text\":\"\"},{\"children\":[{\"text\":\"\"}],\"defaultTranslation\":\"Username\",\"inline\":true,\"key\":\"fields.user.username.label\",\"type\":\"i18n\"},{\"text\":\"\"}],\"type\":\"paragraph\"}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.validation.type", "NONE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.type", "SLATE_TEXTBLOB"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.2.content", "[{\"children\":[{\"text\":\"Sign On\"}],\"type\":\"heading-1\"},{\"children\":[{\"text\":\"\"}],\"type\":\"divider\"},{\"children\":[{\"text\":\"\"}],\"type\":\"paragraph\"}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.type", "SUBMIT_BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.position.row", "3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.3.label", "[{\"children\":[{\"text\":\"\"},{\"children\":[{\"text\":\"\"}],\"defaultTranslation\":\"Sign On\",\"inline\":true,\"key\":\"button.text.signOn\",\"type\":\"i18n\"},{\"text\":\"\"}],\"type\":\"paragraph\"}]"),
 		),
 	}
 
@@ -376,26 +334,24 @@ func TestAccForm_FieldCheckbox(t *testing.T) {
 		Config: testAccFormConfig_FieldCheckboxFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "50",
-				"type":                            "CHECKBOX",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"label_mode":                      "FLOAT",
-				"layout":                          "VERTICAL",
-				"key":                             fmt.Sprintf("user.%s", name),
-				"required":                        "true",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option2",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]",
-				"options.2.value":                 "Option3",
-				"options.2.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "CHECKBOX"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_mode", "FLOAT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "VERTICAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", fmt.Sprintf("user.%s", name)),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -403,23 +359,20 @@ func TestAccForm_FieldCheckbox(t *testing.T) {
 		Config: testAccFormConfig_FieldCheckboxMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "",
-				"type":                            "CHECKBOX",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-				"key":                             "checkbox-field",
-				"layout":                          "HORIZONTAL",
-				"required":                        "false",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option3",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "CHECKBOX"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "checkbox-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "HORIZONTAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -485,26 +438,24 @@ func TestAccForm_FieldCombobox(t *testing.T) {
 		Config: testAccFormConfig_FieldComboboxFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "50",
-				"type":                            "COMBOBOX",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"label_mode":                      "FLOAT",
-				"layout":                          "VERTICAL",
-				"key":                             "user.locale",
-				"required":                        "true",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option2",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]",
-				"options.2.value":                 "Option3",
-				"options.2.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "COMBOBOX"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_mode", "FLOAT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "VERTICAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "user.locale"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -512,22 +463,19 @@ func TestAccForm_FieldCombobox(t *testing.T) {
 		Config: testAccFormConfig_FieldComboboxMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "",
-				"type":                            "COMBOBOX",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-				"key":                             "combobox-field",
-				"required":                        "false",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option3",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "COMBOBOX"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "combobox-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -593,26 +541,24 @@ func TestAccForm_FieldDropdown(t *testing.T) {
 		Config: testAccFormConfig_FieldDropdownFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "50",
-				"type":                            "DROPDOWN",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"label_mode":                      "FLOAT",
-				"layout":                          "VERTICAL",
-				"key":                             "user.locale",
-				"required":                        "true",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option2",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]",
-				"options.2.value":                 "Option3",
-				"options.2.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "DROPDOWN"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_mode", "FLOAT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "VERTICAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "user.locale"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -620,22 +566,19 @@ func TestAccForm_FieldDropdown(t *testing.T) {
 		Config: testAccFormConfig_FieldDropdownMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "",
-				"type":                            "DROPDOWN",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-				"key":                             "dropdown-field",
-				"required":                        "false",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option3",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "DROPDOWN"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "dropdown-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -701,22 +644,20 @@ func TestAccForm_FieldPassword(t *testing.T) {
 		Config: testAccFormConfig_FieldPasswordFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "50",
-				"type":                            "PASSWORD",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.label\",\"defaultTranslation\":\"Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"label_mode":                      "FLOAT",
-				"layout":                          "VERTICAL",
-				"key":                             "user.password",
-				"required":                        "true",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"show_password_requirements":      "true",
-				"validation.type":                 "NONE",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "PASSWORD"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.label\",\"defaultTranslation\":\"Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_mode", "FLOAT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "VERTICAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "user.password"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.show_password_requirements", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.validation.type", "NONE"),
 		),
 	}
 
@@ -724,19 +665,16 @@ func TestAccForm_FieldPassword(t *testing.T) {
 		Config: testAccFormConfig_FieldPasswordMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "",
-				"type":                            "PASSWORD",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-				"key":                             "password-field",
-				"required":                        "false",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"show_password_requirements":      "false",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "PASSWORD"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "password-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.show_password_requirements", "false"),
 		),
 	}
 
@@ -806,23 +744,21 @@ func TestAccForm_FieldPasswordVerify(t *testing.T) {
 		Config: testAccFormConfig_FieldPasswordVerifyFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "50",
-				"type":                            "PASSWORD_VERIFY",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.label\",\"defaultTranslation\":\"Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"label_mode":                      "FLOAT",
-				"label_password_verify":           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.labelPasswordVerify\",\"defaultTranslation\":\"Verify Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"layout":                          "VERTICAL",
-				"key":                             "user.password",
-				"required":                        "true",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"show_password_requirements":      "true",
-				"validation.type":                 "NONE",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "PASSWORD_VERIFY"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.label\",\"defaultTranslation\":\"Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_mode", "FLOAT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_password_verify", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.password.labelPasswordVerify\",\"defaultTranslation\":\"Verify Password\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "VERTICAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "user.password"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.show_password_requirements", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.validation.type", "NONE"),
 		),
 	}
 
@@ -830,19 +766,16 @@ func TestAccForm_FieldPasswordVerify(t *testing.T) {
 		Config: testAccFormConfig_FieldPasswordVerifyMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "",
-				"type":                            "PASSWORD_VERIFY",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-				"key":                             "password-field",
-				"required":                        "false",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"show_password_requirements":      "false",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "PASSWORD_VERIFY"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "password-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.show_password_requirements", "false"),
 		),
 	}
 
@@ -912,26 +845,24 @@ func TestAccForm_FieldRadio(t *testing.T) {
 		Config: testAccFormConfig_FieldRadioFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "50",
-				"type":                            "RADIO",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"label_mode":                      "FLOAT",
-				"layout":                          "VERTICAL",
-				"key":                             "user.locale",
-				"required":                        "true",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option2",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]",
-				"options.2.value":                 "Option3",
-				"options.2.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "RADIO"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.locale.label\",\"defaultTranslation\":\"Locale\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_mode", "FLOAT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "VERTICAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "user.locale"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 2\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.2.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -939,23 +870,20 @@ func TestAccForm_FieldRadio(t *testing.T) {
 		Config: testAccFormConfig_FieldRadioMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "",
-				"type":                            "RADIO",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-				"key":                             "radio-field",
-				"layout":                          "HORIZONTAL",
-				"required":                        "false",
-				"attribute_disabled":              "false",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-				"options.0.value":                 "Option1",
-				"options.0.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]",
-				"options.1.value":                 "Option3",
-				"options.1.label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "RADIO"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "radio-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "HORIZONTAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.value", "Option1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 1\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.value", "Option3"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.options.1.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Option 3\"}]}]"),
 		),
 	}
 
@@ -1021,25 +949,23 @@ func TestAccForm_FieldSubmitButton(t *testing.T) {
 		Config: testAccFormConfig_FieldSubmitButtonFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "1"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":            "0",
-				"position.col":            "0",
-				"position.width":          "50",
-				"type":                    "SUBMIT_BUTTON",
-				"label":                   "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"styles.width":            "25",
-				"styles.width_unit":       "PERCENT",
-				"styles.height":           "36",
-				"styles.padding.top":      "10",
-				"styles.padding.right":    "12",
-				"styles.padding.bottom":   "14",
-				"styles.padding.left":     "16",
-				"styles.alignment":        "RIGHT",
-				"styles.background_color": "#FF0000",
-				"styles.text_color":       "#00FF00",
-				"styles.border_color":     "#0000FF",
-				"styles.enabled":          "true",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "SUBMIT_BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.width", "25"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.width_unit", "PERCENT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.height", "36"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.top", "10"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.right", "12"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.bottom", "14"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.left", "16"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.alignment", "RIGHT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.background_color", "#FF0000"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.text_color", "#00FF00"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.border_color", "#0000FF"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.enabled", "true"),
 		),
 	}
 
@@ -1047,13 +973,10 @@ func TestAccForm_FieldSubmitButton(t *testing.T) {
 		Config: testAccFormConfig_FieldSubmitButtonMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "1"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"type":           "SUBMIT_BUTTON",
-				"label":          "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "SUBMIT_BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
 		),
 	}
 
@@ -1119,23 +1042,21 @@ func TestAccForm_FieldText(t *testing.T) {
 		Config: testAccFormConfig_FieldTextFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "50",
-				"type":                            "TEXT",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.username.label\",\"defaultTranslation\":\"Username\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"label_mode":                      "FLOAT",
-				"layout":                          "VERTICAL",
-				"key":                             "user.username",
-				"required":                        "true",
-				"attribute_disabled":              "false",
-				"validation.type":                 "CUSTOM",
-				"validation.regex":                "[a-zA-Z0-9]+",
-				"validation.error_message":        "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "TEXT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.username.label\",\"defaultTranslation\":\"Username\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label_mode", "FLOAT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.layout", "VERTICAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "user.username"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.validation.type", "CUSTOM"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.validation.regex", "[a-zA-Z0-9]+"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.validation.error_message", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Must be alphanumeric\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
 		),
 	}
 
@@ -1143,19 +1064,16 @@ func TestAccForm_FieldText(t *testing.T) {
 		Config: testAccFormConfig_FieldTextMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":                    "0",
-				"position.col":                    "0",
-				"position.width":                  "",
-				"type":                            "TEXT",
-				"label":                           "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-				"key":                             "text-field",
-				"required":                        "false",
-				"attribute_disabled":              "false",
-				"validation.type":                 "NONE",
-				"other_option_enabled":            "false",
-				"other_option_attribute_disabled": "false",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "TEXT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "text-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.required", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.attribute_disabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.validation.type", "NONE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_enabled", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.other_option_attribute_disabled", "false"),
 		),
 	}
 
@@ -1221,12 +1139,10 @@ func TestAccForm_ItemDivider(t *testing.T) {
 		Config: testAccFormConfig_ItemDividerFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "50",
-				"type":           "DIVIDER",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "DIVIDER"),
 		),
 	}
 
@@ -1234,12 +1150,9 @@ func TestAccForm_ItemDivider(t *testing.T) {
 		Config: testAccFormConfig_ItemDividerMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"type":           "DIVIDER",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "DIVIDER"),
 		),
 	}
 
@@ -1301,12 +1214,10 @@ func TestAccForm_ItemEmptyField(t *testing.T) {
 		Config: testAccFormConfig_ItemEmptyFieldFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "3"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "1",
-				"position.width": "50",
-				"type":           "EMPTY_FIELD",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.col", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.type", "EMPTY_FIELD"),
 		),
 	}
 
@@ -1314,11 +1225,9 @@ func TestAccForm_ItemEmptyField(t *testing.T) {
 		Config: testAccFormConfig_ItemEmptyFieldMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "3"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row": "0",
-				"position.col": "1",
-				"type":         "EMPTY_FIELD",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.position.col", "1"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.1.type", "EMPTY_FIELD"),
 		),
 	}
 
@@ -1380,12 +1289,10 @@ func TestAccForm_ItemErrorDisplay(t *testing.T) {
 		Config: testAccFormConfig_ItemErrorDisplayFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "50",
-				"type":           "ERROR_DISPLAY",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "ERROR_DISPLAY"),
 		),
 	}
 
@@ -1393,12 +1300,9 @@ func TestAccForm_ItemErrorDisplay(t *testing.T) {
 		Config: testAccFormConfig_ItemErrorDisplayMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"type":           "ERROR_DISPLAY",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "ERROR_DISPLAY"),
 		),
 	}
 
@@ -1460,26 +1364,24 @@ func TestAccForm_ItemFlowButton(t *testing.T) {
 		Config: testAccFormConfig_ItemFlowButtonFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":            "0",
-				"position.col":            "0",
-				"position.width":          "50",
-				"type":                    "FLOW_BUTTON",
-				"key":                     "button-field-full",
-				"label":                   "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"styles.width":            "25",
-				"styles.width_unit":       "PERCENT",
-				"styles.height":           "36",
-				"styles.padding.top":      "10",
-				"styles.padding.right":    "12",
-				"styles.padding.bottom":   "14",
-				"styles.padding.left":     "16",
-				"styles.alignment":        "RIGHT",
-				"styles.background_color": "#FF0000",
-				"styles.text_color":       "#00FF00",
-				"styles.border_color":     "#0000FF",
-				"styles.enabled":          "true",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "FLOW_BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "button-field-full"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.width", "25"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.width_unit", "PERCENT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.height", "36"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.top", "10"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.right", "12"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.bottom", "14"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.left", "16"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.alignment", "RIGHT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.background_color", "#FF0000"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.text_color", "#00FF00"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.border_color", "#0000FF"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.enabled", "true"),
 		),
 	}
 
@@ -1487,14 +1389,11 @@ func TestAccForm_ItemFlowButton(t *testing.T) {
 		Config: testAccFormConfig_ItemFlowButtonMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"type":           "FLOW_BUTTON",
-				"key":            "button-field",
-				"label":          "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "FLOW_BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "button-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
 		),
 	}
 
@@ -1560,21 +1459,19 @@ func TestAccForm_ItemFlowLink(t *testing.T) {
 		Config: testAccFormConfig_ItemFlowLinkFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":          "0",
-				"position.col":          "0",
-				"position.width":        "50",
-				"type":                  "FLOW_LINK",
-				"key":                   "link-field-full",
-				"label":                 "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]",
-				"styles.padding.top":    "10",
-				"styles.padding.right":  "12",
-				"styles.padding.bottom": "14",
-				"styles.padding.left":   "16",
-				"styles.alignment":      "RIGHT",
-				"styles.text_color":     "#00FF00",
-				"styles.enabled":        "true",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "FLOW_LINK"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "link-field-full"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.top", "10"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.right", "12"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.bottom", "14"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.padding.left", "16"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.alignment", "RIGHT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.text_color", "#00FF00"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.styles.enabled", "true"),
 		),
 	}
 
@@ -1582,14 +1479,11 @@ func TestAccForm_ItemFlowLink(t *testing.T) {
 		Config: testAccFormConfig_ItemFlowLinkMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"type":           "FLOW_LINK",
-				"key":            "link-field",
-				"label":          "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "FLOW_LINK"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "link-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Placeholder\"}]}]"),
 		),
 	}
 
@@ -1656,16 +1550,14 @@ func TestAccForm_ItemQRCode(t *testing.T) {
 		Config: testAccFormConfig_ItemQRCodeFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "50",
-				"type":           "QR_CODE",
-				"key":            "qr-code-field-full",
-				"qr_code_type":   "MFA_AUTH",
-				"show_border":    "true",
-				"alignment":      "RIGHT",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "QR_CODE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "qr-code-field-full"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.qr_code_type", "MFA_AUTH"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.show_border", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.alignment", "RIGHT"),
 		),
 	}
 
@@ -1673,16 +1565,13 @@ func TestAccForm_ItemQRCode(t *testing.T) {
 		Config: testAccFormConfig_ItemQRCodeMinimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"type":           "QR_CODE",
-				"key":            "qr-code-field",
-				"qr_code_type":   "MFA_AUTH",
-				"show_border":    "false",
-				"alignment":      "LEFT",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "QR_CODE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "qr-code-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.qr_code_type", "MFA_AUTH"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.show_border", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.alignment", "LEFT"),
 		),
 	}
 
@@ -1748,15 +1637,13 @@ func TestAccForm_ItemRecaptchaV2(t *testing.T) {
 		Config: testAccFormConfig_ItemRecaptchaV2Full(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "50",
-				"type":           "RECAPTCHA_V2",
-				"theme":          "LIGHT",
-				"size":           "NORMAL",
-				"alignment":      "RIGHT",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "RECAPTCHA_V2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.theme", "LIGHT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.size", "NORMAL"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.alignment", "RIGHT"),
 		),
 	}
 
@@ -1764,15 +1651,12 @@ func TestAccForm_ItemRecaptchaV2(t *testing.T) {
 		Config: testAccFormConfig_ItemRecaptchaV2Minimal(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "",
-				"type":           "RECAPTCHA_V2",
-				"theme":          "DARK",
-				"size":           "COMPACT",
-				"alignment":      "LEFT",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "RECAPTCHA_V2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.theme", "DARK"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.size", "COMPACT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.alignment", "LEFT"),
 		),
 	}
 
@@ -1838,13 +1722,11 @@ func TestAccForm_ItemSlateTextblob(t *testing.T) {
 		Config: testAccFormConfig_ItemSlateTextblobFull(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs(resourceFullName, "components.fields.*", map[string]string{
-				"position.row":   "0",
-				"position.col":   "0",
-				"position.width": "50",
-				"type":           "SLATE_TEXTBLOB",
-				"content":        "[{\"children\":[{\"text\":\"Two baguettes in a zoo cage, the sign says 'Bread in captivity'.\"}]}]",
-			}),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "SLATE_TEXTBLOB"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.content", "[{\"children\":[{\"text\":\"Two baguettes in a zoo cage, the sign says 'Bread in captivity'.\"}]}]"),
 		),
 	}
 
@@ -1909,6 +1791,7 @@ func TestAccForm_ItemSlateTextblob(t *testing.T) {
 	})
 }
 
+// Deprecated start
 func TestAccForm_ItemTextblob(t *testing.T) {
 	t.Parallel()
 
@@ -1989,6 +1872,8 @@ func TestAccForm_ItemTextblob(t *testing.T) {
 		},
 	})
 }
+
+// Deprecated end
 
 func TestAccForm_BadParameters(t *testing.T) {
 	t.Parallel()
@@ -2380,14 +2265,14 @@ resource "pingone_form" "%[2]s" {
         }
       },
       {
-        type = "TEXTBLOB"
+        type = "SLATE_TEXTBLOB"
 
         position = {
           row = 0
           col = 0
         }
 
-        content = "<h2>Sign On</h2><hr>"
+        content = jsonencode([{ "children" : [{ "text" : "Sign On" }], "type" : "heading-1" }, { "type" : "divider", "children" : [{ "text" : "" }] }, { "type" : "paragraph", "children" : [{ "text" : "" }] }])
       },
       {
         type = "SUBMIT_BUTTON"
@@ -2496,14 +2381,14 @@ resource "pingone_form" "%[2]s" {
         }
       },
       {
-        type = "TEXTBLOB"
+        type = "SLATE_TEXTBLOB"
 
         position = {
           row = 0
           col = 0
         }
 
-        content = "<h2>Sign On</h2><hr>"
+        content = jsonencode([{ "children" : [{ "text" : "Sign On" }], "type" : "heading-1" }, { "type" : "divider", "children" : [{ "text" : "" }] }, { "type" : "paragraph", "children" : [{ "text" : "" }] }])
       },
       {
         type = "SUBMIT_BUTTON"
@@ -4762,6 +4647,7 @@ resource "pingone_form" "%[2]s" {
 // }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 // }
 
+// Deprecated start
 func testAccFormConfig_ItemTextblobFull(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
@@ -4843,6 +4729,8 @@ resource "pingone_form" "%[2]s" {
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
+// Deprecated end
+
 func testAccFormConfig_NoSubmitButton(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
@@ -4860,13 +4748,19 @@ resource "pingone_form" "%[2]s" {
   components = {
     fields = [
       {
-        type = "TEXTBLOB"
-
+        attribute_disabled = false
+        key                = "user.username"
+        label              = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"fields.user.username.label\",\"defaultTranslation\":\"Enter your email address\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
         position = {
-          row = 0
           col = 0
+          row = 0
         }
-      }
+        required = true
+        type     = "TEXT"
+        validation = {
+          type = "NONE"
+        }
+      },
     ]
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)


### PR DESCRIPTION
### Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->

- `resource/pingone_form`: Deprecated the `TEXTBLOB` form field type. This field type will be removed in a future release.
- `resource/pingone_form`: Changed `components.fields` from unordered set to ordered list (resolves field arrangement issues in mobile SDKs)

### Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

N/a

<!--
- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 1200s -run ^TestAccForm_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccForm_RemovalDrift
=== PAUSE TestAccForm_RemovalDrift
=== RUN   TestAccForm_NewEnv
=== PAUSE TestAccForm_NewEnv
=== RUN   TestAccForm_Full
=== PAUSE TestAccForm_Full
=== RUN   TestAccForm_Multiple
=== PAUSE TestAccForm_Multiple
=== RUN   TestAccForm_FieldCheckbox
=== PAUSE TestAccForm_FieldCheckbox
=== RUN   TestAccForm_FieldCombobox
=== PAUSE TestAccForm_FieldCombobox
=== RUN   TestAccForm_FieldDropdown
=== PAUSE TestAccForm_FieldDropdown
=== RUN   TestAccForm_FieldPassword
=== PAUSE TestAccForm_FieldPassword
=== RUN   TestAccForm_FieldPasswordVerify
=== PAUSE TestAccForm_FieldPasswordVerify
=== RUN   TestAccForm_FieldRadio
=== PAUSE TestAccForm_FieldRadio
=== RUN   TestAccForm_FieldSubmitButton
=== PAUSE TestAccForm_FieldSubmitButton
=== RUN   TestAccForm_FieldText
=== PAUSE TestAccForm_FieldText
=== RUN   TestAccForm_ItemDivider
=== PAUSE TestAccForm_ItemDivider
=== RUN   TestAccForm_ItemEmptyField
=== PAUSE TestAccForm_ItemEmptyField
=== RUN   TestAccForm_ItemErrorDisplay
=== PAUSE TestAccForm_ItemErrorDisplay
=== RUN   TestAccForm_ItemFlowButton
=== PAUSE TestAccForm_ItemFlowButton
=== RUN   TestAccForm_ItemFlowLink
=== PAUSE TestAccForm_ItemFlowLink
=== RUN   TestAccForm_ItemQRCode
    resource_form_test.go:1541: Skipping test due to QR code functionality not being fully released in PingOne. Test should be re-enabled when QR code functionality is fully released.
--- SKIP: TestAccForm_ItemQRCode (0.00s)
=== RUN   TestAccForm_ItemRecaptchaV2
=== PAUSE TestAccForm_ItemRecaptchaV2
=== RUN   TestAccForm_ItemSlateTextblob
=== PAUSE TestAccForm_ItemSlateTextblob
=== RUN   TestAccForm_ItemTextblob
=== PAUSE TestAccForm_ItemTextblob
=== RUN   TestAccForm_BadParameters
=== PAUSE TestAccForm_BadParameters
=== CONT  TestAccForm_RemovalDrift
=== CONT  TestAccForm_FieldText
=== CONT  TestAccForm_FieldDropdown
=== CONT  TestAccForm_FieldRadio
=== CONT  TestAccForm_Multiple
=== CONT  TestAccForm_ItemFlowLink
=== CONT  TestAccForm_FieldCombobox
=== CONT  TestAccForm_BadParameters
=== CONT  TestAccForm_ItemTextblob
=== CONT  TestAccForm_ItemSlateTextblob
=== CONT  TestAccForm_FieldCheckbox
=== CONT  TestAccForm_ItemErrorDisplay
=== CONT  TestAccForm_ItemRecaptchaV2
=== CONT  TestAccForm_ItemFlowButton
=== CONT  TestAccForm_FieldPasswordVerify
=== CONT  TestAccForm_FieldSubmitButton
--- PASS: TestAccForm_BadParameters (20.40s)
=== CONT  TestAccForm_NewEnv
--- PASS: TestAccForm_ItemSlateTextblob (31.25s)
=== CONT  TestAccForm_ItemEmptyField
--- PASS: TestAccForm_Multiple (34.34s)
=== CONT  TestAccForm_ItemDivider
--- PASS: TestAccForm_FieldSubmitButton (58.98s)
=== CONT  TestAccForm_FieldPassword
--- PASS: TestAccForm_ItemTextblob (60.42s)
=== CONT  TestAccForm_Full
--- PASS: TestAccForm_ItemRecaptchaV2 (60.85s)
--- PASS: TestAccForm_ItemErrorDisplay (60.87s)
--- PASS: TestAccForm_FieldRadio (62.27s)
--- PASS: TestAccForm_FieldPasswordVerify (62.48s)
--- PASS: TestAccForm_ItemFlowLink (63.23s)
--- PASS: TestAccForm_FieldCombobox (63.50s)
--- PASS: TestAccForm_FieldDropdown (63.54s)
--- PASS: TestAccForm_ItemFlowButton (63.74s)
--- PASS: TestAccForm_FieldCheckbox (63.75s)
--- PASS: TestAccForm_FieldText (64.54s)
--- PASS: TestAccForm_NewEnv (47.43s)
--- PASS: TestAccForm_ItemEmptyField (46.38s)
--- PASS: TestAccForm_ItemDivider (43.94s)
--- PASS: TestAccForm_Full (30.90s)
--- PASS: TestAccForm_FieldPassword (32.34s)
--- PASS: TestAccForm_RemovalDrift (95.65s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base        97.271s
```

</details>