### PR TITLE
Add new pingone_population attrs to pingone_population_default

### DIFF
--- a/.changelog/1089.txt
+++ b/.changelog/1089.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/pingone_population_default`: Added wait on initial create to ensure `theme.id` is correctly assigned when creating a default population in a brand new environment.
+```
+
+```release-note:enhancement
+`resource/pingone_population_default`: Added support for new `alternative_identifiers`, `preferred_language`, and `theme.id` attributes. Also added support for a new `password_policy.id` attribute to better align with the API. `password_policy.id` should be used in place of the now-deprecated `password_policy_id` attribute. `password_policy_id` will be removed in the next major release.
+```

--- a/docs/resources/population_default.md
+++ b/docs/resources/population_default.md
@@ -36,12 +36,22 @@ resource "pingone_population_default" "my_default_population" {
 
 ### Optional
 
+- `alternative_identifiers` (Set of String) Alternative identifiers that can be used to search for populations besides `name`.
 - `description` (String) A description to apply to the default population.
 - `password_policy_id` (String) The ID of a password policy to assign to the default population.
+- `preferred_language` (String) The language locale for the population. If absent, the environment default is used.
+- `theme` (Attributes) The object reference to the theme resource. (see [below for nested schema](#nestedatt--theme))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedatt--theme"></a>
+### Nested Schema for `theme`
+
+Required:
+
+- `id` (String) The ID of the theme to use for the population. If absent, the environment's default is used. Must be a valid PingOne resource ID.
 
 ## Import
 

--- a/docs/resources/population_default.md
+++ b/docs/resources/population_default.md
@@ -38,13 +38,22 @@ resource "pingone_population_default" "my_default_population" {
 
 - `alternative_identifiers` (Set of String) Alternative identifiers that can be used to search for populations besides `name`.
 - `description` (String) A description to apply to the default population.
-- `password_policy_id` (String) The ID of a password policy to assign to the default population.
+- `password_policy` (Attributes) The object reference to the password policy resource. This is an optional property. Conflicts with `password_policy_id`. (see [below for nested schema](#nestedatt--password_policy))
+- `password_policy_id` (String, Deprecated) A string that specifies the ID of a password policy to assign to the population.  Must be a valid PingOne resource ID. The "password_policy.id" attribute should be used instead of this attribute.  Conflicts with "password_policy".
 - `preferred_language` (String) The language locale for the population. If absent, the environment default is used.
 - `theme` (Attributes) The object reference to the theme resource. (see [below for nested schema](#nestedatt--theme))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedatt--password_policy"></a>
+### Nested Schema for `password_policy`
+
+Required:
+
+- `id` (String) The ID of the password policy that is used for this population. If absent, the environment's default is used. Must be a valid PingOne resource ID.
+
 
 <a id="nestedatt--theme"></a>
 ### Nested Schema for `theme`

--- a/internal/service/sso/resource_population.go
+++ b/internal/service/sso/resource_population.go
@@ -58,8 +58,7 @@ func populationWaitForAssignedThemeId(ctx context.Context, client *pingone.Clien
 
 			return responseData, "true", nil
 		},
-		// Align with SDK wait time for environment 404s on creation
-		Timeout:                   17 * time.Second,
+		Timeout:                   30 * time.Second,
 		Delay:                     1 * time.Second,
 		MinTimeout:                1 * time.Second,
 		ContinuousTargetOccurence: 1,

--- a/internal/service/sso/resource_population_default.go
+++ b/internal/service/sso/resource_population_default.go
@@ -208,6 +208,20 @@ func (r *PopulationDefaultResource) Create(ctx context.Context, req resource.Cre
 			sdk.DefaultCreateReadRetryable,
 			&response,
 		)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if response.Theme == nil || response.Theme.Id == nil {
+			responseWithTheme, diags := populationWaitForAssignedThemeId(ctx, r.Client, plan.EnvironmentId.ValueString(), *response.Id)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			if responseWithTheme != nil {
+				response = responseWithTheme
+			}
+		}
 	} else {
 		resp.Diagnostics.Append(framework.ParseResponse(
 			ctx,

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -94,7 +94,7 @@ func TestAccPopulationDefault_Full(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceFullName, "environment_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "description", "Test description"),
-					resource.TestMatchResourceAttr(resourceFullName, "password_policy_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestMatchResourceAttr(resourceFullName, "password_policy.id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "alternative_identifiers.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier1"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier2"),
@@ -153,9 +153,45 @@ func TestAccPopulationDefault_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckNoResourceAttr(resourceFullName, "description"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "password_policy_id"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "password_policy"),
 					resource.TestCheckResourceAttr(resourceFullName, "preferred_language", "en"),
 					resource.TestMatchResourceAttr(resourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
+			},
+		},
+	})
+}
+
+func TestAccPopulationDefault_PasswordPolicy(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+
+	environmentName := acctest.ResourceNameGenEnvironment()
+
+	name := resourceName
+
+	licenseID := os.Getenv("PINGONE_LICENSE_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoFeatureFlag(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             sso.Population_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPopulationDefaultConfig_PasswordPolicyNested(environmentName, licenseID, resourceName, name),
+			},
+			{
+				Config: testAccPopulationDefaultConfig_PasswordPolicyString(environmentName, licenseID, resourceName, name),
+			},
+			{
+				Config:      testAccPopulationDefaultConfig_PasswordPolicyConflict(environmentName, licenseID, resourceName, name),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
 			},
 		},
 	})
@@ -244,7 +280,9 @@ resource "pingone_population_default" "%[3]s" {
   environment_id          = pingone_environment.%[2]s.id
   name                    = "%[4]s"
   description             = "Test description"
-  password_policy_id      = pingone_password_policy.%[3]s.id
+  password_policy     = {
+    id = pingone_password_policy.%[3]s.id
+}
   alternative_identifiers = ["identifier1", "identifier2"]
   preferred_language      = pingone_language_update.%[3]s.locale
   theme = {
@@ -260,5 +298,55 @@ func testAccPopulationDefaultConfig_Minimal(environmentName, licenseID, resource
 resource "pingone_population_default" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
   name           = "%[4]s"
+}`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
+}
+
+func testAccPopulationDefaultConfig_PasswordPolicyNested(environmentName, licenseID, resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+resource "pingone_password_policy" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[4]s"
+}
+
+resource "pingone_population_default" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[4]s"
+  password_policy = {
+    id = pingone_password_policy.%[3]s.id
+  }
+}`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
+}
+
+func testAccPopulationDefaultConfig_PasswordPolicyString(environmentName, licenseID, resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+resource "pingone_password_policy" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[4]s"
+}
+
+resource "pingone_population_default" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name               = "%[4]s"
+  password_policy_id = pingone_password_policy.%[3]s.id
+}`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
+}
+
+func testAccPopulationDefaultConfig_PasswordPolicyConflict(environmentName, licenseID, resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+resource "pingone_password_policy" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[4]s"
+}
+
+resource "pingone_population_default" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[4]s"
+  password_policy = {
+    id = pingone_password_policy.%[3]s.id
+  }
+  password_policy_id = pingone_password_policy.%[3]s.id
 }`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -95,6 +95,9 @@ func TestAccPopulationDefault_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckResourceAttr(resourceFullName, "description", "Test description"),
 					resource.TestMatchResourceAttr(resourceFullName, "password_policy_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "alternative_identifiers.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier1"),
+					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier2"),
 				),
 			},
 			// Test importing the resource
@@ -212,7 +215,9 @@ resource "pingone_population_default" "%[3]s" {
   name               = "%[4]s"
   description        = "Test description"
   password_policy_id = pingone_password_policy.%[3]s.id
-}`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
+  alternative_identifiers = ["identifier1", "identifier2"]
+}`,
+		acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }
 
 func testAccPopulationDefaultConfig_Minimal(environmentName, licenseID, resourceName, name string) string {

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -228,9 +228,9 @@ resource "pingone_language_update" "%[3]s" {
 }
 
 resource "pingone_branding_theme" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
-  name     = "%[3]s"
-  template = "split"
+  environment_id     = pingone_environment.%[2]s.id
+  name               = "%[3]s"
+  template           = "split"
   background_color   = "#FF00F0"
   button_text_color  = "#FF6C6C"
   heading_text_color = "#FF0005"
@@ -241,17 +241,16 @@ resource "pingone_branding_theme" "%[3]s" {
 }
 
 resource "pingone_population_default" "%[3]s" {
-  environment_id     = pingone_environment.%[2]s.id
-  name               = "%[4]s"
-  description        = "Test description"
-  password_policy_id = pingone_password_policy.%[3]s.id
+  environment_id          = pingone_environment.%[2]s.id
+  name                    = "%[4]s"
+  description             = "Test description"
+  password_policy_id      = pingone_password_policy.%[3]s.id
   alternative_identifiers = ["identifier1", "identifier2"]
   preferred_language      = pingone_language_update.%[3]s.locale
   theme = {
-	id = pingone_branding_theme.%[3]s.id
+    id = pingone_branding_theme.%[3]s.id
   }
-}`,
-		acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
+}`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }
 
 func testAccPopulationDefaultConfig_Minimal(environmentName, licenseID, resourceName, name string) string {

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -277,12 +277,12 @@ resource "pingone_branding_theme" "%[3]s" {
 }
 
 resource "pingone_population_default" "%[3]s" {
-  environment_id          = pingone_environment.%[2]s.id
-  name                    = "%[4]s"
-  description             = "Test description"
-  password_policy     = {
+  environment_id = pingone_environment.%[2]s.id
+  name           = "%[4]s"
+  description    = "Test description"
+  password_policy = {
     id = pingone_password_policy.%[3]s.id
-}
+  }
   alternative_identifiers = ["identifier1", "identifier2"]
   preferred_language      = pingone_language_update.%[3]s.locale
   theme = {
@@ -327,7 +327,7 @@ resource "pingone_password_policy" "%[3]s" {
 }
 
 resource "pingone_population_default" "%[3]s" {
-  environment_id = pingone_environment.%[2]s.id
+  environment_id     = pingone_environment.%[2]s.id
   name               = "%[4]s"
   password_policy_id = pingone_password_policy.%[3]s.id
 }`, acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -98,6 +98,7 @@ func TestAccPopulationDefault_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "alternative_identifiers.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier1"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier2"),
+					resource.TestMatchResourceAttr(resourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 			// Test importing the resource
@@ -210,12 +211,28 @@ resource "pingone_password_policy" "%[3]s" {
   name           = "%[4]s"
 }
 
+resource "pingone_branding_theme" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  name     = "%[3]s"
+  template = "split"
+  background_color   = "#FF00F0"
+  button_text_color  = "#FF6C6C"
+  heading_text_color = "#FF0005"
+  card_color         = "#0FFF39"
+  body_text_color    = "#8620FF"
+  link_text_color    = "#8A7F06"
+  button_color       = "#0CFFFB"
+}
+
 resource "pingone_population_default" "%[3]s" {
   environment_id     = pingone_environment.%[2]s.id
   name               = "%[4]s"
   description        = "Test description"
   password_policy_id = pingone_password_policy.%[3]s.id
   alternative_identifiers = ["identifier1", "identifier2"]
+  theme = {
+	id = pingone_branding_theme.%[3]s.id
+  }
 }`,
 		acctest.MinimalSandboxEnvironmentNoPopulation(environmentName, licenseID), environmentName, resourceName, name)
 }

--- a/internal/service/sso/resource_population_default_test.go
+++ b/internal/service/sso/resource_population_default_test.go
@@ -98,6 +98,7 @@ func TestAccPopulationDefault_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "alternative_identifiers.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier1"),
 					resource.TestCheckTypeSetElemAttr(resourceFullName, "alternative_identifiers.*", "identifier2"),
+					resource.TestCheckResourceAttr(resourceFullName, "preferred_language", "es"),
 					resource.TestMatchResourceAttr(resourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
 			},
@@ -152,6 +153,8 @@ func TestAccPopulationDefault_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "name", name),
 					resource.TestCheckNoResourceAttr(resourceFullName, "description"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "password_policy_id"),
+					resource.TestCheckResourceAttr(resourceFullName, "preferred_language", "en"),
+					resource.TestMatchResourceAttr(resourceFullName, "theme.id", verify.P1ResourceIDRegexpFullString),
 				),
 			},
 		},
