### PR TITLE
Randomize domain prefix to avoid test conflicts

### DIFF
--- a/internal/service/base/data_source_trusted_email_domain_dkim_test.go
+++ b/internal/service/base/data_source_trusted_email_domain_dkim_test.go
@@ -16,6 +16,7 @@ func TestAccTrustedEmailDomainDKIMDataSource_Full(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_trusted_email_domain_dkim.%s", resourceName)
 	dataSourceFullName := fmt.Sprintf("data.%s", resourceFullName)
 
@@ -34,7 +35,7 @@ func TestAccTrustedEmailDomainDKIMDataSource_Full(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrustedEmailDomainDKIMDataSourceConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccTrustedEmailDomainDKIMDataSourceConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceFullName, "type", "CNAME"),
 					resource.TestCheckResourceAttrWith(dataSourceFullName, "regions.#", validateRegionCardinality),
@@ -75,21 +76,21 @@ func TestAccTrustedEmailDomainDKIMDataSource_NotFound(t *testing.T) {
 	})
 }
 
-func testAccTrustedEmailDomainDKIMDataSourceConfig_Full(environmentName, licenseID, resourceName string) string {
+func testAccTrustedEmailDomainDKIMDataSourceConfig_Full(environmentName, licenseID, resourceName, domainPrefix string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "pingone_trusted_email_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "terraformdev.ping-eng.com"
+  domain_name = "%[4]s.terraformdev.ping-eng.com"
 }
 
 data "pingone_trusted_email_domain_dkim" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
   trusted_email_domain_id = pingone_trusted_email_domain.%[3]s.id
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, domainPrefix)
 }
 
 func testAccTrustedEmailDomainDKIMDataSourceConfig_NotFoundByID(resourceName string) string {

--- a/internal/service/base/data_source_trusted_email_domain_ownership_test.go
+++ b/internal/service/base/data_source_trusted_email_domain_ownership_test.go
@@ -17,6 +17,7 @@ func TestAccTrustedEmailDomainOwnershipDataSource_Full(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_trusted_email_domain_ownership.%s", resourceName)
 	dataSourceFullName := fmt.Sprintf("data.%s", resourceFullName)
 
@@ -35,7 +36,7 @@ func TestAccTrustedEmailDomainOwnershipDataSource_Full(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrustedEmailDomainOwnershipDataSourceConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccTrustedEmailDomainOwnershipDataSourceConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceFullName, "type", "TXT"),
 					resource.TestCheckResourceAttrWith(dataSourceFullName, "regions.#", validateRegionCardinality),
@@ -78,21 +79,21 @@ func TestAccTrustedEmailDomainOwnershipDataSource_NotFound(t *testing.T) {
 	})
 }
 
-func testAccTrustedEmailDomainOwnershipDataSourceConfig_Full(environmentName, licenseID, resourceName string) string {
+func testAccTrustedEmailDomainOwnershipDataSourceConfig_Full(environmentName, licenseID, resourceName, domainPrefix string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "pingone_trusted_email_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "terraformdev.ping-eng.com"
+  domain_name = "%[4]s.terraformdev.ping-eng.com"
 }
 
 data "pingone_trusted_email_domain_ownership" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
   trusted_email_domain_id = pingone_trusted_email_domain.%[3]s.id
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, domainPrefix)
 }
 
 func testAccTrustedEmailDomainOwnershipDataSourceConfig_NotFoundByID(resourceName string) string {

--- a/internal/service/base/data_source_trusted_email_domain_spf_test.go
+++ b/internal/service/base/data_source_trusted_email_domain_spf_test.go
@@ -16,6 +16,7 @@ func TestAccTrustedEmailDomainSPFDataSource_Full(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_trusted_email_domain_spf.%s", resourceName)
 	dataSourceFullName := fmt.Sprintf("data.%s", resourceFullName)
 
@@ -34,7 +35,7 @@ func TestAccTrustedEmailDomainSPFDataSource_Full(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrustedEmailDomainSPFDataSourceConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccTrustedEmailDomainSPFDataSourceConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceFullName, "type", "TXT"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "status", "VERIFICATION_REQUIRED"),
@@ -72,21 +73,21 @@ func TestAccTrustedEmailDomainSPFDataSource_NotFound(t *testing.T) {
 	})
 }
 
