### PR TITLE
`resource/pingone_application`:  Add Validation for disallowing Catalog Applications type

### DIFF
--- a/.changelog/1061.txt
+++ b/.changelog/1061.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_application`: Added validation for `saml_options.type` to disallow `TEMPLATE_APP` used for Catalog Applications.
+```

--- a/.changelog/1061.txt
+++ b/.changelog/1061.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-`resource/pingone_application`: Added validation for `saml_options.type` to disallow `TEMPLATE_APP` used for Catalog Applications.
+`resource/pingone_application`: Added validation for `saml_options.type` to disallow `TEMPLATE_APP` used for Catalog Applications. See issue ([#1062](https://github.com/pingidentity/terraform-provider-pingone/issues/1062)) for details.
 ```


### PR DESCRIPTION
### Change Description
Added validation for `saml_options.type` to disallow `TEMPLATE_APP` used for Catalog Applications.

Required SDK Upgrades
N/A

Testing
N/a - no acceptance tests impacted