### PR TITLE
Prevent inconsistent value errors for zero-values in pingone_davinci_variable

### DIFF
--- a/internal/service/davinci/resource_davinci_variable_gen.go
+++ b/internal/service/davinci/resource_davinci_variable_gen.go
@@ -312,6 +312,12 @@ func (model *davinciVariableResourceModel) buildClientStructPost() (*pingone.DaV
 			valueValue.Bool = nil
 		}
 		valueValue.Float32 = valueAttrs["float32"].(types.Float32).ValueFloat32Pointer()
+		// Workaround TRIAGE-27920 - unable to set 0 number value
+		if valueValue.Float32 != nil && *valueValue.Float32 == 0 {
+			floatStr := strconv.FormatFloat(float64(*valueValue.Float32), 'f', -1, 32)
+			valueValue.String = &floatStr
+			valueValue.Float32 = nil
+		}
 		if !valueAttrs["json_object"].IsNull() && !valueAttrs["json_object"].IsUnknown() {
 			var jsonValueMap map[string]interface{}
 			err := json.Unmarshal([]byte(valueAttrs["json_object"].(jsontypes.Normalized).ValueString()), &jsonValueMap)
@@ -398,6 +404,12 @@ func (model *davinciVariableResourceModel) buildClientStructPut() (*pingone.DaVi
 			valueValue.Bool = nil
 		}
 		valueValue.Float32 = valueAttrs["float32"].(types.Float32).ValueFloat32Pointer()
+		// Workaround TRIAGE-27920 - unable to set 0 number value
+		if valueValue.Float32 != nil && *valueValue.Float32 == 0 {
+			floatStr := strconv.FormatFloat(float64(*valueValue.Float32), 'f', -1, 32)
+			valueValue.String = &floatStr
+			valueValue.Float32 = nil
+		}
 		if !valueAttrs["json_object"].IsNull() && !valueAttrs["json_object"].IsUnknown() {
 			var jsonValueMap map[string]interface{}
 			err := json.Unmarshal([]byte(valueAttrs["json_object"].(jsontypes.Normalized).ValueString()), &jsonValueMap)
@@ -508,6 +520,15 @@ func (state *davinciVariableResourceModel) readClientResponse(response *pingone.
 			// The API has returned a string "false" instead of a boolean false
 			boolValue := false
 			response.Value.Bool = &boolValue
+			response.Value.String = nil
+		}
+		// Workaround TRIAGE-27920 - unable to set 0 number value
+		if stateValueAttrs != nil &&
+			!stateValueAttrs["float32"].IsNull() && !stateValueAttrs["float32"].IsUnknown() &&
+			response.Value.String != nil && *response.Value.String == "0" {
+			// The API has returned a string "0" instead of a number 0
+			floatValue := float32(0)
+			response.Value.Float32 = &floatValue
 			response.Value.String = nil
 		}
 		// For secret types, the API always returns a series of asterisks for the string value

--- a/internal/service/davinci/resource_davinci_variable_gen_test.go
+++ b/internal/service/davinci/resource_davinci_variable_gen_test.go
@@ -200,6 +200,21 @@ func TestAccDavinciVariable_Number(t *testing.T) {
 				Config: davinciVariable_NumberHCL(resourceName),
 				Check:  davinciVariable_CheckComputedValuesMinimal(resourceName),
 			},
+			{
+				// Update to zero
+				Config: davinciVariable_NumberZeroHCL(resourceName),
+				Check:  davinciVariable_CheckComputedValuesMinimal(resourceName),
+			},
+			{
+				// Destroy the resource
+				Config:  davinciVariable_NumberZeroHCL(resourceName),
+				Destroy: true,
+			},
+			{
+				// Create as zero
+				Config: davinciVariable_NumberZeroHCL(resourceName),
+				Check:  davinciVariable_CheckComputedValuesMinimal(resourceName),
+			},
 		},
 	})
 }
