### PR TITLE
`resource/pingone_identity_provider_attribute`: Fixed `Invalid parameter value` error

### DIFF
--- a/.changelog/1073.txt
+++ b/.changelog/1073.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_identity_provider_attribute`: Fixed `Invalid parameter value - Unmappable identity provider type` error when deleting a `microsoft` identity provider type.
+```

--- a/internal/service/sso/resource_identity_provider_attribute.go
+++ b/internal/service/sso/resource_identity_provider_attribute.go
@@ -497,6 +497,8 @@ func (p *IdentityProviderAttributeResourceModel) getIdentityProviderType(ctx con
 		idpType = &respObject.IdentityProviderFacebook.Type
 	} else if respObject.IdentityProviderOIDC != nil && respObject.IdentityProviderOIDC.GetId() != "" {
 		idpType = &respObject.IdentityProviderOIDC.Type
+	} else if respObject.IdentityProviderMicrosoft != nil && respObject.IdentityProviderMicrosoft.GetId() != "" {
+		idpType = &respObject.IdentityProviderMicrosoft.Type
 	} else if respObject.IdentityProviderPaypal != nil && respObject.IdentityProviderPaypal.GetId() != "" {
 		idpType = &respObject.IdentityProviderPaypal.Type
 	} else if respObject.IdentityProviderSAML != nil && respObject.IdentityProviderSAML.GetId() != "" {

--- a/internal/service/sso/resource_identity_provider_attribute_test.go
+++ b/internal/service/sso/resource_identity_provider_attribute_test.go
@@ -118,10 +118,6 @@ func TestAccIdentityProviderAttribute_MicrosoftIdentityProvider(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mapping_type", "CORE"),
 				),
 			},
-			{
-				Config:  testAccIdentityProviderMicrosoftAttributeConfig(resourceName, name),
-				Destroy: true,
-			},
 		},
 	})
 }

--- a/internal/service/sso/resource_identity_provider_attribute_test.go
+++ b/internal/service/sso/resource_identity_provider_attribute_test.go
@@ -88,7 +88,7 @@ func TestAccIdentityProviderAttribute_RemovalDrift(t *testing.T) {
 	})
 }
 
-func TestAccIdentityProviderMicrosoftAttribute(t *testing.T) {
+func TestAccIdentityProviderAttribute_MicrosoftIdentityProvider(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()

--- a/internal/service/sso/resource_identity_provider_attribute_test.go
+++ b/internal/service/sso/resource_identity_provider_attribute_test.go
@@ -88,6 +88,44 @@ func TestAccIdentityProviderAttribute_RemovalDrift(t *testing.T) {
 	})
 }
 
+func TestAccIdentityProviderMicrosoftAttribute(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_identity_provider_attribute.%s", resourceName)
+
+	name := resourceName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoFeatureFlag(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             sso.IdentityProviderAttribute_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProviderMicrosoftAttributeConfig(resourceName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "identity_provider_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "name", "username"),
+					resource.TestCheckResourceAttr(resourceFullName, "update", "EMPTY_ONLY"),
+					resource.TestCheckResourceAttr(resourceFullName, "value", "${providerAttributes.email}"),
+					resource.TestCheckResourceAttr(resourceFullName, "mapping_type", "CORE"),
+				),
+			},
+			{
+				Config:  testAccIdentityProviderMicrosoftAttributeConfig(resourceName, name),
+				Destroy: true,
+			},
+		},
+	})
+}
+
 func TestAccIdentityProviderAttribute_Full(t *testing.T) {
 	t.Parallel()
 
@@ -435,6 +473,30 @@ resource "pingone_identity_provider_attribute" "%[2]s" {
 
   name  = "email"
   value = "$${providerAttributes.name.givenName}"
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccIdentityProviderMicrosoftAttributeConfig(resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_identity_provider" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  microsoft = {
+    client_id     = "testclientid"
+    client_secret = "testclientsecret"
+  }
+}
+
+resource "pingone_identity_provider_attribute" "%[2]s" {
+  environment_id       = data.pingone_environment.general_test.id
+  identity_provider_id = pingone_identity_provider.%[2]s.id
+
+  name  = "username"
+  value = "$${providerAttributes.email}"
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 


### PR DESCRIPTION
### Change Description
Fixed `Invalid parameter value - Unmappable identity provider type` error when deleting a `microsoft` identity provider attribute type.

### Required SDK Upgrades
N/A

### Testing Shell Command
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccIdentityProviderAttribute_MicrosoftIdentityProvider github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccIdentityProviderMicrosoftAttribute
=== PAUSE TestAccIdentityProviderMicrosoftAttribute
=== CONT  TestAccIdentityProviderMicrosoftAttribute
--- PASS: TestAccIdentityProviderMicrosoftAttribute (6.38s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/sso	6.946s
```

</details>