-func testAccTrustedEmailDomainSPFDataSourceConfig_Full(environmentName, licenseID, resourceName string) string {
+func testAccTrustedEmailDomainSPFDataSourceConfig_Full(environmentName, licenseID, resourceName, domainPrefix string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "pingone_trusted_email_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "terraformdev.ping-eng.com"
+  domain_name = "%[4]s.terraformdev.ping-eng.com"
 }
 
 data "pingone_trusted_email_domain_spf" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
   trusted_email_domain_id = pingone_trusted_email_domain.%[3]s.id
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, domainPrefix)
 }
 
 func testAccTrustedEmailDomainSPFDataSourceConfig_NotFoundByID(resourceName string) string {

--- a/internal/service/base/resource_custom_domain_ssl_test.go
+++ b/internal/service/base/resource_custom_domain_ssl_test.go
@@ -17,6 +17,7 @@ func TestAccCustomDomainSSL_Full(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 
 	environmentName := acctest.ResourceNameGenEnvironment()
 
@@ -39,21 +40,21 @@ func TestAccCustomDomainSSL_Full(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile),
+				Config:      testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile, domainPrefix),
 				ExpectError: regexp.MustCompile(`Cannot add SSL certificate settings to the custom domain - Custom domain status must be 'SSL_CERTIFICATE_REQUIRED' or 'ACTIVE' in order to import a certificate`),
 			},
 		},
 	})
 }
 
-func testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile string) string {
+func testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile, domainPrefix string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_custom_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "terraformdev.ping-eng.com"
+  domain_name = "%[7]s.terraformdev.ping-eng.com"
 }
 
 resource "pingone_custom_domain_ssl" "%[3]s" {
@@ -71,5 +72,5 @@ EOT
 %[6]s
 EOT
 
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, certificateFile, intermediateFile, privateKeyFile)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, certificateFile, intermediateFile, privateKeyFile, domainPrefix)
 }