@@ -949,6 +964,23 @@ resource "pingone_davinci_variable" "%[2]s" {
   name           = "%[2]s"
   value = {
     secret_string = ""
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName)
+}
+
+func davinciVariable_NumberZeroHCL(resourceName string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_davinci_variable" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  context        = "flowInstance"
+  data_type      = "number"
+  mutable        = false
+  name           = "%[2]s"
+  value = {
+    float32 = 0
   }
 }
 `, acctest.GenericSandboxEnvironment(), resourceName)


### PR DESCRIPTION
## Change Description
- Enforce string length of at least 1 for `value.string` and `value.secret_string`.
- Use similar workaround for boolean `false` values to allow number values of `0`. I chose to allow these instead of enforcing validation like I did with the strings, because it felt more reasonable to want to explicitly set a number value to 0 than to want to set a string to empty string.
- CDI-816

## Change Characteristics

- [x] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [x] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 300s -run ^TestAccDavinciVariable github.com/pingidentity/terraform-provider-pingone/internal/service/davinci
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccDavinciVariable_RemovalDrift
=== PAUSE TestAccDavinciVariable_RemovalDrift
=== RUN   TestAccDavinciVariable_MinimalMaximal
=== PAUSE TestAccDavinciVariable_MinimalMaximal
=== RUN   TestAccDavinciVariable_Boolean
=== PAUSE TestAccDavinciVariable_Boolean
=== RUN   TestAccDavinciVariable_Number
=== PAUSE TestAccDavinciVariable_Number
=== RUN   TestAccDavinciVariable_Secret
=== PAUSE TestAccDavinciVariable_Secret
=== RUN   TestAccDavinciVariable_ChangeDataType
=== PAUSE TestAccDavinciVariable_ChangeDataType
=== RUN   TestAccDavinciVariable_UserContextClean
=== PAUSE TestAccDavinciVariable_UserContextClean
=== RUN   TestAccDavinciVariable_UserContextWithBootstrap
=== PAUSE TestAccDavinciVariable_UserContextWithBootstrap
=== RUN   TestAccDavinciVariable_FlowContextClean
=== PAUSE TestAccDavinciVariable_FlowContextClean
=== RUN   TestAccDavinciVariable_FlowContextWithBootstrap
=== PAUSE TestAccDavinciVariable_FlowContextWithBootstrap
=== RUN   TestAccDavinciVariable_SecretValueTypesClean
=== PAUSE TestAccDavinciVariable_SecretValueTypesClean
=== RUN   TestAccDavinciVariable_SecretValueTypesWithBootstrap
=== PAUSE TestAccDavinciVariable_SecretValueTypesWithBootstrap
=== RUN   TestAccDavinciVariable_NewEnv
=== PAUSE TestAccDavinciVariable_NewEnv
=== RUN   TestAccDavinciVariable_BadParameters
=== PAUSE TestAccDavinciVariable_BadParameters
=== RUN   TestAccDavinciVariable_InvalidConfig
=== PAUSE TestAccDavinciVariable_InvalidConfig
=== CONT  TestAccDavinciVariable_RemovalDrift
=== CONT  TestAccDavinciVariable_FlowContextClean
=== CONT  TestAccDavinciVariable_Secret
=== CONT  TestAccDavinciVariable_UserContextClean
=== CONT  TestAccDavinciVariable_Boolean
=== CONT  TestAccDavinciVariable_Number
=== CONT  TestAccDavinciVariable_ChangeDataType
=== CONT  TestAccDavinciVariable_SecretValueTypesClean
=== CONT  TestAccDavinciVariable_SecretValueTypesWithBootstrap
=== CONT  TestAccDavinciVariable_MinimalMaximal
=== CONT  TestAccDavinciVariable_InvalidConfig
=== CONT  TestAccDavinciVariable_UserContextWithBootstrap
=== CONT  TestAccDavinciVariable_FlowContextWithBootstrap
=== CONT  TestAccDavinciVariable_BadParameters
=== CONT  TestAccDavinciVariable_NewEnv
--- PASS: TestAccDavinciVariable_InvalidConfig (5.52s)
--- PASS: TestAccDavinciVariable_Secret (13.93s)
--- PASS: TestAccDavinciVariable_FlowContextClean (19.58s)
--- PASS: TestAccDavinciVariable_FlowContextWithBootstrap (21.31s)
--- PASS: TestAccDavinciVariable_UserContextClean (21.99s)
--- PASS: TestAccDavinciVariable_BadParameters (23.20s)
--- PASS: TestAccDavinciVariable_ChangeDataType (25.72s)
--- PASS: TestAccDavinciVariable_UserContextWithBootstrap (25.85s)
--- PASS: TestAccDavinciVariable_SecretValueTypesWithBootstrap (26.31s)
--- PASS: TestAccDavinciVariable_SecretValueTypesClean (28.26s)
--- PASS: TestAccDavinciVariable_Number (28.75s)
--- PASS: TestAccDavinciVariable_Boolean (31.63s)
--- PASS: TestAccDavinciVariable_MinimalMaximal (44.06s)
--- PASS: TestAccDavinciVariable_NewEnv (45.89s)
--- PASS: TestAccDavinciVariable_RemovalDrift (87.28s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/davinci	88.201s
```

</details>

### End-to-end Tests Workflow Links
<!-- Use the following section to list the URLs to the end-to-end test action workflow runs -->

- 