### PR TITLE
Add back schedule condition for failure webhook

### DIFF
--- a/.github/workflows/acceptance-test-ff-multi-region.yml
+++ b/.github/workflows/acceptance-test-ff-multi-region.yml
@@ -169,7 +169,7 @@ jobs:
           make sweep
 
   onfailure:
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [build, prepare, test, cleanup]
     name: Send failure webhook
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance-test-ff-multi-version.yml
+++ b/.github/workflows/acceptance-test-ff-multi-version.yml
@@ -95,7 +95,7 @@ jobs:
           make sweep
 
   onfailure:
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [build, test]
     name: Send failure webhook
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance-test-multi-region.yml
+++ b/.github/workflows/acceptance-test-multi-region.yml
@@ -272,7 +272,7 @@ jobs:
           make sweep
 
   onfailure:
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [build, prepare, test, test-flaky, cleanup]
     name: Send failure webhook
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance-test-multi-version.yml
+++ b/.github/workflows/acceptance-test-multi-version.yml
@@ -260,7 +260,7 @@ jobs:
           make sweep
 
   onfailure:
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [build, prepare, test, test-flaky, cleanup]
     name: Send failure webhook
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -77,7 +77,7 @@ jobs:
       uses: github/codeql-action/analyze@v3
 
   onfailure:
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [analyze]
     name: Send failure webhook
     runs-on: ubuntu-latest

--- a/.github/workflows/gosec-scan.yml
+++ b/.github/workflows/gosec-scan.yml
@@ -31,7 +31,7 @@ jobs:
           sarif_file: results.sarif
 
   onfailure:
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name == 'schedule' }}
     needs: [tests]
     name: Send failure webhook
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Change Description
Add back condition to only send failure webhook notifications when the failure was on a scheduled workflow.