### PR TITLE
Add vars for application data source beta test

### DIFF
--- a/.github/workflows/acceptance-test-beta-multi-region.yml
+++ b/.github/workflows/acceptance-test-beta-multi-region.yml
@@ -92,6 +92,9 @@ jobs:
       PINGONE_REGION_CODE: ${{ matrix.region }}
       PINGONE_LICENSE_ID: ${{ vars[format('PINGONE_PROD_{0}_FF_LICENSE_ID', matrix.region)] }}
       PINGONE_ORGANIZATION_ID: ${{ vars[format('PINGONE_PROD_{0}_FF_ORG_ID', matrix.region)] }}
+      # Two vars needed for application data source acceptance tests - can be removed when CDI-631 is done
+      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
+      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
 
     timeout-minutes: 45
 

--- a/.github/workflows/acceptance-test-beta-multi-version.yml
+++ b/.github/workflows/acceptance-test-beta-multi-version.yml
@@ -44,6 +44,9 @@ jobs:
       PINGONE_REGION_CODE: "EU"
       PINGONE_LICENSE_ID: ${{ vars.PINGONE_PROD_EU_FF_LICENSE_ID }}
       PINGONE_ORGANIZATION_ID: ${{ vars.PINGONE_PROD_EU_FF_ORG_ID }}
+      # Two vars needed for application data source acceptance tests - can be removed when CDI-631 is done
+      PINGONE_KEY_PKCS7_CERT: ${{ secrets.PINGONE_KEY_PKCS7_CERT }}
+      PINGONE_KEY_PEM_CERT: ${{ secrets.PINGONE_KEY_PEM_CERT }}
 
     timeout-minutes: 45
     strategy:


### PR DESCRIPTION
## Change Description
Add needed variables for `TestAccApplicationDataSource_SAMLAppByID` test that is now running in beta test runs.

## Change Characteristics

- [x] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [x] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged


## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [ ] Acceptance tests _(please paste commands and results below)_
- [x] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### End-to-end Tests Workflow Links
<!-- Use the following section to list the URLs to the end-to-end test action workflow runs -->
https://github.com/pingidentity/terraform-provider-pingone/actions/runs/18317334460
Failures in the above due to davinci access errors, not related to application tests.