### PR TITLE
Sequential multi region tests

### DIFF
--- a/.github/workflows/acceptance-test-ff-multi-region.yml
+++ b/.github/workflows/acceptance-test-ff-multi-region.yml
@@ -17,243 +17,42 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+        id: go
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-      id: go
+      - name: Get dependencies
+        run: |
+          go mod download
 
-    - name: Get dependencies
-      run: |
-        go mod download
+      - name: Build
+        run: |
+          make build
 
-    - name: Build
-      run: |
-        make build
-
-  prepare-ap:
-    name: Prepare AP
+  prepare:
+    name: Prepare ${{ matrix.region }}
+    needs: [build]
     runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.AP_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.AP_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.AP_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "AP"
-      PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-      id: go
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: Sweep to prepare
-      run: |
-        make sweep
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test-ap:
-    name: Acceptance Test AP
-    needs: [prepare-ap, build]
-    runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.AP_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.AP_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.AP_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "AP"
-      PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-      id: go
-
-    - uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: ${{ matrix.terraform }}
-        terraform_wrapper: false
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: TF acceptance tests
-      timeout-minutes: 45
-      run: |
-        make testacc
-
-  cleanup-ap:
-    name: Clean up AP
-    needs: test-ap
-    runs-on: ubuntu-latest
+        region: [AP, CA, EU, NA]
 
     env:
       FEATURE_FLAG: DAVINCI
       PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.AP_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.AP_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.AP_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "AP"
