### PR TITLE
Fix population test failures

### DIFF
--- a/.changelog/1080.txt
+++ b/.changelog/1080.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_population`: Added wait on initial create to ensure `theme.id` is correctly assigned when creating a population in a brand new environment.
+```

--- a/.changelog/1080.txt
+++ b/.changelog/1080.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:bug
 `resource/pingone_population`: Added wait on initial create to ensure `theme.id` is correctly assigned when creating a population in a brand new environment.
 ```

--- a/internal/service/sso/data_source_population_test.go
+++ b/internal/service/sso/data_source_population_test.go
@@ -47,7 +47,7 @@ func TestAccPopulationDataSource_ByNameFull(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceFullName, "alternative_identifiers.#", "2"),
 					resource.TestCheckTypeSetElemAttr(dataSourceFullName, "alternative_identifiers.*", "identifier1"),
 					resource.TestCheckTypeSetElemAttr(dataSourceFullName, "alternative_identifiers.*", "identifier2"),
-					resource.TestCheckResourceAttr(dataSourceFullName, "preferred_language", "es"),
+					resource.TestCheckResourceAttr(dataSourceFullName, "preferred_language", "pl"),
 					resource.TestMatchResourceAttr(dataSourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
 			},
@@ -89,7 +89,7 @@ func TestAccPopulationDataSource_ByIDFull(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceFullName, "alternative_identifiers.#", "2"),
 					resource.TestCheckTypeSetElemAttr(dataSourceFullName, "alternative_identifiers.*", "identifier1"),
 					resource.TestCheckTypeSetElemAttr(dataSourceFullName, "alternative_identifiers.*", "identifier2"),
-					resource.TestCheckResourceAttr(dataSourceFullName, "preferred_language", "es"),
+					resource.TestCheckResourceAttr(dataSourceFullName, "preferred_language", "pt"),
 					resource.TestMatchResourceAttr(dataSourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
 			},
@@ -136,7 +136,7 @@ resource "pingone_password_policy" "%[2]s" {
 data "pingone_language" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
 
-  locale = "es"
+  locale = "pl"
 }
 
 resource "pingone_language_update" "%[2]s" {
@@ -193,7 +193,7 @@ resource "pingone_password_policy" "%[2]s" {
 data "pingone_language" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
 
-  locale = "es"
+  locale = "pt"
 }
 
 resource "pingone_language_update" "%[2]s" {

--- a/internal/service/sso/data_source_population_test.go
+++ b/internal/service/sso/data_source_population_test.go
@@ -4,6 +4,7 @@ package sso_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -19,13 +20,15 @@ func TestAccPopulationDataSource_ByNameFull(t *testing.T) {
 	resourceName := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_population.%s", resourceName)
 	dataSourceFullName := fmt.Sprintf("data.%s", resourceFullName)
-
+	environmentName := acctest.ResourceNameGenEnvironment()
 	name := resourceName
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheckNoTestAccFlaky(t)
 			acctest.PreCheckClient(t)
+			acctest.PreCheckNewEnvironment(t)
 			acctest.PreCheckNoFeatureFlag(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -33,7 +36,7 @@ func TestAccPopulationDataSource_ByNameFull(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPopulationDataSourceConfig_ByNameFull(resourceName, name),
+				Config: testAccPopulationDataSourceConfig_ByNameFull(environmentName, licenseID, resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(dataSourceFullName, "population_id", verify.P1ResourceIDRegexpFullString),
@@ -61,13 +64,15 @@ func TestAccPopulationDataSource_ByIDFull(t *testing.T) {
 	resourceName := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_population.%s", resourceName)
 	dataSourceFullName := fmt.Sprintf("data.%s", resourceFullName)
-
+	environmentName := acctest.ResourceNameGenEnvironment()
 	name := resourceName
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheckNoTestAccFlaky(t)
 			acctest.PreCheckClient(t)
+			acctest.PreCheckNewEnvironment(t)
 			acctest.PreCheckNoFeatureFlag(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -75,7 +80,7 @@ func TestAccPopulationDataSource_ByIDFull(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPopulationDataSourceConfig_ByIDFull(resourceName, name),
+				Config: testAccPopulationDataSourceConfig_ByIDFull(environmentName, licenseID, resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(dataSourceFullName, "population_id", verify.P1ResourceIDRegexpFullString),
@@ -124,30 +129,30 @@ func TestAccPopulationDataSource_NotFound(t *testing.T) {
 	})
 }
 
-func testAccPopulationDataSourceConfig_ByNameFull(resourceName, name string) string {
+func testAccPopulationDataSourceConfig_ByNameFull(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_password_policy" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
   name           = "%[3]s"
 }
 
 data "pingone_language" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   locale = "pl"
 }
 
 resource "pingone_language_update" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   language_id = data.pingone_language.%[2]s.id
   enabled     = true
 }
 
 resource "pingone_branding_theme" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   name     = "%[2]s"
   template = "split"
@@ -162,7 +167,7 @@ resource "pingone_branding_theme" "%[2]s" {
 }
 
 resource "pingone_population" "%[2]s-name" {
-  environment_id          = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
   name                    = "%[3]s"
   description             = "Test description"
   password_policy_id      = pingone_password_policy.%[2]s.id
@@ -174,37 +179,37 @@ resource "pingone_population" "%[2]s-name" {
 }
 
 data "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   name = pingone_population.%[2]s-name.name
 }
-`, acctest.GenericSandboxEnvironment(), resourceName, name)
+`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), resourceName, name, environmentName)
 }
 
-func testAccPopulationDataSourceConfig_ByIDFull(resourceName, name string) string {
+func testAccPopulationDataSourceConfig_ByIDFull(environmentName, licenseID, resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_password_policy" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
   name           = "%[3]s"
 }
 
 data "pingone_language" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   locale = "pt"
 }
 
 resource "pingone_language_update" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   language_id = data.pingone_language.%[2]s.id
   enabled     = true
 }
 
 resource "pingone_branding_theme" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   name     = "%[2]s"
   template = "split"
@@ -219,7 +224,7 @@ resource "pingone_branding_theme" "%[2]s" {
 }
 
 resource "pingone_population" "%[2]s-name" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
   name           = "%[3]s"
   description    = "Test description"
   password_policy = {
@@ -233,10 +238,10 @@ resource "pingone_population" "%[2]s-name" {
 }
 
 data "pingone_population" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
+  environment_id = pingone_environment.%[4]s.id
 
   population_id = pingone_population.%[2]s-name.id
-}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), resourceName, name, environmentName)
 }
 
 func testAccPopulationDataSourceConfig_NotFoundByName(resourceName string) string {

--- a/internal/service/sso/data_source_population_test.go
+++ b/internal/service/sso/data_source_population_test.go
@@ -167,7 +167,7 @@ resource "pingone_branding_theme" "%[2]s" {
 }
 
 resource "pingone_population" "%[2]s-name" {
-  environment_id = pingone_environment.%[4]s.id
+  environment_id          = pingone_environment.%[4]s.id
   name                    = "%[3]s"
   description             = "Test description"
   password_policy_id      = pingone_password_policy.%[2]s.id

--- a/internal/service/sso/resource_population.go
+++ b/internal/service/sso/resource_population.go
@@ -22,6 +22,7 @@ import (
 
 // Sometimes the default theme for a brand-new environment takes a few moments to be assigned.
 // We'll wait for new populations to have a theme id set before returning from the resource Create method.
+// If the theme id is not set after the timeout, a warning is returned.
 func populationWaitForAssignedThemeId(ctx context.Context, client *pingone.Client, envId, populationId string) (*management.Population, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	stateConf := &retry.StateChangeConf{
@@ -65,8 +66,8 @@ func populationWaitForAssignedThemeId(ctx context.Context, client *pingone.Clien
 	}
 	responseData, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		diags.AddError(
-			"Could not find population theme ID",
+		diags.AddWarning(
+			"Population theme ID not assigned",
 			fmt.Sprintf("Expected to find theme id for population %s, got error: %s", populationId, err.Error()))
 	}
 	var returnValue *management.Population

--- a/internal/service/sso/resource_population.go
+++ b/internal/service/sso/resource_population.go
@@ -66,7 +66,7 @@ func populationWaitForAssignedThemeId(ctx context.Context, client *pingone.Clien
 	}
 	responseData, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		diags.AddWarning(
+		diags.AddError(
 			"Population theme ID not assigned",
 			fmt.Sprintf("Expected to find theme id for population %s, got error: %s", populationId, err.Error()))
 	}

--- a/internal/service/sso/resource_population.go
+++ b/internal/service/sso/resource_population.go
@@ -4,17 +4,73 @@ package sso
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/patrickcping/pingone-go-sdk-v2/management"
+	"github.com/patrickcping/pingone-go-sdk-v2/pingone"
 	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
 	"github.com/pingidentity/terraform-provider-pingone/internal/verify"
 )
+
+// Sometimes the default theme for a brand-new environment takes a few moments to be assigned.
+// We'll wait for new populations to have a theme id set before returning from the resource Create method.
+func populationWaitForAssignedThemeId(ctx context.Context, client *pingone.Client, envId, populationId string) (*management.Population, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{
+			"false",
+		},
+		Target: []string{
+			"true",
+			"err",
+		},
+		Refresh: func() (interface{}, string, error) {
+			var responseData *management.Population
+			diags.Append(framework.ParseResponse(
+				ctx,
+
+				func() (any, *http.Response, error) {
+					fO, fR, fErr := client.ManagementAPIClient.PopulationsApi.ReadOnePopulation(ctx, envId, populationId).Execute()
+					return framework.CheckEnvironmentExistsOnPermissionsError(ctx, client.ManagementAPIClient, envId, fO, fR, fErr)
+				},
+				"WaitForPopulationThemeId",
+				framework.DefaultCustomError,
+				sdk.DefaultCreateReadRetryable,
+				&responseData,
+			)...)
+			if diags.HasError() {
+				return nil, "err", errors.New("Error reading population when checking for theme ID")
+			}
+
+			// Theme id hasn't yet been assigned
+			if responseData.Theme == nil || responseData.Theme.Id == nil {
+				return nil, "false", nil
+			}
+
+			return responseData, "true", nil
+		},
+		// Align with SDK wait time for environment 404s on creation
+		Timeout:                   17 * time.Second,
+		Delay:                     1 * time.Second,
+		MinTimeout:                1 * time.Second,
+		ContinuousTargetOccurence: 1,
+	}
+	responseData, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		diags.AddError(
+			"Could not find population theme ID",
+			fmt.Sprintf("Expected to find theme id for population %s, got error: %s", populationId, err.Error()))
+	}
+	return responseData.(*management.Population), diags
+}
 
 func populationDeleteCustomErrorHandler(r *http.Response, p1Error *model.P1Error) diag.Diagnostics {
 	var diags diag.Diagnostics

--- a/internal/service/sso/resource_population.go
+++ b/internal/service/sso/resource_population.go
@@ -69,7 +69,11 @@ func populationWaitForAssignedThemeId(ctx context.Context, client *pingone.Clien
 			"Could not find population theme ID",
 			fmt.Sprintf("Expected to find theme id for population %s, got error: %s", populationId, err.Error()))
 	}
-	return responseData.(*management.Population), diags
+	var returnValue *management.Population
+	if responseData != nil {
+		returnValue = responseData.(*management.Population)
+	}
+	return returnValue, diags
 }
 
 func populationDeleteCustomErrorHandler(r *http.Response, p1Error *model.P1Error) diag.Diagnostics {

--- a/internal/service/sso/resource_population_default.go
+++ b/internal/service/sso/resource_population_default.go
@@ -176,8 +176,11 @@ func (r *PopulationDefaultResource) Create(ctx context.Context, req resource.Cre
 		}
 
 		if response.Theme == nil || response.Theme.Id == nil {
-			response, d = populationWaitForAssignedThemeId(ctx, r.Client, plan.EnvironmentId.ValueString(), *response.Id)
+			responseWithTheme, d := populationWaitForAssignedThemeId(ctx, r.Client, plan.EnvironmentId.ValueString(), *response.Id)
 			resp.Diagnostics.Append(d...)
+			if responseWithTheme != nil {
+				response = responseWithTheme
+			}
 		}
 	} else {
 		resp.Diagnostics.Append(framework.ParseResponse(

--- a/internal/service/sso/resource_population_default.go
+++ b/internal/service/sso/resource_population_default.go
@@ -171,6 +171,14 @@ func (r *PopulationDefaultResource) Create(ctx context.Context, req resource.Cre
 			sdk.DefaultCreateReadRetryable,
 			&response,
 		)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if response.Theme == nil || response.Theme.Id == nil {
+			response, d = populationWaitForAssignedThemeId(ctx, r.Client, plan.EnvironmentId.ValueString(), *response.Id)
+			resp.Diagnostics.Append(d...)
+		}
 	} else {
 		resp.Diagnostics.Append(framework.ParseResponse(
 			ctx,

--- a/internal/service/sso/resource_population_default.go
+++ b/internal/service/sso/resource_population_default.go
@@ -174,14 +174,6 @@ func (r *PopulationDefaultResource) Create(ctx context.Context, req resource.Cre
 		if resp.Diagnostics.HasError() {
 			return
 		}
-
-		if response.Theme == nil || response.Theme.Id == nil {
-			responseWithTheme, d := populationWaitForAssignedThemeId(ctx, r.Client, plan.EnvironmentId.ValueString(), *response.Id)
-			resp.Diagnostics.Append(d...)
-			if responseWithTheme != nil {
-				response = responseWithTheme
-			}
-		}
 	} else {
 		resp.Diagnostics.Append(framework.ParseResponse(
 			ctx,

--- a/internal/service/sso/resource_population_default.go
+++ b/internal/service/sso/resource_population_default.go
@@ -171,9 +171,6 @@ func (r *PopulationDefaultResource) Create(ctx context.Context, req resource.Cre
 			sdk.DefaultCreateReadRetryable,
 			&response,
 		)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	} else {
 		resp.Diagnostics.Append(framework.ParseResponse(
 			ctx,

--- a/internal/service/sso/resource_population_gen.go
+++ b/internal/service/sso/resource_population_gen.go
@@ -303,10 +303,10 @@ func (r *populationResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	if responseData.Theme == nil || responseData.Theme.Id == nil {
-		responseData, diags = populationWaitForAssignedThemeId(ctx, r.Client, data.EnvironmentId.ValueString(), *responseData.Id)
+		responseWithTheme, diags := populationWaitForAssignedThemeId(ctx, r.Client, data.EnvironmentId.ValueString(), *responseData.Id)
 		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
+		if responseWithTheme != nil {
+			responseData = responseWithTheme
 		}
 	}
 

--- a/internal/service/sso/resource_population_gen.go
+++ b/internal/service/sso/resource_population_gen.go
@@ -305,6 +305,9 @@ func (r *populationResource) Create(ctx context.Context, req resource.CreateRequ
 	if responseData.Theme == nil || responseData.Theme.Id == nil {
 		responseWithTheme, diags := populationWaitForAssignedThemeId(ctx, r.Client, data.EnvironmentId.ValueString(), *responseData.Id)
 		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		if responseWithTheme != nil {
 			responseData = responseWithTheme
 		}

--- a/internal/service/sso/resource_population_gen.go
+++ b/internal/service/sso/resource_population_gen.go
@@ -302,6 +302,14 @@ func (r *populationResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	if responseData.Theme == nil || responseData.Theme.Id == nil {
+		responseData, diags = populationWaitForAssignedThemeId(ctx, r.Client, data.EnvironmentId.ValueString(), *responseData.Id)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	// Read response into the model
 	resp.Diagnostics.Append(data.readClientResponse(responseData)...)
 

--- a/internal/service/sso/resource_population_test.go
+++ b/internal/service/sso/resource_population_test.go
@@ -105,6 +105,7 @@ func TestAccPopulation_NewEnv(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "preferred_language", "en"),
+					resource.TestMatchResourceAttr(resourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 		},

--- a/internal/service/sso/resource_population_test.go
+++ b/internal/service/sso/resource_population_test.go
@@ -105,7 +105,6 @@ func TestAccPopulation_NewEnv(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "preferred_language", "en"),
-					resource.TestMatchResourceAttr(resourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 		},


### PR DESCRIPTION
Fix `TestAccPopulationDataSource_ByNameFull` failing due to parallel tests enabling and disabling the preferred language simultaneously.

Fix `TestAccPopulation_NewEnv` by removing `theme.id` check that failed due to eventual consistency issues.

```
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccPopulation github.com/pingidentity/terraform-provider-pingone/internal/service/sso
=== RUN   TestAccPopulationDataSource_ByNameFull
=== PAUSE TestAccPopulationDataSource_ByNameFull
=== RUN   TestAccPopulationDataSource_ByIDFull
=== PAUSE TestAccPopulationDataSource_ByIDFull
=== RUN   TestAccPopulationDataSource_NotFound
=== PAUSE TestAccPopulationDataSource_NotFound
=== RUN   TestAccPopulationsDataSource_BySCIMFilter
=== PAUSE TestAccPopulationsDataSource_BySCIMFilter
=== RUN   TestAccPopulationsDataSource_ByDataFilters
=== PAUSE TestAccPopulationsDataSource_ByDataFilters
=== RUN   TestAccPopulationsDataSource_NotFound
=== PAUSE TestAccPopulationsDataSource_NotFound
=== RUN   TestAccPopulationDefaultIdp_RemovalDrift
=== PAUSE TestAccPopulationDefaultIdp_RemovalDrift
=== RUN   TestAccPopulationDefaultIdp_Full
=== PAUSE TestAccPopulationDefaultIdp_Full
=== RUN   TestAccPopulationDefaultIdp_BadParameters
=== PAUSE TestAccPopulationDefaultIdp_BadParameters
=== RUN   TestAccPopulationDefault_RemovalDrift
=== PAUSE TestAccPopulationDefault_RemovalDrift
=== RUN   TestAccPopulationDefault_Full
=== PAUSE TestAccPopulationDefault_Full
=== RUN   TestAccPopulationDefault_Minimal
=== PAUSE TestAccPopulationDefault_Minimal
=== RUN   TestAccPopulationDefault_BadParameters
=== PAUSE TestAccPopulationDefault_BadParameters
=== RUN   TestAccPopulation_RemovalDrift
=== PAUSE TestAccPopulation_RemovalDrift
=== RUN   TestAccPopulation_NewEnv
=== PAUSE TestAccPopulation_NewEnv
=== RUN   TestAccPopulation_Full
=== PAUSE TestAccPopulation_Full
=== RUN   TestAccPopulation_Minimal
=== PAUSE TestAccPopulation_Minimal
=== RUN   TestAccPopulation_PasswordPolicy
=== PAUSE TestAccPopulation_PasswordPolicy
=== RUN   TestAccPopulation_DataProtection
=== PAUSE TestAccPopulation_DataProtection
=== RUN   TestAccPopulation_BadParameters
=== PAUSE TestAccPopulation_BadParameters
=== CONT  TestAccPopulationDataSource_ByNameFull
=== CONT  TestAccPopulation_RemovalDrift
=== CONT  TestAccPopulation_PasswordPolicy
=== CONT  TestAccPopulation_Full
=== CONT  TestAccPopulation_BadParameters
=== CONT  TestAccPopulation_NewEnv
=== CONT  TestAccPopulationDefault_BadParameters
=== CONT  TestAccPopulationDefault_Minimal
=== CONT  TestAccPopulation_DataProtection
=== CONT  TestAccPopulationDefault_Full
=== CONT  TestAccPopulation_Minimal
=== CONT  TestAccPopulationsDataSource_NotFound
=== CONT  TestAccPopulationDefault_RemovalDrift
=== CONT  TestAccPopulationDefaultIdp_BadParameters
=== CONT  TestAccPopulationDefaultIdp_Full
=== CONT  TestAccPopulationDefaultIdp_RemovalDrift
--- PASS: TestAccPopulationsDataSource_NotFound (2.79s)
=== CONT  TestAccPopulationsDataSource_BySCIMFilter
--- PASS: TestAccPopulation_Minimal (3.33s)
=== CONT  TestAccPopulationsDataSource_ByDataFilters
--- PASS: TestAccPopulation_BadParameters (4.86s)
=== CONT  TestAccPopulationDataSource_NotFound
--- PASS: TestAccPopulationDefaultIdp_BadParameters (5.51s)
=== CONT  TestAccPopulationDataSource_ByIDFull
--- PASS: TestAccPopulationDataSource_ByNameFull (6.00s)
--- PASS: TestAccPopulationDataSource_NotFound (1.21s)
--- PASS: TestAccPopulation_Full (6.18s)
--- PASS: TestAccPopulationsDataSource_BySCIMFilter (3.67s)
--- PASS: TestAccPopulation_PasswordPolicy (7.24s)
--- PASS: TestAccPopulationsDataSource_ByDataFilters (6.29s)
--- PASS: TestAccPopulationDataSource_ByIDFull (5.77s)
--- PASS: TestAccPopulation_DataProtection (12.14s)
--- PASS: TestAccPopulationDefaultIdp_Full (18.30s)
--- PASS: TestAccPopulationDefault_Minimal (39.36s)
--- PASS: TestAccPopulation_NewEnv (39.39s)
--- PASS: TestAccPopulationDefault_BadParameters (39.94s)
--- PASS: TestAccPopulationDefault_Full (42.48s)
--- PASS: TestAccPopulationDefault_RemovalDrift (66.18s)
--- PASS: TestAccPopulation_RemovalDrift (68.70s)
--- PASS: TestAccPopulationDefaultIdp_RemovalDrift (69.61s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/sso	70.381s
```