### PR TITLE
Add support for `fido2.failure` to MFA device policy resources

### DIFF
--- a/.changelog/pr-1286.txt
+++ b/.changelog/pr-1286.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+`resource/pingone_mfa_device_policy`: Added support for `fido2.failure` attribute
+```
+
+```release-note:enhancement
+`resource/pingone_mfa_device_policy_default`: Added support for `fido2.failure` attribute
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 *.dll
 *.exe
 .DS_Store

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -344,7 +344,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the length of time that push notifications should be blocked for the application if the defined limit has been reached. The minimum value is `1` minute and the maximum value is `120` minutes. If this parameter is not provided, the default value is `30` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 <a id="nestedatt--mobile--applications--push_limit--time_period"></a>
@@ -353,7 +353,7 @@ Required:
 Required:
 
 - `duration` (Number) An integer that defines the length of time that push notifications should be blocked for the application if the defined limit has been reached. The minimum value is `1` minute and the maximum value is `120` minutes. If this parameter is not provided, the default value is `30` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -394,7 +394,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. The minimum value is `2`, maximum is `30`, and the default is `2`. Note that when using the "onetime authentication" feature, the user is not blocked after the maximum number of failures even if you specified a block duration.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -489,7 +489,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -582,7 +582,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `2` minutes and the maximum value is `30` minutes.  Defaults to `2`.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 ## Import
 

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -563,9 +563,26 @@ Required:
 
 Optional:
 
