### PR TITLE
Custom domain test fixes

### DIFF
--- a/internal/service/base/resource_custom_domain_ssl_test.go
+++ b/internal/service/base/resource_custom_domain_ssl_test.go
@@ -17,7 +17,6 @@ func TestAccCustomDomainSSL_Full(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
-	domainPrefix := acctest.ResourceNameGen()
 
 	environmentName := acctest.ResourceNameGenEnvironment()
 
@@ -40,21 +39,21 @@ func TestAccCustomDomainSSL_Full(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile, domainPrefix),
+				Config:      testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile),
 				ExpectError: regexp.MustCompile(`Cannot add SSL certificate settings to the custom domain - Custom domain status must be 'SSL_CERTIFICATE_REQUIRED' or 'ACTIVE' in order to import a certificate`),
 			},
 		},
 	})
 }
 
-func testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile, domainPrefix string) string {
+func testAccCustomDomainSSLConfig_Full(environmentName, licenseID, resourceName, certificateFile, intermediateFile, privateKeyFile string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_custom_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "%[7]s.terraformdev.ping-eng.com"
+  domain_name = "terraformdev.ping-eng.com"
 }
 
 resource "pingone_custom_domain_ssl" "%[3]s" {
@@ -72,5 +71,5 @@ EOT
 %[6]s
 EOT
 
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, certificateFile, intermediateFile, privateKeyFile, domainPrefix)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, certificateFile, intermediateFile, privateKeyFile)
 }

--- a/internal/service/base/resource_custom_domain_verify_test.go
+++ b/internal/service/base/resource_custom_domain_verify_test.go
@@ -17,6 +17,7 @@ func TestAccCustomDomainVerify_CannotVerifyNXDOMAIN(t *testing.T) {
 	t.Parallel()
 
 	resourceName := acctest.ResourceNameGen()
+	domainPrefix := acctest.ResourceNameGen()
 
 	environmentName := acctest.ResourceNameGenEnvironment()
 
@@ -34,21 +35,21 @@ func TestAccCustomDomainVerify_CannotVerifyNXDOMAIN(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCustomDomainVerifyConfig_CannotVerifyNXDOMAIN(environmentName, licenseID, resourceName),
+				Config:      testAccCustomDomainVerifyConfig_CannotVerifyNXDOMAIN(environmentName, licenseID, resourceName, domainPrefix),
 				ExpectError: regexp.MustCompile(`Cannot verify the domain`),
 			},
 		},
 	})
 }
 
-func testAccCustomDomainVerifyConfig_CannotVerifyNXDOMAIN(environmentName, licenseID, resourceName string) string {
+func testAccCustomDomainVerifyConfig_CannotVerifyNXDOMAIN(environmentName, licenseID, resourceName, domainPrefix string) string {
 	return fmt.Sprintf(`
 	%[1]s
 
 resource "pingone_custom_domain" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
 
-  domain_name = "terraformdev-verify.ping-eng.com"
+  domain_name = "%[4]s.terraformdev-verify.ping-eng.com"
 }
 
 resource "pingone_custom_domain_verify" "%[3]s" {
@@ -59,5 +60,5 @@ resource "pingone_custom_domain_verify" "%[3]s" {
   timeouts = {
     create = "5s"
   }
-}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName)
+}`, acctest.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, domainPrefix)
 }


### PR DESCRIPTION
Use domain that aligns with test certificate, and randomize domain to avoid conflicts in pingone_custom_domain_verify test.

These were missed in #1082  because I mistakenly was using `-run ^TestAccCustomDomain_` (with underscore) instead of `-run ^TestAccCustomDomain` in my testing command.

Currently running a multi-region pipeline to confirm these fixes.

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccCustomDomain github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccCustomDomainSSL_Full
=== PAUSE TestAccCustomDomainSSL_Full
=== RUN   TestAccCustomDomain_RemovalDrift
=== PAUSE TestAccCustomDomain_RemovalDrift
=== RUN   TestAccCustomDomain_Full
=== PAUSE TestAccCustomDomain_Full
=== RUN   TestAccCustomDomain_BadParameters
=== PAUSE TestAccCustomDomain_BadParameters
=== RUN   TestAccCustomDomainVerify_CannotVerifyNXDOMAIN
=== PAUSE TestAccCustomDomainVerify_CannotVerifyNXDOMAIN
=== CONT  TestAccCustomDomainSSL_Full
=== CONT  TestAccCustomDomain_BadParameters
=== CONT  TestAccCustomDomain_Full
=== CONT  TestAccCustomDomain_RemovalDrift
=== CONT  TestAccCustomDomainVerify_CannotVerifyNXDOMAIN
=== NAME  TestAccCustomDomainSSL_Full
    acctest.go:229: PINGONE_DOMAIN_CERTIFICATE_PEM is missing and must be set
--- FAIL: TestAccCustomDomainSSL_Full (0.00s)
--- PASS: TestAccCustomDomainVerify_CannotVerifyNXDOMAIN (39.69s)
--- PASS: TestAccCustomDomain_Full (41.62s)
--- PASS: TestAccCustomDomain_BadParameters (44.10s)
--- PASS: TestAccCustomDomain_RemovalDrift (81.54s)
FAIL
FAIL	github.com/pingidentity/terraform-provider-pingone/internal/service/base	82.325s
FAIL
```

</details>