-      PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-      id: go
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: Sweep to prepare
-      run: |
-        make sweep
-
-  prepare-ca:
-    name: Prepare CA
-    runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.CA_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.CA_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.CA_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "CA"
-      PINGONE_LICENSE_ID: ${{ secrets.CA_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.CA_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-      id: go
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: Sweep to prepare
-      run: |
-        make sweep
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test-ca:
-    name: Acceptance Test CA
-    needs: [prepare-ca, build]
-    runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.CA_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.CA_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.CA_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "CA"
-      PINGONE_LICENSE_ID: ${{ secrets.CA_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.CA_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-    steps:
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-      id: go
-
-    - uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: ${{ matrix.terraform }}
-        terraform_wrapper: false
-
-    - name: Get dependencies
-      run: |
-        go mod download
-
-    - name: TF acceptance tests
-      timeout-minutes: 45
-      run: |
-        make testacc
-
-  cleanup-ca:
-    name: Clean up CA
-    needs: test-ca
-    runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.CA_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.CA_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.CA_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "CA"
-      PINGONE_LICENSE_ID: ${{ secrets.CA_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.CA_PINGONE_FF_ORGANIZATION_ID }}
+      PINGONE_CLIENT_ID: ${{ secrets[format('{0}_PINGONE_FF_CLIENT_ID', matrix.region)] }}
+      PINGONE_CLIENT_SECRET: ${{ secrets[format('{0}_PINGONE_FF_CLIENT_SECRET', matrix.region)] }}
+      PINGONE_ENVIRONMENT_ID: ${{ secrets[format('{0}_PINGONE_FF_ENVIRONMENT_ID', matrix.region)] }}
+      PINGONE_REGION_CODE: ${{ matrix.region }}
+      PINGONE_LICENSE_ID: ${{ secrets[format('{0}_PINGONE_FF_LICENSE_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_ID: ${{ secrets[format('{0}_PINGONE_FF_ORGANIZATION_ID', matrix.region)] }}
 
     timeout-minutes: 10
 
@@ -276,64 +75,32 @@ jobs:
         run: |
           make sweep
 
-  prepare-eu:
-    name: Prepare EU
+  # run acceptance tests in a matrix with Terraform core versions and regions
+  test:
+    name: Acceptance Test ${{ matrix.region }}
+    needs: [prepare]
     runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.EU_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.EU_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.EU_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "EU"
-      PINGONE_LICENSE_ID: ${{ secrets.EU_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.EU_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test-eu:
-    name: Acceptance Test EU
-    needs: [prepare-eu, build]
-    runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.EU_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.EU_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.EU_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "EU"
-      PINGONE_LICENSE_ID: ${{ secrets.EU_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.EU_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
+        region: [AP, CA, EU, NA]
         # list whatever Terraform versions here you would like to support
         terraform:
           - '1.11.*'
+      # If we have issues due to simultaneous tests across regions, max-parallel can be set to 1 to run sequentially
+      #max-parallel: 1
+
+    env:
+      FEATURE_FLAG: DAVINCI
+      PINGONE_TESTING_PROVIDER_VERSION: test
+      PINGONE_CLIENT_ID: ${{ secrets[format('{0}_PINGONE_FF_CLIENT_ID', matrix.region)] }}
+      PINGONE_CLIENT_SECRET: ${{ secrets[format('{0}_PINGONE_FF_CLIENT_SECRET', matrix.region)] }}
+      PINGONE_ENVIRONMENT_ID: ${{ secrets[format('{0}_PINGONE_FF_ENVIRONMENT_ID', matrix.region)] }}
+      PINGONE_REGION_CODE: ${{ matrix.region }}
+      PINGONE_LICENSE_ID: ${{ secrets[format('{0}_PINGONE_FF_LICENSE_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_ID: ${{ secrets[format('{0}_PINGONE_FF_ORGANIZATION_ID', matrix.region)] }}
+
+    timeout-minutes: 45
 
     steps:
       - name: Check out code into the Go module directory
@@ -360,140 +127,25 @@ jobs:
         run: |
           make testacc
 
-  cleanup-eu:
-    name: Clean up EU
-    needs: test-eu
+  cleanup:
+    name: Clean up ${{ matrix.region }}
+    needs: [test]
     runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.EU_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.EU_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.EU_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "EU"
-      PINGONE_LICENSE_ID: ${{ secrets.EU_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.EU_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  prepare-na:
-    name: Prepare NA
-    runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.NA_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.NA_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.NA_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "NA"
-      PINGONE_LICENSE_ID: ${{ secrets.NA_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.NA_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test-na:
-    name: Acceptance Test NA
-    needs: [prepare-na, build]
-    runs-on: ubuntu-latest
-
-    env:
-      FEATURE_FLAG: DAVINCI
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.NA_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.NA_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.NA_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "NA"
-      PINGONE_LICENSE_ID: ${{ secrets.NA_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.NA_PINGONE_FF_ORGANIZATION_ID }}
-
-    timeout-minutes: 45
+    if: always()
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: TF acceptance tests
-        timeout-minutes: 45
-        run: |
-          make testacc
-
-  cleanup-na:
-    name: Clean up NA
-    needs: test-na
-    runs-on: ubuntu-latest
+        region: [AP, CA, EU, NA]
 
     env:
       FEATURE_FLAG: DAVINCI
       PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.NA_PINGONE_FF_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.NA_PINGONE_FF_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.NA_PINGONE_FF_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "NA"
-      PINGONE_LICENSE_ID: ${{ secrets.NA_PINGONE_FF_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.NA_PINGONE_FF_ORGANIZATION_ID }}
+      PINGONE_CLIENT_ID: ${{ secrets[format('{0}_PINGONE_FF_CLIENT_ID', matrix.region)] }}
+      PINGONE_CLIENT_SECRET: ${{ secrets[format('{0}_PINGONE_FF_CLIENT_SECRET', matrix.region)] }}
+      PINGONE_ENVIRONMENT_ID: ${{ secrets[format('{0}_PINGONE_FF_ENVIRONMENT_ID', matrix.region)] }}
+      PINGONE_REGION_CODE: ${{ matrix.region }}
+      PINGONE_LICENSE_ID: ${{ secrets[format('{0}_PINGONE_FF_LICENSE_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_ID: ${{ secrets[format('{0}_PINGONE_FF_ORGANIZATION_ID', matrix.region)] }}
 
     timeout-minutes: 10
 
@@ -512,17 +164,13 @@ jobs:
         run: |
           go mod download
 
-      - name: Sweep to prepare
+      - name: Sweep to cleanup
         run: |
           make sweep
 
   onfailure:
-    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
-    needs: [build,
-            prepare-ap, test-ap, cleanup-ap,
-            prepare-ca, test-ca, cleanup-ca,
-            prepare-eu, test-eu, cleanup-eu,
-            prepare-na, test-na, cleanup-na]
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.outcome, 'failure') }}
+    needs: [build, prepare, test, cleanup]
     name: Send failure webhook
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -43,6 +43,7 @@ jobs:
 
   prepare-ap:
     name: Prepare AP
+    needs: [build]
     runs-on: ubuntu-latest
 
     env:
@@ -257,6 +258,7 @@ jobs:
 
   prepare-ca:
     name: Prepare CA
+    needs: [cleanup-ap]
     runs-on: ubuntu-latest
 
     env:
@@ -291,7 +293,7 @@ jobs:
   # run acceptance tests in a matrix with Terraform core versions
   test-ca:
     name: Acceptance Test CA
-    needs: [build, prepare-ca]
+    needs: [prepare-ca]
     runs-on: ubuntu-latest
 
     env:
@@ -358,7 +360,7 @@ jobs:
   # flaky flag set
   test-ca-flaky:
     name: Acceptance Test CA (FLAKY)
-    needs: [build, prepare-ca]
+    needs: [prepare-ca]
     runs-on: ubuntu-latest
 
     env:
@@ -397,6 +399,7 @@ jobs:
         # list whatever Terraform versions here you would like to support
         terraform:
           - '1.11.*'
+
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -468,6 +471,7 @@ jobs:
 
   prepare-eu:
     name: Prepare EU
+    needs: [cleanup-ca]
     runs-on: ubuntu-latest
 
     env:
@@ -503,7 +507,7 @@ jobs:
   # run acceptance tests in a matrix with Terraform core versions
   test-eu:
     name: Acceptance Test EU
-    needs: [build, prepare-eu]
+    needs: [prepare-eu]
     runs-on: ubuntu-latest
 
     env:
@@ -571,7 +575,7 @@ jobs:
   # flaky flag set
   test-eu-flaky:
     name: Acceptance Test EU (FLAKY)
-    needs: [build, prepare-eu]
+    needs: [prepare-eu]
     runs-on: ubuntu-latest
 
     env:
@@ -682,6 +686,7 @@ jobs:
 
   prepare-na:
     name: Prepare NA
+    needs: [cleanup-eu]
     runs-on: ubuntu-latest
 
     env:
@@ -717,7 +722,7 @@ jobs:
   # run acceptance tests in a matrix with Terraform core versions
   test-na:
     name: Acceptance Test NA
-    needs: [build, prepare-na]
+    needs: [prepare-na]
     runs-on: ubuntu-latest
 
     env:
@@ -785,7 +790,7 @@ jobs:
   # flaky flag set
   test-na-flaky:
     name: Acceptance Test NA (FLAKY)
-    needs: [build, prepare-na]
+    needs: [prepare-na]
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -41,19 +41,23 @@ jobs:
         run: |
           make build
 
-  prepare-ap:
-    name: Prepare AP
+  prepare:
+    name: Prepare ${{ matrix.region }}
     needs: [build]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        region: [AP, CA, EU, NA]
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.AP_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.AP_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.AP_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "AP"
-      PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_ORGANIZATION_ID }}
+      PINGONE_CLIENT_ID: ${{ secrets[format('{0}_PINGONE_CLIENT_ID', matrix.region)] }}
+      PINGONE_CLIENT_SECRET: ${{ secrets[format('{0}_PINGONE_CLIENT_SECRET', matrix.region)] }}
+      PINGONE_ENVIRONMENT_ID: ${{ secrets[format('{0}_PINGONE_ENVIRONMENT_ID', matrix.region)] }}
+      PINGONE_REGION_CODE: ${{ matrix.region }}
+      PINGONE_LICENSE_ID: ${{ secrets[format('{0}_PINGONE_LICENSE_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_ID: ${{ secrets[format('{0}_PINGONE_ORGANIZATION_ID', matrix.region)] }}
 
     timeout-minutes: 10
 
@@ -76,22 +80,29 @@ jobs:
         run: |
           make sweep
 
-  # run acceptance tests in a matrix with Terraform core versions
-  test-ap:
-    name: Acceptance Test AP
-    needs: [prepare-ap]
+  # run acceptance tests in a matrix with Terraform core versions and regions
+  test:
+    name: Acceptance Test ${{ matrix.region }}
+    needs: [prepare]
     runs-on: ubuntu-latest
-    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        region: [AP, CA, EU, NA]
+        # list whatever Terraform versions here you would like to support
+        terraform:
+          - '1.11.*'
+      max-parallel: 1
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.AP_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.AP_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.AP_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "AP"
-      PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.AP_PINGONE_ORGANIZATION_NAME }}
+      PINGONE_CLIENT_ID: ${{ secrets[format('{0}_PINGONE_CLIENT_ID', matrix.region)] }}
+      PINGONE_CLIENT_SECRET: ${{ secrets[format('{0}_PINGONE_CLIENT_SECRET', matrix.region)] }}
+      PINGONE_ENVIRONMENT_ID: ${{ secrets[format('{0}_PINGONE_ENVIRONMENT_ID', matrix.region)] }}
+      PINGONE_REGION_CODE: ${{ matrix.region }}
+      PINGONE_LICENSE_ID: ${{ secrets[format('{0}_PINGONE_LICENSE_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_ID: ${{ secrets[format('{0}_PINGONE_ORGANIZATION_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_NAME: ${{ secrets[format('{0}_PINGONE_ORGANIZATION_NAME', matrix.region)] }}
       PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
       PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
       PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
@@ -112,12 +123,6 @@ jobs:
       PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
 
     timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
 
     steps:
       - name: Check out code into the Go module directory
@@ -144,24 +149,31 @@ jobs:
         run: |
           make testacc
 
-  # run acceptance tests in a matrix with Terraform core versions
+  # run acceptance tests in a matrix with Terraform core versions and regions
   # flaky flag set
-  test-ap-flaky:
-    name: Acceptance Test AP (FLAKY)
-    needs: [prepare-ap]
+  test-flaky:
+    name: Acceptance Test ${{ matrix.region }} (FLAKY)
+    needs: [prepare]
     runs-on: ubuntu-latest
-    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        region: [AP, CA, EU, NA]
+        # list whatever Terraform versions here you would like to support
+        terraform:
+          - '1.11.*'
+      max-parallel: 1
 
     env:
       TESTACC_FLAKY: true
       PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.AP_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.AP_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.AP_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "AP"
-      PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.AP_PINGONE_ORGANIZATION_NAME }}
+      PINGONE_CLIENT_ID: ${{ secrets[format('{0}_PINGONE_CLIENT_ID', matrix.region)] }}
+      PINGONE_CLIENT_SECRET: ${{ secrets[format('{0}_PINGONE_CLIENT_SECRET', matrix.region)] }}
+      PINGONE_ENVIRONMENT_ID: ${{ secrets[format('{0}_PINGONE_ENVIRONMENT_ID', matrix.region)] }}
+      PINGONE_REGION_CODE: ${{ matrix.region }}
+      PINGONE_LICENSE_ID: ${{ secrets[format('{0}_PINGONE_LICENSE_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_ID: ${{ secrets[format('{0}_PINGONE_ORGANIZATION_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_NAME: ${{ secrets[format('{0}_PINGONE_ORGANIZATION_NAME', matrix.region)] }}
       PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
       PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
       PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
@@ -182,12 +194,6 @@ jobs:
       PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
 
     timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
 
     steps:
       - name: Check out code into the Go module directory
@@ -210,7 +216,7 @@ jobs:
           go mod download
 
       - name: TF acceptance tests (FLAKY)
-        id: tf-flaky-acc-test-ap
+        id: tf-flaky-acc-test
         continue-on-error: true
         timeout-minutes: 180
         run: |
@@ -218,680 +224,29 @@ jobs:
 
       - name: Check flaky step status
         run: |
-          echo "ACCTEST-AP-FLAKY step outcome: ${{ steps.tf-flaky-acc-test-ap }}"
-           if [[ "${{ steps.tf-flaky-acc-test-ap }}" == "failure" ]]; then
-            echo "Flaky acceptance tests in AP failed: Continuing..."
+          echo "ACCTEST-${{ matrix.region }}-FLAKY step outcome: ${{ steps.tf-flaky-acc-test }}"
+           if [[ "${{ steps.tf-flaky-acc-test }}" == "failure" ]]; then
+            echo "Flaky acceptance tests in ${{ matrix.region }} failed: Continuing..."
           fi
 
-  cleanup-ap:
-    name: Clean up AP
-    needs: [test-ap, test-ap-flaky]
+  cleanup:
+    name: Clean up ${{ matrix.region }}
+    needs: [test, test-flaky]
     runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.AP_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.AP_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.AP_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "AP"
-      PINGONE_LICENSE_ID: ${{ secrets.AP_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.AP_PINGONE_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  prepare-ca:
-    name: Prepare CA
-    needs: [test-ap, test-ap-flaky]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.CA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.CA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.CA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "CA"
-      PINGONE_LICENSE_ID: ${{ secrets.CA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.CA_PINGONE_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test-ca:
-    name: Acceptance Test CA
-    needs: [prepare-ca]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.CA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.CA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.CA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "CA"
-      PINGONE_LICENSE_ID: ${{ secrets.CA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.CA_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.CA_PINGONE_ORGANIZATION_NAME }}
-      PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
-      PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
-      PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
-      PINGONE_KEY_PKCS10_CSR: ${{ secrets.PINGONE_KEY_PKCS10_CSR }}
-      PINGONE_KEY_PEM_CSR: ${{ secrets.PINGONE_KEY_PEM_CSR }}
-      PINGONE_KEY_PEM_CSR_RESPONSE: ${{ secrets.PINGONE_KEY_PEM_CSR_RESPONSE }}
-      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
-      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
-      PINGONE_DOMAIN_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_KEY_PEM: ${{ secrets.PINGONE_DOMAIN_KEY_PEM }}
-      PINGONE_VERIFIED_EMAIL_DOMAIN: ${{ secrets.PINGONE_VERIFIED_EMAIL_DOMAIN }}
-      PINGONE_GOOGLE_JSON_KEY: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_GOOGLE_FIREBASE_CREDENTIALS: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_KEY_PKCS8: ${{ secrets.PINGONE_KEY_PKCS8 }}
-      PINGONE_TWILIO_TEST_SKIP: true
-      PINGONE_SYNIVERSE_TEST_SKIP: true
-      PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
-
-    timeout-minutes: 180
+    if: always()
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: TF acceptance tests
-        timeout-minutes: 180
-        run: |
-          make testacc
-
-  # run acceptance tests in a matrix with Terraform core versions
-  # flaky flag set
-  test-ca-flaky:
-    name: Acceptance Test CA (FLAKY)
-    needs: [prepare-ca]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      TESTACC_FLAKY: true
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.CA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.CA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.CA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "CA"
-      PINGONE_LICENSE_ID: ${{ secrets.CA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.CA_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.CA_PINGONE_ORGANIZATION_NAME }}
-      PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
-      PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
-      PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
-      PINGONE_KEY_PKCS10_CSR: ${{ secrets.PINGONE_KEY_PKCS10_CSR }}
-      PINGONE_KEY_PEM_CSR: ${{ secrets.PINGONE_KEY_PEM_CSR }}
-      PINGONE_KEY_PEM_CSR_RESPONSE: ${{ secrets.PINGONE_KEY_PEM_CSR_RESPONSE }}
-      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
-      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
-      PINGONE_DOMAIN_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_KEY_PEM: ${{ secrets.PINGONE_DOMAIN_KEY_PEM }}
-      PINGONE_VERIFIED_EMAIL_DOMAIN: ${{ secrets.PINGONE_VERIFIED_EMAIL_DOMAIN }}
-      PINGONE_GOOGLE_JSON_KEY: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_GOOGLE_FIREBASE_CREDENTIALS: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_KEY_PKCS8: ${{ secrets.PINGONE_KEY_PKCS8 }}
-      PINGONE_TWILIO_TEST_SKIP: true
-      PINGONE_SYNIVERSE_TEST_SKIP: true
-      PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
-
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: TF acceptance tests (FLAKY)
-        id: tf-flaky-acc-test-ca
-        continue-on-error: true
-        timeout-minutes: 180
-        run: |
-          make testacc
-
-      - name: Check flaky step status
-        run: |
-          echo "ACCTEST-CA-FLAKY step outcome: ${{ steps.tf-flaky-acc-test-ca }}"
-           if [[ "${{ steps.tf-flaky-acc-test-ca }}" == "failure" ]]; then
-            echo "Flaky acceptance tests in CA failed: Continuing..."
-          fi
-
-  cleanup-ca:
-    name: Clean up CA
-    needs: [test-ca, test-ca-flaky]
-    runs-on: ubuntu-latest
-    continue-on-error: true
+        region: [AP, CA, EU, NA]
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.CA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.CA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.CA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "CA"
-      PINGONE_LICENSE_ID: ${{ secrets.CA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.CA_PINGONE_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  prepare-eu:
-    name: Prepare EU
-    needs: [test-ca, test-ca-flaky]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.EU_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.EU_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.EU_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "EU"
-      PINGONE_LICENSE_ID: ${{ secrets.EU_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.EU_PINGONE_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test-eu:
-    name: Acceptance Test EU
-    needs: [prepare-eu]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.EU_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.EU_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.EU_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "EU"
-      PINGONE_LICENSE_ID: ${{ secrets.EU_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.EU_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.EU_PINGONE_ORGANIZATION_NAME }}
-      PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
-      PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
-      PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
-      PINGONE_KEY_PKCS10_CSR: ${{ secrets.PINGONE_KEY_PKCS10_CSR }}
-      PINGONE_KEY_PEM_CSR: ${{ secrets.PINGONE_KEY_PEM_CSR }}
-      PINGONE_KEY_PEM_CSR_RESPONSE: ${{ secrets.PINGONE_KEY_PEM_CSR_RESPONSE }}
-      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
-      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
-      PINGONE_DOMAIN_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_KEY_PEM: ${{ secrets.PINGONE_DOMAIN_KEY_PEM }}
-      PINGONE_VERIFIED_EMAIL_DOMAIN: ${{ secrets.PINGONE_VERIFIED_EMAIL_DOMAIN }}
-      PINGONE_GOOGLE_JSON_KEY: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_GOOGLE_FIREBASE_CREDENTIALS: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_KEY_PKCS8: ${{ secrets.PINGONE_KEY_PKCS8 }}
-      PINGONE_TWILIO_TEST_SKIP: true
-      PINGONE_SYNIVERSE_TEST_SKIP: true
-      PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
-
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: TF acceptance tests
-        timeout-minutes: 180
-        run: |
-          make testacc
-  
-  # run acceptance tests in a matrix with Terraform core versions
-  # flaky flag set
-  test-eu-flaky:
-    name: Acceptance Test EU (FLAKY)
-    needs: [prepare-eu]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      TESTACC_FLAKY: true
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.EU_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.EU_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.EU_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "EU"
-      PINGONE_LICENSE_ID: ${{ secrets.EU_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.EU_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.EU_PINGONE_ORGANIZATION_NAME }}
-      PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
-      PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
-      PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
-      PINGONE_KEY_PKCS10_CSR: ${{ secrets.PINGONE_KEY_PKCS10_CSR }}
-      PINGONE_KEY_PEM_CSR: ${{ secrets.PINGONE_KEY_PEM_CSR }}
-      PINGONE_KEY_PEM_CSR_RESPONSE: ${{ secrets.PINGONE_KEY_PEM_CSR_RESPONSE }}
-      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
-      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
-      PINGONE_DOMAIN_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_KEY_PEM: ${{ secrets.PINGONE_DOMAIN_KEY_PEM }}
-      PINGONE_VERIFIED_EMAIL_DOMAIN: ${{ secrets.PINGONE_VERIFIED_EMAIL_DOMAIN }}
-      PINGONE_GOOGLE_JSON_KEY: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_GOOGLE_FIREBASE_CREDENTIALS: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_KEY_PKCS8: ${{ secrets.PINGONE_KEY_PKCS8 }}
-      PINGONE_TWILIO_TEST_SKIP: true
-      PINGONE_SYNIVERSE_TEST_SKIP: true
-      PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
-
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: TF acceptance tests (FLAKY)
-        id: tf-flaky-acc-test-eu
-        continue-on-error: true
-        timeout-minutes: 180
-        run: |
-          make testacc
-
-      - name: Check flaky step status
-        run: |
-          echo "ACCTEST-EU-FLAKY step outcome: ${{ steps.tf-flaky-acc-test-eu }}"
-           if [[ "${{ steps.tf-flaky-acc-test-eu }}" == "failure" ]]; then
-            echo "Flaky acceptance tests in EU failed: Continuing..."
-          fi
-
-  cleanup-eu:
-    name: Clean up EU
-    needs: [test-eu, test-eu-flaky]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.EU_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.EU_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.EU_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "EU"
-      PINGONE_LICENSE_ID: ${{ secrets.EU_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.EU_PINGONE_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  prepare-na:
-    name: Prepare NA
-    needs: [test-eu, test-eu-flaky]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.NA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.NA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.NA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "NA"
-      PINGONE_LICENSE_ID: ${{ secrets.NA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.NA_PINGONE_ORGANIZATION_ID }}
-
-    timeout-minutes: 10
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: Sweep to prepare
-        run: |
-          make sweep
-
-  # run acceptance tests in a matrix with Terraform core versions
-  test-na:
-    name: Acceptance Test NA
-    needs: [prepare-na]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.NA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.NA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.NA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "NA"
-      PINGONE_LICENSE_ID: ${{ secrets.NA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.NA_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.NA_PINGONE_ORGANIZATION_NAME }}
-      PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
-      PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
-      PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
-      PINGONE_KEY_PKCS10_CSR: ${{ secrets.PINGONE_KEY_PKCS10_CSR }}
-      PINGONE_KEY_PEM_CSR: ${{ secrets.PINGONE_KEY_PEM_CSR }}
-      PINGONE_KEY_PEM_CSR_RESPONSE: ${{ secrets.PINGONE_KEY_PEM_CSR_RESPONSE }}
-      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
-      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
-      PINGONE_DOMAIN_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_KEY_PEM: ${{ secrets.PINGONE_DOMAIN_KEY_PEM }}
-      PINGONE_VERIFIED_EMAIL_DOMAIN: ${{ secrets.PINGONE_VERIFIED_EMAIL_DOMAIN }}
-      PINGONE_GOOGLE_JSON_KEY: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_GOOGLE_FIREBASE_CREDENTIALS: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_KEY_PKCS8: ${{ secrets.PINGONE_KEY_PKCS8 }}
-      PINGONE_TWILIO_TEST_SKIP: true
-      PINGONE_SYNIVERSE_TEST_SKIP: true
-      PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
-
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: TF acceptance tests
-        timeout-minutes: 180
-        run: |
-          make testacc
-
-  # run acceptance tests in a matrix with Terraform core versions
-  # flaky flag set
-  test-na-flaky:
-    name: Acceptance Test NA (FLAKY)
-    needs: [prepare-na]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      TESTACC_FLAKY: true
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.NA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.NA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.NA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "NA"
-      PINGONE_LICENSE_ID: ${{ secrets.NA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.NA_PINGONE_ORGANIZATION_ID }}
-      PINGONE_ORGANIZATION_NAME: ${{ secrets.NA_PINGONE_ORGANIZATION_NAME }}
-      PINGONE_KEY_PKCS12_UNENCRYPTED: ${{ secrets.PINGONE_KEY_PKCS12_UNENCRYPTED }}
-      PINGONE_KEY_PKCS12: ${{ secrets.PINGONE_KEY_PKCS12 }}
-      PINGONE_KEY_PKCS12_PASSWORD:  ${{ secrets.PINGONE_KEY_PKCS12_PASSWORD }}
-      PINGONE_KEY_PKCS10_CSR: ${{ secrets.PINGONE_KEY_PKCS10_CSR }}
-      PINGONE_KEY_PEM_CSR: ${{ secrets.PINGONE_KEY_PEM_CSR }}
-      PINGONE_KEY_PEM_CSR_RESPONSE: ${{ secrets.PINGONE_KEY_PEM_CSR_RESPONSE }}
-      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
-      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
-      PINGONE_DOMAIN_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM: ${{ secrets.PINGONE_DOMAIN_INTERMEDIATE_CERTIFICATE_PEM }}
-      PINGONE_DOMAIN_KEY_PEM: ${{ secrets.PINGONE_DOMAIN_KEY_PEM }}
-      PINGONE_VERIFIED_EMAIL_DOMAIN: ${{ secrets.PINGONE_VERIFIED_EMAIL_DOMAIN }}
-      PINGONE_GOOGLE_JSON_KEY: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_GOOGLE_FIREBASE_CREDENTIALS: ${{ secrets.PINGONE_GOOGLE_JSON_KEY }}
-      PINGONE_KEY_PKCS8: ${{ secrets.PINGONE_KEY_PKCS8 }}
-      PINGONE_TWILIO_TEST_SKIP: true
-      PINGONE_SYNIVERSE_TEST_SKIP: true
-      PINGONE_EMAIL_DOMAIN_TEST_SKIP: true
-
-    timeout-minutes: 180
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.11.*'
-
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-        id: go
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-
-      - name: Get dependencies
-        run: |
-          go mod download
-
-      - name: TF acceptance tests (FLAKY)
-        id: tf-flaky-acc-test-na
-        continue-on-error: true
-        timeout-minutes: 180
-        run: |
-          make testacc
-
-      - name: Check flaky test status
-        run: |
-          echo "ACCTEST-NA-FLAKY step outcome: ${{ steps.tf-flaky-acc-test-na }}"
-           if [[ "${{ steps.tf-flaky-acc-test-na }}" == "failure" ]]; then
-            echo "Flaky acceptance tests in NA failed: Continuing..."
-          fi
-
-  cleanup-na:
-    name: Clean up NA
-    needs: [test-na, test-na-flaky]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    env:
-      PINGONE_TESTING_PROVIDER_VERSION: test
-      PINGONE_CLIENT_ID: ${{ secrets.NA_PINGONE_CLIENT_ID }}
-      PINGONE_CLIENT_SECRET: ${{ secrets.NA_PINGONE_CLIENT_SECRET }}
-      PINGONE_ENVIRONMENT_ID: ${{ secrets.NA_PINGONE_ENVIRONMENT_ID }}
-      PINGONE_REGION_CODE: "NA"
-      PINGONE_LICENSE_ID: ${{ secrets.NA_PINGONE_LICENSE_ID }}
-      PINGONE_ORGANIZATION_ID: ${{ secrets.NA_PINGONE_ORGANIZATION_ID }}
+      PINGONE_CLIENT_ID: ${{ secrets[format('{0}_PINGONE_CLIENT_ID', matrix.region)] }}
+      PINGONE_CLIENT_SECRET: ${{ secrets[format('{0}_PINGONE_CLIENT_SECRET', matrix.region)] }}
+      PINGONE_ENVIRONMENT_ID: ${{ secrets[format('{0}_PINGONE_ENVIRONMENT_ID', matrix.region)] }}
+      PINGONE_REGION_CODE: ${{ matrix.region }}
+      PINGONE_LICENSE_ID: ${{ secrets[format('{0}_PINGONE_LICENSE_ID', matrix.region)] }}
+      PINGONE_ORGANIZATION_ID: ${{ secrets[format('{0}_PINGONE_ORGANIZATION_ID', matrix.region)] }}
 
     timeout-minutes: 10
 
@@ -916,11 +271,7 @@ jobs:
 
   onfailure:
     if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.outcome, 'failure') }}
-    needs: [build,
-            prepare-ap, test-ap, test-ap-flaky, cleanup-ap,
-            prepare-ca, test-ca, test-ca-flaky, cleanup-ca,
-            prepare-eu, test-eu, test-eu-flaky, cleanup-eu,
-            prepare-na, test-na, test-na-flaky, cleanup-na]
+    needs: [build, prepare, test, test-flaky, cleanup]
     name: Send failure webhook
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -261,7 +261,7 @@ jobs:
 
   prepare-ca:
     name: Prepare CA
-    needs: [cleanup-ap]
+    needs: [test-ap, test-ap-flaky]
     runs-on: ubuntu-latest
     continue-on-error: true
 
@@ -478,7 +478,7 @@ jobs:
 
   prepare-eu:
     name: Prepare EU
-    needs: [cleanup-ca]
+    needs: [test-ca, test-ca-flaky]
     runs-on: ubuntu-latest
     continue-on-error: true
 
@@ -697,7 +697,7 @@ jobs:
 
   prepare-na:
     name: Prepare NA
-    needs: [cleanup-eu]
+    needs: [test-eu, test-eu-flaky]
     runs-on: ubuntu-latest
     continue-on-error: true
 

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -265,7 +265,7 @@ jobs:
         run: |
           go mod download
 
-      - name: Sweep to prepare
+      - name: Sweep to cleanup
         run: |
           make sweep
 

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -79,8 +79,9 @@ jobs:
   # run acceptance tests in a matrix with Terraform core versions
   test-ap:
     name: Acceptance Test AP
-    needs: [build, prepare-ap]
+    needs: [prepare-ap]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -147,8 +148,9 @@ jobs:
   # flaky flag set
   test-ap-flaky:
     name: Acceptance Test AP (FLAKY)
-    needs: [build, prepare-ap]
+    needs: [prepare-ap]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       TESTACC_FLAKY: true
@@ -225,6 +227,7 @@ jobs:
     name: Clean up AP
     needs: [test-ap, test-ap-flaky]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -260,6 +263,7 @@ jobs:
     name: Prepare CA
     needs: [cleanup-ap]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -295,6 +299,7 @@ jobs:
     name: Acceptance Test CA
     needs: [prepare-ca]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -362,6 +367,7 @@ jobs:
     name: Acceptance Test CA (FLAKY)
     needs: [prepare-ca]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       TESTACC_FLAKY: true
@@ -438,6 +444,7 @@ jobs:
     name: Clean up CA
     needs: [test-ca, test-ca-flaky]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -473,6 +480,7 @@ jobs:
     name: Prepare EU
     needs: [cleanup-ca]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -509,6 +517,7 @@ jobs:
     name: Acceptance Test EU
     needs: [prepare-eu]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -577,6 +586,7 @@ jobs:
     name: Acceptance Test EU (FLAKY)
     needs: [prepare-eu]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       TESTACC_FLAKY: true
@@ -653,6 +663,7 @@ jobs:
     name: Clean up EU
     needs: [test-eu, test-eu-flaky]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -688,6 +699,7 @@ jobs:
     name: Prepare NA
     needs: [cleanup-eu]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -724,6 +736,7 @@ jobs:
     name: Acceptance Test NA
     needs: [prepare-na]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -792,6 +805,7 @@ jobs:
     name: Acceptance Test NA (FLAKY)
     needs: [prepare-na]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       TESTACC_FLAKY: true
@@ -868,6 +882,7 @@ jobs:
     name: Clean up NA
     needs: [test-na, test-na-flaky]
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -900,7 +915,7 @@ jobs:
           make sweep
 
   onfailure:
-    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.outcome, 'failure') }}
     needs: [build,
             prepare-ap, test-ap, test-ap-flaky, cleanup-ap,
             prepare-ca, test-ca, test-ca-flaky, cleanup-ca,

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -92,7 +92,8 @@ jobs:
         # list whatever Terraform versions here you would like to support
         terraform:
           - '1.11.*'
-      max-parallel: 1
+      # If we have issues due to simultaneous tests across regions, max-parallel can be set to 1 to run sequentially
+      #max-parallel: 1
 
     env:
       PINGONE_TESTING_PROVIDER_VERSION: test
@@ -162,7 +163,8 @@ jobs:
         # list whatever Terraform versions here you would like to support
         terraform:
           - '1.11.*'
-      max-parallel: 1
+      # If we have issues due to simultaneous tests across regions, max-parallel can be set to 1 to run sequentially
+      #max-parallel: 1
 
     env:
       TESTACC_FLAKY: true


### PR DESCRIPTION
### Change Description
Use matrix in acceptance test workflow with max-parallel to run tests sequentially for non-flaky pipelines. This should reduce any pressure caused by overlapping tests.

I have a run pending on a previous iteration where I was not yet using the matrix design: https://github.com/pingidentity/terraform-provider-pingone/actions/runs/16272451451

I am going to wait until that workflow is complete (so we don't trigger anything) to do a test run for this and confirm that the changes do not break anything. With max-parallel set to 1, it should behave similar to the PingFed provider scheduled tests.