### PR TITLE
Update TestAccLicenseDataSource_ByIDFull for SG

### DIFF
--- a/internal/service/base/data_source_license_test.go
+++ b/internal/service/base/data_source_license_test.go
@@ -27,13 +27,9 @@ func TestAccLicenseDataSource_ByIDFull(t *testing.T) {
 	positiveIntegerRegex := regexp.MustCompile(`^[1-9][0-9]*$`)
 
 	terminatesAtCheck := resource.TestCheckNoResourceAttr(dataSourceFullName, "terminates_at")
-	allowDataConsentCheck := resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_data_consent", "true")
-	allowAdvancedPredictorsCheck := resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_advanced_predictors", "true")
 	if os.Getenv("PINGONE_REGION_CODE") == "SG" {
-		// The SG license has a few differences
+		// The SG license has a terminates_at field
 		terminatesAtCheck = resource.TestMatchResourceAttr(dataSourceFullName, "terminates_at", verify.RFC3339Regexp)
-		allowDataConsentCheck = resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_data_consent", "false")
-		allowAdvancedPredictorsCheck = resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_advanced_predictors", "false")
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -92,9 +88,9 @@ func TestAccLicenseDataSource_ByIDFull(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_geo_velocity", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_anonymous_network_detection", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_reputation", "true"),
-					allowDataConsentCheck,
+					resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_data_consent", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_risk", "true"),
-					allowAdvancedPredictorsCheck,
+					resource.TestCheckResourceAttr(dataSourceFullName, "intelligence.allow_advanced_predictors", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "mfa.allow_push_notification", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "mfa.allow_notification_outside_whitelist", "true"),
 					resource.TestCheckResourceAttr(dataSourceFullName, "mfa.allow_fido2_devices", "true"),


### PR DESCRIPTION
Differences in SG license capabilities have been addressed, so the SG-specific checks can be removed

### Testing Shell Command
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme github.com/pingidentity/terraform-provider-pingone/internal/service/base -->
```shell
TF_ACC=1 go test -v -timeout 300s -run TestAccLicenseDataSource_ByIDFull github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
Ran for both feature-flagged and normal prod SG envs
<!-- Use the following shell block to paste the results from the testing command used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccLicenseDataSource_ByIDFull
=== PAUSE TestAccLicenseDataSource_ByIDFull
=== CONT  TestAccLicenseDataSource_ByIDFull
--- PASS: TestAccLicenseDataSource_ByIDFull (9.38s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/base	9.857s
```

</details>