### PR TITLE
Temporarily skip tests that create prod environments

### DIFF
--- a/.github/workflows/acceptance-test-ff-multi-region.yml
+++ b/.github/workflows/acceptance-test-ff-multi-region.yml
@@ -50,7 +50,7 @@ jobs:
       PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_FF_LICENSE_ID }}
       PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_FF_ORGANIZATION_ID }}
 
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -54,7 +54,7 @@ jobs:
       PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_LICENSE_ID }}
       PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_ORGANIZATION_ID }}
 
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Check out code into the Go module directory

--- a/internal/service/base/data_source_license_test.go
+++ b/internal/service/base/data_source_license_test.go
@@ -69,7 +69,7 @@ func TestAccLicenseDataSource_ByIDFull(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceFullName, "environments.allow_custom_domain", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "environments.allow_custom_schema", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "environments.allow_production", "true"),
-					resource.TestCheckResourceAttr(dataSourceFullName, "environments.max", "50"),
+					resource.TestCheckResourceAttr(dataSourceFullName, "environments.max", "500"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "environments.regions.#", "4"),
 					resource.TestCheckTypeSetElemAttr(dataSourceFullName, "environments.regions.*", "EU"),
 					resource.TestCheckTypeSetElemAttr(dataSourceFullName, "environments.regions.*", "NORTH_AMERICA"),

--- a/internal/service/base/resource_environment_test.go
+++ b/internal/service/base/resource_environment_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -239,6 +240,12 @@ func TestAccEnvironment_NonCompatibleRegion(t *testing.T) {
 }
 
 func TestAccEnvironment_EnvironmentTypeSwitching(t *testing.T) {
+	// If it is before the week of the next release, skip this test
+	if time.Now().Before(time.Date(2025, time.June, 14, 0, 0, 0, 0, time.UTC)) {
+		t.Skipf("Skipping TestAccEnvironment_EnvironmentTypeSwitching as it requires creating a production environment")
+	} else {
+		t.Fatal("Remove skip logic from TestAccEnvironment_EnvironmentTypeSwitching")
+	}
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGenEnvironment()

--- a/internal/service/sso/resource_population_test.go
+++ b/internal/service/sso/resource_population_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -226,6 +227,12 @@ func TestAccPopulation_PasswordPolicy(t *testing.T) {
 }
 
 func TestAccPopulation_DataProtection(t *testing.T) {
+	// If it is before the week of the next release, skip this test
+	if time.Now().Before(time.Date(2025, time.June, 14, 0, 0, 0, 0, time.UTC)) {
+		t.Skipf("Skipping TestAccPopulation_DataProtection as it requires creating a production environment")
+	} else {
+		t.Fatal("Remove skip logic from TestAccPopulation_DataProtection")
+	}
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()


### PR DESCRIPTION
Skipped tests will start failing June 14th, to remind us to remove the skip

Affects `TestAccEnvironment_EnvironmentTypeSwitching` and `TestAccPopulation_DataProtection`