### PR TITLE
Disable automatic acctest run in vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -77,10 +77,7 @@
         "showReuseMessage": true,
         "clear": true
       },
-      "problemMatcher": "$go",
-      "runOptions": {
-        "runOn": "folderOpen"
-      }
+      "problemMatcher": "$go"
     },
     {
       "label": "Run Acceptance Tests - SSO Service",


### PR DESCRIPTION
## Change Description
Update VSCode tasks to disable automatic run of all acceptance tests on folder open. This is too expensive and could unintentionally interfere with config being manually tested.