+- `failure` (Attributes) A single object that allows configuration of FIDO2 authentication failure settings. (see [below for nested schema](#nestedatt--fido2--failure))
 - `fido2_policy_id` (String) A string that specifies the resource UUID that represents the FIDO2 policy in PingOne. This property can be null / left undefined. When null, the environment's default FIDO2 Policy is used.  Must be a valid PingOne resource ID.
 - `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the FIDO2 method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
 - `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
+
+<a id="nestedatt--fido2--failure"></a>
+### Nested Schema for `fido2.failure`
+
+Optional:
+
+- `cool_down` (Attributes) A single object that allows configuration of FIDO2 authentication failure cool down settings. (see [below for nested schema](#nestedatt--fido2--failure--cool_down))
+- `count` (Number) An integer that defines the maximum number of times that authentication can fail before the user is blocked. The minimum value is `1` and the maximum value is `7`.  Defaults to `3`.
+
+<a id="nestedatt--fido2--failure--cool_down"></a>
+### Nested Schema for `fido2.failure.cool_down`
+
+Required:
+
+- `duration` (Number) An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `2` minutes and the maximum value is `30` minutes.  Defaults to `2`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
 
 ## Import
 

--- a/docs/resources/mfa_device_policy_default.md
+++ b/docs/resources/mfa_device_policy_default.md
@@ -827,9 +827,28 @@ Required:
 
 Optional:
 
+- `failure` (Attributes) A single object that allows configuration of FIDO2 authentication failure settings. (see [below for nested schema](#nestedatt--fido2--failure))
 - `fido2_policy_id` (String) A string that specifies the resource UUID that represents the FIDO2 policy in PingOne. When null, the environment's default FIDO2 Policy is used.
 - `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the FIDO2 method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
 - `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
+
+<a id="nestedatt--fido2--failure"></a>
+### Nested Schema for `fido2.failure`
+
+Optional:
+
+- `cool_down` (Attributes) A single object that allows configuration of FIDO2 authentication failure cool down settings. (see [below for nested schema](#nestedatt--fido2--failure--cool_down))
+- `count` (Number) An integer that defines the maximum number of times that authentication can fail before user is blocked for the specified period. The minimum value is `1` and the maximum value is `7`.
+
+<a id="nestedatt--fido2--failure--cool_down"></a>
+### Nested Schema for `fido2.failure.cool_down`
+
+Required:
+
+- `duration` (Number) An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `2` minutes and the maximum value is `30` minutes.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+
+
 
 
 <a id="nestedatt--notifications_policy"></a>

--- a/docs/resources/mfa_device_policy_default.md
+++ b/docs/resources/mfa_device_policy_default.md
@@ -558,7 +558,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the length of time that push notifications should be blocked for the application if the defined limit has been reached. The minimum value is `1` minute and the maximum value is `120` minutes. Defaults to `30` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 <a id="nestedatt--mobile--applications--push_limit--time_period"></a>
@@ -567,7 +567,7 @@ Required:
 Required:
 
 - `duration` (Number) An integer that defines the time period window where the push notification limit applies. If the limit is reached within this period, push notifications are blocked. The minimum value is `1` minute and the maximum value is `120` minutes. Defaults to `10` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -608,7 +608,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. The minimum value is `2`, maximum is `30`.  Defaults to `2`.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -703,7 +703,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -803,7 +803,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Must be between `1` seconds and `30` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -838,15 +838,15 @@ Optional:
 Optional:
 
 - `cool_down` (Attributes) A single object that allows configuration of FIDO2 authentication failure cool down settings. (see [below for nested schema](#nestedatt--fido2--failure--cool_down))
-- `count` (Number) An integer that defines the maximum number of times that authentication can fail before user is blocked for the specified period. The minimum value is `1` and the maximum value is `7`.
+- `count` (Number) An integer that defines the maximum number of times that authentication can fail before user is blocked for the specified period. The minimum value is `1` and the maximum value is `7`.  Defaults to `3`.
 
 <a id="nestedatt--fido2--failure--cool_down"></a>
 ### Nested Schema for `fido2.failure.cool_down`
 
 Required:
 
-- `duration` (Number) An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `2` minutes and the maximum value is `30` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `duration` (Number) An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `2` minutes and the maximum value is `30` minutes.  Defaults to `2`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -891,7 +891,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Must be between `1` seconds and `30` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 
@@ -967,7 +967,7 @@ Optional:
 Required:
 
 - `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures. Must be between `1` seconds and `30` minutes.
-- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
 
 
 

--- a/internal/acctest/service/mfa/mfa_device_policy_default.go
+++ b/internal/acctest/service/mfa/mfa_device_policy_default.go
@@ -292,6 +292,18 @@ func MFADevicePolicyDefault_CheckDestroy(s *terraform.State) error {
 			return fmt.Errorf("expected FIDO2 PromptForNicknameOnPairing to be false")
 		}
 
+		if v := policy.Fido2.Failure.GetCount(); v != 3 {
+			return fmt.Errorf("expected FIDO2 Otp.Failure.Count to be 3, got %d", v)
+		}
+
+		if v := policy.Fido2.Failure.CoolDown.GetDuration(); v != 2 {
+			return fmt.Errorf("expected FIDO2 Otp.Failure.CoolDown.Duration to be 2, got %d", v)
+		}
+
+		if v := policy.Fido2.Failure.CoolDown.GetTimeUnit(); v != mfa.ENUMTIMEUNIT_MINUTES {
+			return fmt.Errorf("expected FIDO2 Otp.Failure.CoolDown.TimeUnit to be MINUTES, got %s", v)
+		}
+
 		// OATH Token
 		if policy.OathToken.GetEnabled() {
 			return fmt.Errorf("expected OATH Token to be disabled")

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -357,7 +357,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 
 	durationTimeUnitMinsSecondsDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the type of time unit for `duration`.",
-	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues)
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
 
 	mobileApplicationsPairingKeyLifetimeTimeUnitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the type of time unit for `duration`.",

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -938,6 +938,13 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that allows configuration of FIDO2 authentication failure cool down settings.").Description,
 								Optional:    true,
 								Computed:    true,
+								Default: objectdefault.StaticValue(types.ObjectValueMust(
+									MFADevicePolicyTimePeriodTFObjectTypes,
+									map[string]attr.Value{
+										"duration":  types.Int32Value(fido2FailureCoolDownDurationDefault),
+										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+									},
+								)),
 
 								Attributes: map[string]schema.Attribute{
 									"duration": schema.Int32Attribute{

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -102,6 +102,7 @@ type MFADevicePolicyTimePeriodResourceModel struct {
 
 type MFADevicePolicyFido2ResourceModel struct {
 	Enabled                    types.Bool                   `tfsdk:"enabled"`
+	Failure                    types.Object                 `tfsdk:"failure"`
 	Fido2PolicyId              pingonetypes.ResourceIDValue `tfsdk:"fido2_policy_id"`
 	PairingDisabled            types.Bool                   `tfsdk:"pairing_disabled"`
 	PromptForNicknameOnPairing types.Bool                   `tfsdk:"prompt_for_nickname_on_pairing"`
@@ -245,6 +246,7 @@ var (
 
 	MFADevicePolicyFido2TFObjectTypes = map[string]attr.Type{
 		"enabled":                        types.BoolType,
+		"failure":                        types.ObjectType{AttrTypes: MFADevicePolicyFailureTFObjectTypes},
 		"fido2_policy_id":                pingonetypes.ResourceIDType{},
 		"pairing_disabled":               types.BoolType,
 		"prompt_for_nickname_on_pairing": types.BoolType,
@@ -284,6 +286,13 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 
 	const totpOtpFailureCountDefault = 3
 	const totpOtpFailureCoolDownDurationDefault = 2
+
+	const fido2FailureCountDefault = 3
+	const fido2FailureCoolDownDurationDefault = 2
+	const fido2FailureCountMin = 1
+	const fido2FailureCountMax = 7
+	const fido2FailureCoolDownDurationMin = 2
+	const fido2FailureCoolDownDurationMax = 30
 
 	// schema descriptions and validation settings
 	deviceSelectionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -367,6 +376,14 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	fido2PairingDisabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that, when set to `true`, prevents users from pairing new devices with the FIDO2 method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.",
 	).DefaultValue(false)
+
+	fido2FailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that defines the maximum number of times that authentication can fail before the user is blocked. The minimum value is `%d`, the maximum value is `%d`, and the default is `%d`.", fido2FailureCountMin, fido2FailureCountMax, fido2FailureCountDefault),
+	)
+
+	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes (`%d` seconds), the maximum value is `%d` minutes (`%d` seconds), and the default is `%d` minutes (`%d` seconds).", fido2FailureCoolDownDurationMin, fido2FailureCoolDownDurationMin*60, fido2FailureCoolDownDurationMax, fido2FailureCoolDownDurationMax*60, fido2FailureCoolDownDurationDefault, fido2FailureCoolDownDurationDefault*60),
+	)
 
 	promptForNicknameOnPairingDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.",
@@ -857,7 +874,20 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 				Computed:    true,
 				Default: objectdefault.StaticValue(types.ObjectValueMust(MFADevicePolicyFido2TFObjectTypes,
 					map[string]attr.Value{
-						"enabled":                        types.BoolValue(false),
+						"enabled": types.BoolValue(false),
+						"failure": types.ObjectValueMust(
+							MFADevicePolicyFailureTFObjectTypes,
+							map[string]attr.Value{
+								"count": types.Int32Value(fido2FailureCountDefault),
+								"cool_down": types.ObjectValueMust(
+									MFADevicePolicyTimePeriodTFObjectTypes,
+									map[string]attr.Value{
+										"duration":  types.Int32Value(fido2FailureCoolDownDurationDefault),
+										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+									},
+								),
+							},
+						),
 						"fido2_policy_id":                framework.PingOneResourceIDToTF(""),
 						"pairing_disabled":               types.BoolNull(),
 						"prompt_for_nickname_on_pairing": types.BoolNull(),
@@ -867,6 +897,71 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 					"enabled": schema.BoolAttribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("A boolean that specifies whether the FIDO2 method is enabled or disabled in the policy.").Description,
 						Required:    true,
+					},
+
+					"failure": schema.SingleNestedAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that allows configuration of FIDO2 authentication failure settings.").Description,
+						Optional:    true,
+						Computed:    true,
+
+						Default: objectdefault.StaticValue(types.ObjectValueMust(
+							MFADevicePolicyFailureTFObjectTypes,
+							map[string]attr.Value{
+								"count": types.Int32Value(fido2FailureCountDefault),
+								"cool_down": types.ObjectValueMust(
+									MFADevicePolicyTimePeriodTFObjectTypes,
+									map[string]attr.Value{
+										"duration":  types.Int32Value(fido2FailureCoolDownDurationDefault),
+										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+									},
+								),
+							},
+						)),
+
+						Attributes: map[string]schema.Attribute{
+							"count": schema.Int32Attribute{
+								Description: fido2FailureCountDescription.Description,
+								Optional:    true,
+								Computed:    true,
+
+								Default: int32default.StaticInt32(fido2FailureCountDefault),
+
+								Validators: []validator.Int32{
+									int32validator.Between(fido2FailureCountMin, fido2FailureCountMax),
+								},
+							},
+
+							"cool_down": schema.SingleNestedAttribute{
+								Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that allows configuration of FIDO2 authentication failure cool down settings.").Description,
+								Optional:    true,
+								Computed:    true,
+
+								Default: objectdefault.StaticValue(types.ObjectValueMust(
+									MFADevicePolicyTimePeriodTFObjectTypes,
+									map[string]attr.Value{
+										"duration":  types.Int32Value(fido2FailureCoolDownDurationDefault),
+										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+									},
+								)),
+
+								Attributes: map[string]schema.Attribute{
+									"duration": schema.Int32Attribute{
+										Description: fido2FailureCoolDownDurationDescription.Description,
+										Required:    true,
+									},
+
+									"time_unit": schema.StringAttribute{
+										Description:         durationTimeUnitMinsSecondsDescription.Description,
+										MarkdownDescription: durationTimeUnitMinsSecondsDescription.MarkdownDescription,
+										Required:            true,
+
+										Validators: []validator.String{
+											stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+										},
+									},
+								},
+							},
+						},
 					},
 
 					"pairing_disabled": schema.BoolAttribute{
@@ -1969,6 +2064,40 @@ func (p *MFADevicePolicyFido2ResourceModel) expand() *mfa.DeviceAuthenticationPo
 		data.SetFido2PolicyId(p.Fido2PolicyId.ValueString())
 	}
 
+	if !p.Failure.IsNull() && !p.Failure.IsUnknown() {
+		failure := mfa.NewDeviceAuthenticationPolicyCommonFido2Failure()
+
+		if count, ok := p.Failure.Attributes()["count"]; ok {
+			if countType, ok := count.(types.Int32); ok && !countType.IsNull() && !countType.IsUnknown() {
+				failure.SetCount(countType.ValueInt32())
+			}
+		}
+
+		if coolDown, ok := p.Failure.Attributes()["cool_down"]; ok {
+			if coolDownType, ok := coolDown.(types.Object); ok && !coolDownType.IsNull() && !coolDownType.IsUnknown() {
+				coolDownObj := mfa.NewDeviceAuthenticationPolicyCommonFido2FailureCoolDown()
+
+				if duration, ok := coolDownType.Attributes()["duration"]; ok {
+					if durationType, ok := duration.(types.Int32); ok && !durationType.IsNull() && !durationType.IsUnknown() {
+						coolDownObj.SetDuration(durationType.ValueInt32())
+					}
+				}
+
+				if timeUnit, ok := coolDownType.Attributes()["time_unit"]; ok {
+					if timeUnitType, ok := timeUnit.(types.String); ok && !timeUnitType.IsNull() && !timeUnitType.IsUnknown() {
+						coolDownObj.SetTimeUnit(mfa.EnumTimeUnit(timeUnitType.ValueString()))
+					}
+				}
+
+				failure.SetCoolDown(*coolDownObj)
+			}
+		}
+
+		if failure.HasCount() || failure.HasCoolDown() {
+			data.SetFailure(*failure)
+		}
+	}
+
 	if !p.PromptForNicknameOnPairing.IsNull() && !p.PromptForNicknameOnPairing.IsUnknown() {
 		data.SetPromptForNicknameOnPairing(p.PromptForNicknameOnPairing.ValueBool())
 	}
@@ -2635,14 +2764,63 @@ func toStateMfaDevicePolicyFido2(apiObject *mfa.DeviceAuthenticationPolicyCommon
 		return types.ObjectNull(MFADevicePolicyFido2TFObjectTypes), nil
 	}
 
+	failure, d := toStateMfaDevicePolicyFido2Failure(apiObject.GetFailureOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(MFADevicePolicyFido2TFObjectTypes), diags
+	}
+
 	o := map[string]attr.Value{
 		"enabled":                        framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"failure":                        failure,
 		"fido2_policy_id":                framework.PingOneResourceIDOkToTF(apiObject.GetFido2PolicyIdOk()),
 		"pairing_disabled":               framework.BoolOkToTF(apiObject.GetPairingDisabledOk()),
 		"prompt_for_nickname_on_pairing": framework.BoolOkToTF(apiObject.GetPromptForNicknameOnPairingOk()),
 	}
 
 	objValue, d := types.ObjectValue(MFADevicePolicyFido2TFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
+}
+
+func toStateMfaDevicePolicyFido2Failure(apiObject *mfa.DeviceAuthenticationPolicyCommonFido2Failure, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFADevicePolicyFailureTFObjectTypes), nil
+	}
+
+	coolDown, d := toStateMfaDevicePolicyFido2FailureCoolDown(apiObject.GetCoolDownOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(MFADevicePolicyFailureTFObjectTypes), diags
+	}
+
+	o := map[string]attr.Value{
+		"cool_down": coolDown,
+		"count":     framework.Int32OkToTF(apiObject.GetCountOk()),
+	}
+
+	objValue, d := types.ObjectValue(MFADevicePolicyFailureTFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
+}
+
+func toStateMfaDevicePolicyFido2FailureCoolDown(apiObject *mfa.DeviceAuthenticationPolicyCommonFido2FailureCoolDown, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFADevicePolicyTimePeriodTFObjectTypes), nil
+	}
+
+	o := map[string]attr.Value{
+		"duration":  framework.Int32OkToTF(apiObject.GetDurationOk()),
+		"time_unit": framework.EnumOkToTF(apiObject.GetTimeUnitOk()),
+	}
+
+	objValue, d := types.ObjectValue(MFADevicePolicyTimePeriodTFObjectTypes, o)
 	diags.Append(d...)
 
 	return objValue, diags

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -380,8 +380,8 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	).DefaultValue(false)
 
 	fido2FailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		fmt.Sprintf("An integer that defines the maximum number of times that authentication can fail before the user is blocked. The minimum value is `%d`, the maximum value is `%d`, and the default is `%d`.", fido2FailureCountMin, fido2FailureCountMax, fido2FailureCountDefault),
-	)
+		fmt.Sprintf("An integer that defines the maximum number of times that authentication can fail before the user is blocked. The minimum value is `%d` and the maximum value is `%d`.", fido2FailureCountMin, fido2FailureCountMax),
+	).DefaultValue(fido2FailureCountDefault)
 
 	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes and the maximum value is `%d` minutes.", fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
@@ -922,9 +922,10 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 
 						Attributes: map[string]schema.Attribute{
 							"count": schema.Int32Attribute{
-								Description: fido2FailureCountDescription.Description,
-								Optional:    true,
-								Computed:    true,
+								Description:         fido2FailureCountDescription.Description,
+								MarkdownDescription: fido2FailureCountDescription.MarkdownDescription,
+								Optional:            true,
+								Computed:            true,
 
 								Default: int32default.StaticInt32(fido2FailureCountDefault),
 
@@ -938,18 +939,11 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 								Optional:    true,
 								Computed:    true,
 
-								Default: objectdefault.StaticValue(types.ObjectValueMust(
-									MFADevicePolicyTimePeriodTFObjectTypes,
-									map[string]attr.Value{
-										"duration":  types.Int32Value(fido2FailureCoolDownDurationDefault),
-										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
-									},
-								)),
-
 								Attributes: map[string]schema.Attribute{
 									"duration": schema.Int32Attribute{
-										Description: fido2FailureCoolDownDurationDescription.Description,
-										Required:    true,
+										Description:         fido2FailureCoolDownDurationDescription.Description,
+										MarkdownDescription: fido2FailureCoolDownDurationDescription.MarkdownDescription,
+										Required:            true,
 									},
 
 									"time_unit": schema.StringAttribute{

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -2096,9 +2096,7 @@ func (p *MFADevicePolicyFido2ResourceModel) expand() *mfa.DeviceAuthenticationPo
 			}
 		}
 
-		if failure.HasCount() || failure.HasCoolDown() {
-			data.SetFailure(*failure)
-		}
+		data.SetFailure(*failure)
 	}
 
 	if !p.PromptForNicknameOnPairing.IsNull() && !p.PromptForNicknameOnPairing.IsUnknown() {

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -291,8 +291,10 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	const fido2FailureCoolDownDurationDefault = 2
 	const fido2FailureCountMin = 1
 	const fido2FailureCountMax = 7
-	const fido2FailureCoolDownDurationMin = 2
-	const fido2FailureCoolDownDurationMax = 30
+	const fido2FailureCoolDownDurationMinMinutes = 2
+	const fido2FailureCoolDownDurationMaxMinutes = 30
+	const fido2FailureCoolDownDurationMinSeconds = fido2FailureCoolDownDurationMinMinutes * 60
+	const fido2FailureCoolDownDurationMaxSeconds = fido2FailureCoolDownDurationMaxMinutes * 60
 
 	// schema descriptions and validation settings
 	deviceSelectionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -382,8 +384,8 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	)
 
 	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		fmt.Sprintf("An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes (`%d` seconds), the maximum value is `%d` minutes (`%d` seconds), and the default is `%d` minutes (`%d` seconds).", fido2FailureCoolDownDurationMin, fido2FailureCoolDownDurationMin*60, fido2FailureCoolDownDurationMax, fido2FailureCoolDownDurationMax*60, fido2FailureCoolDownDurationDefault, fido2FailureCoolDownDurationDefault*60),
-	)
+		fmt.Sprintf("An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes and the maximum value is `%d` minutes.", fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
+	).DefaultValue(fido2FailureCoolDownDurationDefault)
 
 	promptForNicknameOnPairingDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.",

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -669,7 +669,7 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 
 	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes and the maximum value is `%d` minutes.", fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
-	).DefaultValue(fido2FailureCoolDownDurationDefault)
+	)
 
 	desktopDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("A single object that allows configuration of PingID desktop device authentication policy settings. Only applicable when `policy_type` is `%s`.", POLICY_TYPE_PINGID),

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -277,10 +277,10 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 	const fido2FailureCoolDownDurationDefault = 2
 	const fido2FailureCountMin = 1
 	const fido2FailureCountMax = 7
-	const fido2FailureCoolDownDurationMinSeconds = 120
-	const fido2FailureCoolDownDurationMaxSeconds = 1800
 	const fido2FailureCoolDownDurationMinMinutes = 2
 	const fido2FailureCoolDownDurationMaxMinutes = 30
+	const fido2FailureCoolDownDurationMinSeconds = fido2FailureCoolDownDurationMinMinutes * 60
+	const fido2FailureCoolDownDurationMaxSeconds = fido2FailureCoolDownDurationMaxMinutes * 60
 
 	const rememberMeWebLifeTimeDurationDefault = 30
 	const rememberMeWebLifeTimeDurationMinMinutes = 1
@@ -668,8 +668,8 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 	)
 
 	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		fmt.Sprintf("An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of failures. Must be between `%d` seconds and `%d` minutes.", fido2FailureCoolDownDurationMinSeconds, fido2FailureCoolDownDurationMaxMinutes),
-	)
+		fmt.Sprintf("An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes and the maximum value is `%d` minutes.", fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
+	).DefaultValue(fido2FailureCoolDownDurationDefault)
 
 	desktopDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("A single object that allows configuration of PingID desktop device authentication policy settings. Only applicable when `policy_type` is `%s`.", POLICY_TYPE_PINGID),

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -273,6 +273,15 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 	const totpOtpFailureCountDefault = 3
 	const totpOtpFailureCoolDownDurationDefault = 2
 
+	const fido2FailureCountDefault = 3
+	const fido2FailureCoolDownDurationDefault = 2
+	const fido2FailureCountMin = 1
+	const fido2FailureCountMax = 7
+	const fido2FailureCoolDownDurationMinSeconds = 120
+	const fido2FailureCoolDownDurationMaxSeconds = 1800
+	const fido2FailureCoolDownDurationMinMinutes = 2
+	const fido2FailureCoolDownDurationMaxMinutes = 30
+
 	const rememberMeWebLifeTimeDurationDefault = 30
 	const rememberMeWebLifeTimeDurationMinMinutes = 1
 	const rememberMeWebLifeTimeDurationMaxMinutes = 129600
@@ -644,6 +653,22 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 
 	fido2PolicyIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the resource UUID that represents the FIDO2 policy in PingOne. When null, the environment's default FIDO2 Policy is used.",
+	)
+
+	fido2FailureDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that allows configuration of FIDO2 authentication failure settings.",
+	)
+
+	fido2FailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that defines the maximum number of times that authentication can fail before user is blocked for the specified period. The minimum value is `%d` and the maximum value is `%d`.", fido2FailureCountMin, fido2FailureCountMax),
+	)
+
+	fido2FailureCoolDownDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that allows configuration of FIDO2 authentication failure cool down settings.",
+	)
+
+	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of failures. Must be between `%d` seconds and `%d` minutes.", fido2FailureCoolDownDurationMinSeconds, fido2FailureCoolDownDurationMaxMinutes),
 	)
 
 	desktopDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -1727,7 +1752,20 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 				Computed:            true,
 				Default: objectdefault.StaticValue(types.ObjectValueMust(MFADevicePolicyFido2TFObjectTypes,
 					map[string]attr.Value{
-						"enabled":                        types.BoolValue(false),
+						"enabled": types.BoolValue(false),
+						"failure": types.ObjectValueMust(
+							MFADevicePolicyFailureTFObjectTypes,
+							map[string]attr.Value{
+								"count": types.Int32Value(fido2FailureCountDefault),
+								"cool_down": types.ObjectValueMust(
+									MFADevicePolicyTimePeriodTFObjectTypes,
+									map[string]attr.Value{
+										"duration":  types.Int32Value(fido2FailureCoolDownDurationDefault),
+										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+									},
+								),
+							},
+						),
 						"fido2_policy_id":                pingonetypes.NewResourceIDNull(),
 						"pairing_disabled":               types.BoolValue(false),
 						"prompt_for_nickname_on_pairing": types.BoolNull(),
@@ -1738,6 +1776,83 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 						Description:         fido2EnabledDescription.Description,
 						MarkdownDescription: fido2EnabledDescription.MarkdownDescription,
 						Required:            true,
+					},
+
+					"failure": schema.SingleNestedAttribute{
+						Description:         fido2FailureDescription.Description,
+						MarkdownDescription: fido2FailureDescription.MarkdownDescription,
+						Optional:            true,
+						Computed:            true,
+						Default: objectdefault.StaticValue(types.ObjectValueMust(
+							MFADevicePolicyFailureTFObjectTypes,
+							map[string]attr.Value{
+								"count": types.Int32Value(fido2FailureCountDefault),
+								"cool_down": types.ObjectValueMust(
+									MFADevicePolicyTimePeriodTFObjectTypes,
+									map[string]attr.Value{
+										"duration":  types.Int32Value(fido2FailureCoolDownDurationDefault),
+										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+									},
+								),
+							},
+						)),
+
+						Attributes: map[string]schema.Attribute{
+							"count": schema.Int32Attribute{
+								Description:         fido2FailureCountDescription.Description,
+								MarkdownDescription: fido2FailureCountDescription.MarkdownDescription,
+								Optional:            true,
+
+								Validators: []validator.Int32{
+									int32validator.Between(fido2FailureCountMin, fido2FailureCountMax),
+								},
+							},
+
+							"cool_down": schema.SingleNestedAttribute{
+								Description:         fido2FailureCoolDownDescription.Description,
+								MarkdownDescription: fido2FailureCoolDownDescription.MarkdownDescription,
+								Optional:            true,
+
+								Attributes: map[string]schema.Attribute{
+									"duration": schema.Int32Attribute{
+										Description:         fido2FailureCoolDownDurationDescription.Description,
+										MarkdownDescription: fido2FailureCoolDownDurationDescription.MarkdownDescription,
+										Required:            true,
+
+										Validators: []validator.Int32{
+											int32validator.Any(
+												int32validator.All(
+													int32validator.Between(fido2FailureCoolDownDurationMinSeconds, fido2FailureCoolDownDurationMaxSeconds),
+													int32validatorinternal.RegexMatchesPathValue(
+														regexp.MustCompile(`SECONDS`),
+														fmt.Sprintf("If `time_unit` is `SECONDS`, the allowed duration range is %d - %d.", fido2FailureCoolDownDurationMinSeconds, fido2FailureCoolDownDurationMaxSeconds),
+														path.MatchRelative().AtParent().AtName("time_unit"),
+													),
+												),
+												int32validator.All(
+													int32validator.Between(fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
+													int32validatorinternal.RegexMatchesPathValue(
+														regexp.MustCompile(`MINUTES`),
+														fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
+														path.MatchRelative().AtParent().AtName("time_unit"),
+													),
+												),
+											),
+										},
+									},
+
+									"time_unit": schema.StringAttribute{
+										Description:         durationTimeUnitMinsSecondsDescription.Description,
+										MarkdownDescription: durationTimeUnitMinsSecondsDescription.MarkdownDescription,
+										Required:            true,
+
+										Validators: []validator.String{
+											stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+										},
+									},
+								},
+							},
+						},
 					},
 
 					"pairing_disabled": schema.BoolAttribute{
@@ -3195,6 +3310,15 @@ func (p *MFADevicePolicyDefaultResourceModel) buildDefaultPolicyStruct(mobileApp
 	}
 
 	fido2 := mfa.NewDeviceAuthenticationPolicyCommonFido2(fido2Enabled)
+	fido2FailureCoolDown := mfa.NewDeviceAuthenticationPolicyCommonFido2FailureCoolDown()
+	fido2FailureCoolDown.SetDuration(defaultOTPFailureCooldown)
+	fido2FailureCoolDown.SetTimeUnit(minutes)
+
+	fido2Failure := mfa.NewDeviceAuthenticationPolicyCommonFido2Failure()
+	fido2Failure.SetCount(defaultOTPFailureCount)
+	fido2Failure.SetCoolDown(*fido2FailureCoolDown)
+	fido2.SetFailure(*fido2Failure)
+
 	fido2.SetPairingDisabled(false)
 	fido2.SetPromptForNicknameOnPairing(false)
 	data.SetFido2(*fido2)

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -485,7 +485,7 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 
 	durationTimeUnitMinsSecondsDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the type of time unit for `duration`.",
-	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues)
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues).DefaultValue(string(mfa.ENUMTIMEUNIT_MINUTES))
 
 	mobileApplicationsPairingKeyLifetimeTimeUnitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the type of time unit for `duration`.",
@@ -661,7 +661,7 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 
 	fido2FailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("An integer that defines the maximum number of times that authentication can fail before user is blocked for the specified period. The minimum value is `%d` and the maximum value is `%d`.", fido2FailureCountMin, fido2FailureCountMax),
-	)
+	).DefaultValue(fido2FailureCountDefault)
 
 	fido2FailureCoolDownDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A single object that allows configuration of FIDO2 authentication failure cool down settings.",
@@ -669,7 +669,7 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 
 	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes and the maximum value is `%d` minutes.", fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
-	)
+	).DefaultValue(fido2FailureCoolDownDurationDefault)
 
 	desktopDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("A single object that allows configuration of PingID desktop device authentication policy settings. Only applicable when `policy_type` is `%s`.", POLICY_TYPE_PINGID),

--- a/internal/service/mfa/resource_mfa_device_policy_default_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default_test.go
@@ -139,6 +139,9 @@ func TestAccMFADevicePolicyDefault_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.prompt_for_nickname_on_pairing", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "4"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "150"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.time_unit", "SECONDS"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing", "false"),
 				),
@@ -206,6 +209,9 @@ func TestAccMFADevicePolicyDefault_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "3"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "2"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.time_unit", "MINUTES"),
 				),
 			},
 		},
@@ -779,6 +785,16 @@ func TestAccMFADevicePolicyDefault_Validation(t *testing.T) {
 						Config:      testAccMFADevicePolicyDefaultConfig_TotpOtpFailureCoolDownDuration(resourceName, name, 31),
 						ExpectError: regexp.MustCompile(`Attribute totp.otp.failure.cool_down.duration value must be between 1 and[\s\n]+30`),
 					},
+					// FIDO2 - failure count too high
+					{
+						Config:      testAccMFADevicePolicyDefaultConfig_Fido2FailureCount(environmentName, licenseID, resourceName, name, 8),
+						ExpectError: regexp.MustCompile(`Attribute fido2.failure.count value must be between 1 and 7`),
+					},
+					// FIDO2 - failure cool down duration too high for MINUTES
+					{
+						Config:      testAccMFADevicePolicyDefaultConfig_Fido2FailureCoolDownDuration(environmentName, licenseID, resourceName, name, 31),
+						ExpectError: regexp.MustCompile(`Attribute\s+fido2.failure.cool_down.duration\s+value must\s+be between\s+2 and\s+30`),
+					},
 				},
 			})
 		},
@@ -1244,7 +1260,14 @@ resource "pingone_mfa_device_policy_default" "%[3]s" {
   }
 
   fido2 = {
-    enabled                        = true
+    enabled = true
+    failure = {
+      count = 4
+      cool_down = {
+        duration  = 150
+        time_unit = "SECONDS"
+      }
+    }
     pairing_disabled               = false
     prompt_for_nickname_on_pairing = false
   }
@@ -3161,6 +3184,70 @@ resource "pingone_mfa_device_policy_default" "%[2]s" {
   voice   = { enabled = false }
   email   = { enabled = false }
 }`, acctest.WorkforceV2SandboxEnvironment(), resourceName, name, duration)
+}
+
+func testAccMFADevicePolicyDefaultConfig_Fido2FailureCount(environmentName, licenseID, resourceName, name string, count int) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_mfa_device_policy_default" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  policy_type    = "PING_ONE_MFA"
+  name           = "%[4]s"
+
+  fido2 = {
+    enabled = true
+    failure = {
+      count = %[5]d
+      cool_down = {
+        duration  = 2
+        time_unit = "MINUTES"
+      }
+    }
+  }
+
+  sms   = { enabled = false }
+  voice = { enabled = false }
+  email = { enabled = false }
+  mobile = {
+    enabled = false
+  }
+  totp = {
+    enabled = false
+  }
+}`, acctestlegacysdk.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, count)
+}
+
+func testAccMFADevicePolicyDefaultConfig_Fido2FailureCoolDownDuration(environmentName, licenseID, resourceName, name string, duration int) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_mfa_device_policy_default" "%[3]s" {
+  environment_id = pingone_environment.%[2]s.id
+  policy_type    = "PING_ONE_MFA"
+  name           = "%[4]s"
+
+  fido2 = {
+    enabled = true
+    failure = {
+      count = 1
+      cool_down = {
+        duration  = %[5]d
+        time_unit = "MINUTES"
+      }
+    }
+  }
+
+  sms   = { enabled = false }
+  voice = { enabled = false }
+  email = { enabled = false }
+  mobile = {
+    enabled = false
+  }
+  totp = {
+    enabled = false
+  }
+}`, acctestlegacysdk.MinimalSandboxEnvironment(environmentName, licenseID), environmentName, resourceName, name, duration)
 }
 
 func testAccMFADevicePolicyDefaultConfig_WithIPs(resourceName, name string, ips []string) string {

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -1278,6 +1278,9 @@ func TestAccMFADevicePolicy_FIDO2_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "4"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "5"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "fido2.fido2_policy_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing", "true"),
@@ -1331,6 +1334,9 @@ func TestAccMFADevicePolicy_FIDO2_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "3"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "2"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "false"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "fido2.fido2_policy_id"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing"),
@@ -1368,6 +1374,9 @@ func TestAccMFADevicePolicy_FIDO2_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "4"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "5"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "fido2.fido2_policy_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing", "true"),
@@ -1383,6 +1392,9 @@ func TestAccMFADevicePolicy_FIDO2_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "3"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "2"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "false"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "fido2.fido2_policy_id"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing"),
@@ -1398,6 +1410,9 @@ func TestAccMFADevicePolicy_FIDO2_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "4"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "5"),
+					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "fido2.fido2_policy_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing", "true"),
@@ -1435,6 +1450,9 @@ func TestAccMFADevicePolicy_FIDO2_Disabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.count"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.cool_down.duration"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.cool_down.time_unit"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "fido2.fido2_policy_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing", "true"),
@@ -1450,6 +1468,9 @@ func TestAccMFADevicePolicy_FIDO2_Disabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.count"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.cool_down.duration"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.cool_down.time_unit"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "fido2.pairing_disabled"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "fido2.fido2_policy_id"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing"),
@@ -1465,6 +1486,9 @@ func TestAccMFADevicePolicy_FIDO2_Disabled(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.count"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.cool_down.duration"),
+					resource.TestCheckResourceAttrSet(resourceFullName, "fido2.failure.cool_down.time_unit"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.pairing_disabled", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "fido2.fido2_policy_id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.prompt_for_nickname_on_pairing", "true"),
@@ -3016,6 +3040,14 @@ resource "pingone_mfa_device_policy" "%[2]s" {
   fido2 = {
     enabled          = true
     pairing_disabled = true
+
+    failure = {
+      count = 4
+      cool_down = {
+        duration  = 5
+        time_unit = "MINUTES"
+      }
+    }
 
     prompt_for_nickname_on_pairing = true
 


### PR DESCRIPTION
## Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
**CDI-864**: Add support for `fido2.failure` to `pingone_mfa_device_policy` and `pingone_mfa_device_policy_default`
- `failure.count`
- `failure.cool_down.duration`
- `failure.cool_down.time_unit`

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->
- N/A
<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 go test ./internal/service/mfa -count=1 -run='TestAccMFADevicePolicy' -v
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->
- Two failures for missing `PINGONE_GOOGLE_FIREBASE_CREDENTIALS`
<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccMFADevicePolicyDefault_RemovalDrift
=== PAUSE TestAccMFADevicePolicyDefault_RemovalDrift
=== RUN   TestAccMFADevicePolicyDefault_Full
=== PAUSE TestAccMFADevicePolicyDefault_Full
=== RUN   TestAccMFADevicePolicyDefault_Minimal
=== PAUSE TestAccMFADevicePolicyDefault_Minimal
=== RUN   TestAccMFADevicePolicyDefault_Change
=== PAUSE TestAccMFADevicePolicyDefault_Change
=== RUN   TestAccMFADevicePolicyDefault_BadParameters
=== PAUSE TestAccMFADevicePolicyDefault_BadParameters
=== RUN   TestAccMFADevicePolicyDefault_PingID_Full
--- PASS: TestAccMFADevicePolicyDefault_PingID_Full (14.20s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_Minimal
--- PASS: TestAccMFADevicePolicyDefault_PingID_Minimal (12.27s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_Change
--- PASS: TestAccMFADevicePolicyDefault_PingID_Change (16.61s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_SetOrdering
--- PASS: TestAccMFADevicePolicyDefault_PingID_SetOrdering (16.09s)
=== RUN   TestAccMFADevicePolicyDefault_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation
=== RUN   TestAccMFADevicePolicyDefault_BOMValidation
=== PAUSE TestAccMFADevicePolicyDefault_BOMValidation
=== RUN   TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== PAUSE TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== RUN   TestAccMFADevicePolicyDefault_DriftCorrection
=== PAUSE TestAccMFADevicePolicyDefault_DriftCorrection
=== RUN   TestAccMFADevicePolicy_RemovalDrift
=== PAUSE TestAccMFADevicePolicy_RemovalDrift
=== RUN   TestAccMFADevicePolicy_NewEnv
=== PAUSE TestAccMFADevicePolicy_NewEnv
=== RUN   TestAccMFADevicePolicy_SMS_Full
=== PAUSE TestAccMFADevicePolicy_SMS_Full
=== RUN   TestAccMFADevicePolicy_SMS_Minimal
=== PAUSE TestAccMFADevicePolicy_SMS_Minimal
=== RUN   TestAccMFADevicePolicy_SMS_Change
=== PAUSE TestAccMFADevicePolicy_SMS_Change
=== RUN   TestAccMFADevicePolicy_Voice_Full
=== PAUSE TestAccMFADevicePolicy_Voice_Full
=== RUN   TestAccMFADevicePolicy_Voice_Minimal
=== PAUSE TestAccMFADevicePolicy_Voice_Minimal
=== RUN   TestAccMFADevicePolicy_Voice_Change
=== PAUSE TestAccMFADevicePolicy_Voice_Change
=== RUN   TestAccMFADevicePolicy_Email_Full
=== PAUSE TestAccMFADevicePolicy_Email_Full
=== RUN   TestAccMFADevicePolicy_Email_Minimal
=== PAUSE TestAccMFADevicePolicy_Email_Minimal
=== RUN   TestAccMFADevicePolicy_Email_Change
=== PAUSE TestAccMFADevicePolicy_Email_Change
=== RUN   TestAccMFADevicePolicy_Mobile_Full
=== PAUSE TestAccMFADevicePolicy_Mobile_Full
=== RUN   TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== RUN   TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== RUN   TestAccMFADevicePolicy_Mobile_Minimal
=== PAUSE TestAccMFADevicePolicy_Mobile_Minimal
=== RUN   TestAccMFADevicePolicy_Mobile_Change
=== PAUSE TestAccMFADevicePolicy_Mobile_Change
=== RUN   TestAccMFADevicePolicy_Totp_Full
=== PAUSE TestAccMFADevicePolicy_Totp_Full
=== RUN   TestAccMFADevicePolicy_Totp_Minimal
=== PAUSE TestAccMFADevicePolicy_Totp_Minimal
=== RUN   TestAccMFADevicePolicy_Totp_Change
=== PAUSE TestAccMFADevicePolicy_Totp_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Full
=== PAUSE TestAccMFADevicePolicy_FIDO2_Full
=== RUN   TestAccMFADevicePolicy_FIDO2_Minimal
=== PAUSE TestAccMFADevicePolicy_FIDO2_Minimal
=== RUN   TestAccMFADevicePolicy_FIDO2_Change
=== PAUSE TestAccMFADevicePolicy_FIDO2_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Disabled
=== PAUSE TestAccMFADevicePolicy_FIDO2_Disabled
=== RUN   TestAccMFADevicePolicy_DataModel
=== PAUSE TestAccMFADevicePolicy_DataModel
=== RUN   TestAccMFADevicePolicy_BadParameters
=== PAUSE TestAccMFADevicePolicy_BadParameters
=== RUN   TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== PAUSE TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicyDefault_RemovalDrift
=== CONT  TestAccMFADevicePolicy_Email_Minimal
=== CONT  TestAccMFADevicePolicy_Totp_Change
=== CONT  TestAccMFADevicePolicy_Email_Full
=== CONT  TestAccMFADevicePolicy_Mobile_Minimal
=== CONT  TestAccMFADevicePolicy_Totp_Full
=== CONT  TestAccMFADevicePolicy_FIDO2_Disabled
=== CONT  TestAccMFADevicePolicy_Totp_Minimal
=== CONT  TestAccMFADevicePolicy_RemovalDrift
=== CONT  TestAccMFADevicePolicy_FIDO2_Minimal
=== CONT  TestAccMFADevicePolicy_Voice_Change
=== CONT  TestAccMFADevicePolicy_BadParameters
=== CONT  TestAccMFADevicePolicy_FIDO2_Change
=== CONT  TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicyDefault_Validation
=== CONT  TestAccMFADevicePolicyDefault_DriftCorrection
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/General_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/General_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
=== CONT  TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
--- PASS: TestAccMFADevicePolicy_Totp_Minimal (11.10s)
=== CONT  TestAccMFADevicePolicyDefault_BOMValidation
--- PASS: TestAccMFADevicePolicy_Email_Full (13.37s)
=== CONT  TestAccMFADevicePolicyDefault_Change
--- PASS: TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes (13.91s)
=== CONT  TestAccMFADevicePolicyDefault_BadParameters
--- PASS: TestAccMFADevicePolicyDefault_BOMValidation (6.60s)
=== CONT  TestAccMFADevicePolicy_DataModel
--- PASS: TestAccMFADevicePolicy_FIDO2_Minimal (19.13s)
=== CONT  TestAccMFADevicePolicy_FIDO2_Full
--- PASS: TestAccMFADevicePolicy_BadParameters (19.80s)
=== CONT  TestAccMFADevicePolicyDefault_Minimal
--- PASS: TestAccMFADevicePolicy_Email_Minimal (20.33s)
=== CONT  TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
--- PASS: TestAccMFADevicePolicy_Totp_Change (22.85s)
=== CONT  TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
--- PASS: TestAccMFADevicePolicy_FIDO2_Disabled (23.95s)
=== CONT  TestAccMFADevicePolicy_Mobile_Change
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
--- FAIL: TestAccMFADevicePolicy_Mobile_Change (0.00s)
=== CONT  TestAccMFADevicePolicy_SMS_Change
--- PASS: TestAccMFADevicePolicy_Voice_Change (26.45s)
=== CONT  TestAccMFADevicePolicy_Voice_Minimal
--- PASS: TestAccMFADevicePolicy_FIDO2_Change (39.11s)
=== CONT  TestAccMFADevicePolicy_Voice_Full
--- PASS: TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors (28.79s)
=== CONT  TestAccMFADevicePolicy_SMS_Full
--- PASS: TestAccMFADevicePolicy_Totp_Full (50.21s)
=== CONT  TestAccMFADevicePolicy_SMS_Minimal
--- PASS: TestAccMFADevicePolicy_FIDO2_Full (31.84s)
=== CONT  TestAccMFADevicePolicy_Mobile_Full
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
--- FAIL: TestAccMFADevicePolicy_Mobile_Full (0.00s)
=== CONT  TestAccMFADevicePolicy_NewEnv
--- PASS: TestAccMFADevicePolicy_DeleteDependentSOPFinalAction (58.49s)
=== CONT  TestAccMFADevicePolicy_Email_Change
--- PASS: TestAccMFADevicePolicy_Voice_Minimal (34.51s)
=== CONT  TestAccMFADevicePolicyDefault_Full
--- PASS: TestAccMFADevicePolicy_Voice_Full (40.16s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
--- PASS: TestAccMFADevicePolicy_SMS_Minimal (29.08s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
--- PASS: TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors (60.95s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/General_Validation
--- PASS: TestAccMFADevicePolicyDefault_Validation (0.01s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation (2.74s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation (3.99s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation (2.90s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation (2.35s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/General_Validation (2.16s)
--- PASS: TestAccMFADevicePolicyDefault_Minimal (69.01s)
--- PASS: TestAccMFADevicePolicy_SMS_Full (41.02s)
--- PASS: TestAccMFADevicePolicyDefault_BadParameters (77.64s)
--- PASS: TestAccMFADevicePolicy_SMS_Change (82.35s)
--- PASS: TestAccMFADevicePolicyDefault_DriftCorrection (118.47s)
--- PASS: TestAccMFADevicePolicyDefault_RemovalDrift (118.49s)
--- PASS: TestAccMFADevicePolicy_NewEnv (74.56s)
--- PASS: TestAccMFADevicePolicy_Mobile_Minimal (127.35s)
--- PASS: TestAccMFADevicePolicy_Email_Change (83.18s)
--- PASS: TestAccMFADevicePolicyDefault_Full (82.16s)
--- PASS: TestAccMFADevicePolicyDefault_Change (132.67s)
--- PASS: TestAccMFADevicePolicy_DataModel (129.49s)
--- PASS: TestAccMFADevicePolicy_RemovalDrift (158.19s)
FAIL
FAIL    github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 218.098s
FAIL
```

</details>

### End-to-end Tests Workflow Links
<!-- Use the following section to list the URLs to the end-to-end test action workflow runs -->

- N/A