### PR TITLE
`resource/custom_domain_verify`: Allow use of already verified custom domain

### DIFF
--- a/.changelog/1085.txt
+++ b/.changelog/1085.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-`resource/custom_domain_verify`: Allow use of already verified custom domain
+`resource/pingone_custom_domain_verify`: Allow use of already verified custom domain
 ```

--- a/.changelog/1085.txt
+++ b/.changelog/1085.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/custom_domain_verify`: Allow use of already verified custom domain
+```

--- a/internal/service/base/resource_custom_domain_verify.go
+++ b/internal/service/base/resource_custom_domain_verify.go
@@ -180,11 +180,11 @@ func (r *CustomDomainVerifyResource) Create(ctx context.Context, req resource.Cr
 						return diags
 					}
 
-					m, _ = regexp.MatchString("^custom domain does not need to be verified$", details[0].GetMessage())
+					m, _ = regexp.MatchString("^custom domain does not need to be verified", details[0].GetMessage())
 					if m {
 						diags.AddWarning(
 							details[0].GetMessage(),
-							"This is expected if the custom domain has already been verified previously.",
+							"This is expected if the custom domain was verified previously.  The verification step has been skipped and the resource now tracks the domain's verified status.",
 						)
 
 						existingDomain = true
@@ -208,7 +208,7 @@ func (r *CustomDomainVerifyResource) Create(ctx context.Context, req resource.Cr
 				return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, plan.EnvironmentId.ValueString(), fO, fR, fErr)
 			},
 			"ReadOneDomain",
-			framework.CustomErrorResourceNotFoundWarning,
+			framework.DefaultCustomError,
 			sdk.DefaultCreateReadRetryable,
 			&response,
 		)...)

--- a/internal/service/base/resource_custom_domain_verify.go
+++ b/internal/service/base/resource_custom_domain_verify.go
@@ -121,6 +121,7 @@ func (r *CustomDomainVerifyResource) Configure(ctx context.Context, req resource
 
 func (r *CustomDomainVerifyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan, state CustomDomainVerifyResourceModel
+	existingDomain := false
 
 	if r.Client == nil || r.Client.ManagementAPIClient == nil {
 		resp.Diagnostics.AddError(
@@ -178,6 +179,16 @@ func (r *CustomDomainVerifyResource) Create(ctx context.Context, req resource.Cr
 
 						return diags
 					}
+
+					m, _ = regexp.MatchString("^custom domain does not need to be verified$", details[0].GetMessage())
+					if m {
+						diags.AddWarning(
+							fmt.Sprintf("%s", details[0].GetMessage()),
+							"This is expected if the custom domain has already been verified previously.",
+						)
+
+						existingDomain = true
+					}
 				}
 			}
 
@@ -187,6 +198,25 @@ func (r *CustomDomainVerifyResource) Create(ctx context.Context, req resource.Cr
 		&response,
 		timeout,
 	)...)
+
+	if existingDomain {
+		resp.Diagnostics.Append(framework.ParseResponse(
+			ctx,
+
+			func() (any, *http.Response, error) {
+				fO, fR, fErr := r.Client.ManagementAPIClient.CustomDomainsApi.ReadOneDomain(ctx, plan.EnvironmentId.ValueString(), plan.CustomDomainId.ValueString()).Execute()
+				return framework.CheckEnvironmentExistsOnPermissionsError(ctx, r.Client.ManagementAPIClient, plan.EnvironmentId.ValueString(), fO, fR, fErr)
+			},
+			"ReadOneDomain",
+			framework.CustomErrorResourceNotFoundWarning,
+			sdk.DefaultCreateReadRetryable,
+			&response,
+		)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/base/resource_custom_domain_verify.go
+++ b/internal/service/base/resource_custom_domain_verify.go
@@ -183,7 +183,7 @@ func (r *CustomDomainVerifyResource) Create(ctx context.Context, req resource.Cr
 					m, _ = regexp.MatchString("^custom domain does not need to be verified$", details[0].GetMessage())
 					if m {
 						diags.AddWarning(
-							fmt.Sprintf("%s", details[0].GetMessage()),
+							details[0].GetMessage(),
 							"This is expected if the custom domain has already been verified previously.",
 						)
 


### PR DESCRIPTION
### Change Description
Allow use of already verified custom domain

### Required SDK Upgrades
N/A

### Testing Shell Command
N/A