@@ -211,6 +214,19 @@ resource "pingone_password_policy" "%[3]s" {
   name           = "%[4]s"
 }
 
+data "pingone_language" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+
+  locale = "es"
+}
+
+resource "pingone_language_update" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+
+  language_id = data.pingone_language.%[3]s.id
+  enabled     = true
+}
+
 resource "pingone_branding_theme" "%[3]s" {
   environment_id = pingone_environment.%[2]s.id
   name     = "%[3]s"
@@ -230,6 +246,7 @@ resource "pingone_population_default" "%[3]s" {
   description        = "Test description"
   password_policy_id = pingone_password_policy.%[3]s.id
   alternative_identifiers = ["identifier1", "identifier2"]
+  preferred_language      = pingone_language_update.%[3]s.locale
   theme = {
 	id = pingone_branding_theme.%[3]s.id
   }


### PR DESCRIPTION
### Change Description
Add new `theme`, `preferred_language`, and `alternative_identifiers` attributes to `pingone_population_default`. These attributes were added to `pingone_population` in #983.

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccPopulationDefault_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso -count=1
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccPopulationDefault_RemovalDrift
=== PAUSE TestAccPopulationDefault_RemovalDrift
=== RUN   TestAccPopulationDefault_Full
=== PAUSE TestAccPopulationDefault_Full
=== RUN   TestAccPopulationDefault_Minimal
=== PAUSE TestAccPopulationDefault_Minimal
=== RUN   TestAccPopulationDefault_BadParameters
=== PAUSE TestAccPopulationDefault_BadParameters
=== CONT  TestAccPopulationDefault_RemovalDrift
=== CONT  TestAccPopulationDefault_Full
=== CONT  TestAccPopulationDefault_Minimal
=== CONT  TestAccPopulationDefault_BadParameters
--- PASS: TestAccPopulationDefault_Minimal (41.65s)
--- PASS: TestAccPopulationDefault_BadParameters (42.66s)
--- PASS: TestAccPopulationDefault_Full (49.63s)
--- PASS: TestAccPopulationDefault_RemovalDrift (74.14s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/sso74.628s
```

</details>