### PR TITLE
Fix beta build failure: update field name to match bumped pingone-go-client dependency

### DIFF
--- a/internal/service/davinci/resource_davinci_variable_gen.go
+++ b/internal/service/davinci/resource_davinci_variable_gen.go
@@ -313,7 +313,7 @@ func (model *davinciVariableResourceModel) buildClientStructPost() (*pingone.DaV
 					fmt.Sprintf("The value provided for json_object could not be parsed as json: %s", err.Error()),
 				)
 			}
-			valueValue.MapmapOfStringAny = &jsonValueMap
+			valueValue.Object = &jsonValueMap
 		}
 		if !valueAttrs["string"].IsNull() && !valueAttrs["string"].IsUnknown() {
 			valueValue.String = valueAttrs["string"].(types.String).ValueStringPointer()
@@ -393,7 +393,7 @@ func (model *davinciVariableResourceModel) buildClientStructPut() (*pingone.DaVi
 					fmt.Sprintf("The value provided for json_object could not be parsed as json: %s", err.Error()),
 				)
 			}
-			valueValue.MapmapOfStringAny = &jsonValueMap
+			valueValue.Object = &jsonValueMap
 		}
 		if !valueAttrs["string"].IsNull() && !valueAttrs["string"].IsUnknown() {
 			valueValue.String = valueAttrs["string"].(types.String).ValueStringPointer()
@@ -470,8 +470,8 @@ func (state *davinciVariableResourceModel) readClientResponse(response *pingone.
 		valueValue = types.ObjectNull(valueAttrTypes)
 	} else {
 		jsonObjectValue := jsontypes.NewNormalizedNull()
-		if response.Value.MapmapOfStringAny != nil {
-			jsonObjectBytes, err := json.Marshal(response.Value.MapmapOfStringAny)
+		if response.Value.Object != nil {
+			jsonObjectBytes, err := json.Marshal(response.Value.Object)
 			if err != nil {
 				respDiags.AddAttributeError(
 					path.Root("value").AtName("json_object"),


### PR DESCRIPTION
## Change Description
Fix compile failures in the beta provider build in `pingone_davinci_variable`, due to the client changing a field name.

## Change Characteristics

- [x] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [x] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
% TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 300s -run ^TestAcc github.com/pingidentity/terraform-provider-pingone/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccDavinciVariable_RemovalDrift
=== PAUSE TestAccDavinciVariable_RemovalDrift
=== RUN   TestAccDavinciVariable_MinimalMaximal
=== PAUSE TestAccDavinciVariable_MinimalMaximal
=== RUN   TestAccDavinciVariable_Boolean
=== PAUSE TestAccDavinciVariable_Boolean
=== RUN   TestAccDavinciVariable_Number
=== PAUSE TestAccDavinciVariable_Number
=== RUN   TestAccDavinciVariable_Secret
=== PAUSE TestAccDavinciVariable_Secret
=== RUN   TestAccDavinciVariable_ChangeDataType
=== PAUSE TestAccDavinciVariable_ChangeDataType
=== RUN   TestAccDavinciVariable_UserContextClean
=== PAUSE TestAccDavinciVariable_UserContextClean
=== RUN   TestAccDavinciVariable_UserContextWithBootstrap
=== PAUSE TestAccDavinciVariable_UserContextWithBootstrap
=== RUN   TestAccDavinciVariable_FlowContextClean
    resource_davinci_variable_gen_test.go:312: Skipping TestAccDavinciVariable_FlowContext until pingone_davinci_flow is available for use in tests
--- SKIP: TestAccDavinciVariable_FlowContextClean (0.00s)
=== RUN   TestAccDavinciVariable_FlowContextWithBootstrap
    resource_davinci_variable_gen_test.go:312: Skipping TestAccDavinciVariable_FlowContext until pingone_davinci_flow is available for use in tests
--- SKIP: TestAccDavinciVariable_FlowContextWithBootstrap (0.00s)
=== RUN   TestAccDavinciVariable_SecretValueTypesClean
=== PAUSE TestAccDavinciVariable_SecretValueTypesClean
=== RUN   TestAccDavinciVariable_SecretValueTypesWithBootstrap
=== PAUSE TestAccDavinciVariable_SecretValueTypesWithBootstrap
=== RUN   TestAccDavinciVariable_NewEnv
=== PAUSE TestAccDavinciVariable_NewEnv
=== RUN   TestAccDavinciVariable_BadParameters
=== PAUSE TestAccDavinciVariable_BadParameters
=== CONT  TestAccDavinciVariable_RemovalDrift
=== CONT  TestAccDavinciVariable_UserContextClean
=== CONT  TestAccDavinciVariable_Number
=== CONT  TestAccDavinciVariable_Boolean
=== CONT  TestAccDavinciVariable_MinimalMaximal
=== CONT  TestAccDavinciVariable_SecretValueTypesWithBootstrap
=== CONT  TestAccDavinciVariable_Secret
=== CONT  TestAccDavinciVariable_BadParameters
=== CONT  TestAccDavinciVariable_SecretValueTypesClean
=== CONT  TestAccDavinciVariable_NewEnv
=== CONT  TestAccDavinciVariable_UserContextWithBootstrap
=== CONT  TestAccDavinciVariable_ChangeDataType
--- PASS: TestAccDavinciVariable_Boolean (10.29s)
--- PASS: TestAccDavinciVariable_Secret (12.88s)
--- PASS: TestAccDavinciVariable_Number (13.06s)
--- PASS: TestAccDavinciVariable_BadParameters (18.81s)
--- PASS: TestAccDavinciVariable_UserContextWithBootstrap (18.89s)
--- PASS: TestAccDavinciVariable_UserContextClean (19.42s)
--- PASS: TestAccDavinciVariable_ChangeDataType (19.81s)
--- PASS: TestAccDavinciVariable_SecretValueTypesWithBootstrap (21.22s)
--- PASS: TestAccDavinciVariable_SecretValueTypesClean (23.33s)
--- PASS: TestAccDavinciVariable_MinimalMaximal (30.00s)
--- PASS: TestAccDavinciVariable_NewEnv (44.80s)
--- PASS: TestAccDavinciVariable_RemovalDrift (81.77s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/davinci	82.451s
```

</details>

### End-to-end Tests Workflow Links
<!-- Use the following section to list the URLs to the end-to-end test action workflow runs -->

- 