--- a/internal/service/base/resource_custom_domain_test.go
+++ b/internal/service/base/resource_custom_domain_test.go
@@ -21,6 +21,7 @@ func TestAccCustomDomain_RemovalDrift(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_custom_domain.%s", resourceName)
 
 	environmentName := acctest.ResourceNameGenEnvironment()
@@ -47,7 +48,7 @@ func TestAccCustomDomain_RemovalDrift(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check:  base.CustomDomain_GetIDs(resourceFullName, &environmentID, &customDomainID),
 			},
 			{
@@ -59,7 +60,7 @@ func TestAccCustomDomain_RemovalDrift(t *testing.T) {
 			},
 			// Test removal of the environment
 			{
-				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check:  base.CustomDomain_GetIDs(resourceFullName, &environmentID, &customDomainID),
 			},
 			{
@@ -77,6 +78,7 @@ func TestAccCustomDomain_Full(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_custom_domain.%s", resourceName)
 
 	environmentName := acctest.ResourceNameGenEnvironment()
@@ -95,11 +97,11 @@ func TestAccCustomDomain_Full(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "domain_name", "terraformdev.ping-eng.com"),
+					resource.TestCheckResourceAttr(resourceFullName, "domain_name", fmt.Sprintf("%s.terraformdev.ping-eng.com", domainPrefix)),
 					resource.TestCheckResourceAttr(resourceFullName, "status", "VERIFICATION_REQUIRED"),
 					resource.TestMatchResourceAttr(resourceFullName, "canonical_name", regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.[0-9a-zA-Z]+\.pingone.[a-z]+\.$`)),
 					resource.TestCheckNoResourceAttr(resourceFullName, "certificate_expires_at"),
@@ -129,6 +131,7 @@ func TestAccCustomDomain_BadParameters(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_custom_domain.%s", resourceName)
 
 	environmentName := acctest.ResourceNameGenEnvironment()
@@ -148,7 +151,7 @@ func TestAccCustomDomain_BadParameters(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 			},
 			// Errors
 			{
@@ -172,13 +175,13 @@ func TestAccCustomDomain_BadParameters(t *testing.T) {
 	})
 }
 
-func testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName string) string {
+func testAccCustomDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_custom_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "terraformdev.ping-eng.com"
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+  domain_name = "%[4]s.terraformdev.ping-eng.com"
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, domainPrefix)
 }

--- a/internal/service/base/resource_trusted_email_address_test.go
+++ b/internal/service/base/resource_trusted_email_address_test.go
@@ -154,7 +154,8 @@ func TestAccTrustedEmailAddress_NotVerified(t *testing.T) {
 	environmentName := acctest.ResourceNameGenEnvironment()
 	licenseID := os.Getenv("PINGONE_LICENSE_ID")
 
-	unverifiedDomain := "terraformdev.ping-eng.com"
+	domainPrefix := acctest.ResourceNameGen()
+	unverifiedDomain := fmt.Sprintf("%s.terraformdev.ping-eng.com", domainPrefix)
 	unverifiedEmailAddress := fmt.Sprintf("noreply@%s", unverifiedDomain)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/base/resource_trusted_email_domain_test.go
+++ b/internal/service/base/resource_trusted_email_domain_test.go
@@ -21,6 +21,7 @@ func TestAccTrustedEmailDomain_RemovalDrift(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_trusted_email_domain.%s", resourceName)
 
 	environmentName := acctest.ResourceNameGenEnvironment()
@@ -47,7 +48,7 @@ func TestAccTrustedEmailDomain_RemovalDrift(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check:  base.TrustedEmailDomain_GetIDs(resourceFullName, &environmentID, &trustedEmailDomainID),
 			},
 			{
@@ -59,7 +60,7 @@ func TestAccTrustedEmailDomain_RemovalDrift(t *testing.T) {
 			},
 			// Test removal of the environment
 			{
-				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check:  base.TrustedEmailDomain_GetIDs(resourceFullName, &environmentID, &trustedEmailDomainID),
 			},
 			{
@@ -77,6 +78,7 @@ func TestAccTrustedEmailDomain_Full(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_trusted_email_domain.%s", resourceName)
 
 	environmentName := acctest.ResourceNameGenEnvironment()
@@ -95,11 +97,11 @@ func TestAccTrustedEmailDomain_Full(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttr(resourceFullName, "domain_name", "terraformdev.ping-eng.com"),
+					resource.TestCheckResourceAttr(resourceFullName, "domain_name", fmt.Sprintf("%s.terraformdev.ping-eng.com", domainPrefix)),
 				),
 			},
 			// Test importing the resource
@@ -125,6 +127,7 @@ func TestAccTrustedEmailDomain_BadParameters(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_trusted_email_domain.%s", resourceName)
 
 	environmentName := acctest.ResourceNameGenEnvironment()
@@ -144,7 +147,7 @@ func TestAccTrustedEmailDomain_BadParameters(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Configure
 			{
-				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName),
+				Config: testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix),
 			},
 			// Errors
 			{
@@ -168,13 +171,13 @@ func TestAccTrustedEmailDomain_BadParameters(t *testing.T) {
 	})
 }
 
-func testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName string) string {
+func testAccTrustedEmailDomainConfig_Full(environmentName, licenseID, resourceName, domainPrefix string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_trusted_email_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "terraformdev.ping-eng.com"
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+  domain_name = "%[4]s.terraformdev.ping-eng.com"
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, domainPrefix)
 }


### PR DESCRIPTION
### Change Description
Tests for pingone_custom_domain and pingone_trusted_email_domain will now add a randomized prefix to domain names, to avoid test conflicts. Environments do not permit having the same custom domain as another environment in the same tenant.

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccCustomDomain_ github.com/pingidentity/terraform-provider-pingone/internal/service/base -count=1
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccTrustedEmailDomain_ github.com/pingidentity/terraform-provider-pingone/internal/service/base -count=1
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
% TF_ACC=1 go test -v -timeout 3000s -run ^TestAccCustomDomain_ github.com/pingidentity/terraform-provider-pingone/internal/service/base -count=1
=== RUN   TestAccCustomDomain_RemovalDrift
=== PAUSE TestAccCustomDomain_RemovalDrift
=== RUN   TestAccCustomDomain_Full
=== PAUSE TestAccCustomDomain_Full
=== RUN   TestAccCustomDomain_BadParameters
=== PAUSE TestAccCustomDomain_BadParameters
=== CONT  TestAccCustomDomain_RemovalDrift
=== CONT  TestAccCustomDomain_Full
=== CONT  TestAccCustomDomain_BadParameters
--- PASS: TestAccCustomDomain_Full (40.74s)
--- PASS: TestAccCustomDomain_BadParameters (41.73s)
--- PASS: TestAccCustomDomain_RemovalDrift (79.87s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/base80.351s
% TF_ACC=1 go test -v -timeout 3000s -run ^TestAccTrustedEmailDomain_ github.com/pingidentity/terraform-provider-pingone/internal/service/base -count=1
=== RUN   TestAccTrustedEmailDomain_RemovalDrift
=== PAUSE TestAccTrustedEmailDomain_RemovalDrift
=== RUN   TestAccTrustedEmailDomain_Full
=== PAUSE TestAccTrustedEmailDomain_Full
=== RUN   TestAccTrustedEmailDomain_BadParameters
=== PAUSE TestAccTrustedEmailDomain_BadParameters
=== CONT  TestAccTrustedEmailDomain_RemovalDrift
=== CONT  TestAccTrustedEmailDomain_Full
=== CONT  TestAccTrustedEmailDomain_BadParameters
--- PASS: TestAccTrustedEmailDomain_Full (40.99s)
--- PASS: TestAccTrustedEmailDomain_BadParameters (41.91s)
--- PASS: TestAccTrustedEmailDomain_RemovalDrift (79.46s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/base79.866s
```

</details>