### PR TITLE
Support POLLING field type in pingone_form

### DIFF
--- a/.changelog/pr-1287.txt
+++ b/.changelog/pr-1287.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_form`: Added support for `POLLING` form field type, including new `polling_appearance` attribute.
+```

--- a/.changelog/pr-1288.txt
+++ b/.changelog/pr-1288.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_form`: Added support for `FIDO2` form field type, including new `action` and `trigger` attributes.
+```

--- a/.changelog/pr-1289.txt
+++ b/.changelog/pr-1289.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_form`: Added support for `AGREEMENT` form field type, including new `agreement`, `input_type`, and `title_enabled` attributes.
+```

--- a/docs/resources/form.md
+++ b/docs/resources/form.md
@@ -216,7 +216,7 @@ resource "pingone_form" "my_awesome_form" {
 
 ### Read-Only
 
-- `field_types` (Set of String) A set of strings that specifies the field types in the form.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
+- `field_types` (Set of String) A set of strings that specifies the field types in the form.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
 - `id` (String) The ID of this resource.
 - `language_bundle` (Map of String) An object that provides a map of i18n keys to their translations. This object includes both the keys and their default translations. The PingOne language management service finds this object, and creates the new keys for translation for this form.
 
@@ -233,7 +233,7 @@ Required:
 Required:
 
 - `position` (Attributes) A single object that specifies the position of the form field in the form.  The combination of `col` and `row` must be unique between form fields. (see [below for nested schema](#nestedatt--components--fields--position))
-- `type` (String) A string that specifies the type of form field.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
+- `type` (String) A string that specifies the type of form field.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
 
 Optional:
 
@@ -242,7 +242,7 @@ Optional:
 - `content` (String) Optional when the `type` is one of `SLATE_TEXTBLOB`.  A string that specifies the field's content (for example, escaped JSON string when the field type is `SLATE_TEXTBLOB` - use `jsonencode` to convert JSON to escaped JSON string.)
 - `fallback_text` (String) Optional when the `type` is one of `QR_CODE`.  A string that specifies the text label for fallback under the QR code.
 - `icon` (Attributes) Optional when the `type` is one of `SLATE_TEXTBLOB`.  An object that specifies the icon. (see [below for nested schema](#nestedatt--components--fields--icon))
-- `key` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `QR_CODE`, `RADIO`, `TEXT`, optional when the `type` is one of `SLATE_TEXTBLOB`.  A string that specifies an identifier for the field component.
+- `key` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `TEXT`, optional when the `type` is one of `SLATE_TEXTBLOB`.  A string that specifies an identifier for the field component.
 - `label` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `SUBMIT_BUTTON`, `TEXT`.  A string that specifies the field label.
 - `label_mode` (String) Optional when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `TEXT`.  A string that specifies how the field is rendered.  Options are `DEFAULT`, `FLOAT`.
 - `label_password_verify` (String) Optional when the `type` is one of `PASSWORD_VERIFY`.  A string that when a second field for verifies password is used, this property specifies the field label for that verify field.
@@ -253,9 +253,10 @@ Optional:
 - `other_option_input_label` (String) A string that specifies the label placeholder text for the other option in drop-down controls.
 - `other_option_key` (String) A string that specifies the key associated with the other option.
 - `other_option_label` (String) A string that specifies the label for a custom or "other" choice in a list.
+- `polling_appearance` (String) **Required** when the `type` is one of `POLLING`.  A string that specifies the polling activity indicator appearance.  Options are `DOTS`, `NONE`, `SPINNER`.
 - `required` (Boolean) Optional when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `TEXT`.  A boolean that specifies whether the field is required.
 - `show_password_requirements` (Boolean) Optional when the `type` is one of `PASSWORD`, `PASSWORD_VERIFY`.  A boolean that specifies whether to display password requirements to the user.
-- `size` (String) **Required** when the `type` is one of `QR_CODE`, `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA size or the QR code size. For reCAPTCHA fields, options are `NORMAL`, `COMPACT`. For QR code fields, options are `SMALL`, `MEDIUM`, `LARGE`.
+- `size` (String) **Required** when the `type` is one of `POLLING`, `QR_CODE`, `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA size or the QR code/polling size. For reCAPTCHA fields, options are `NORMAL`, `COMPACT`. For QR code and polling fields, options are `SMALL`, `MEDIUM`, `LARGE`.
 - `styles` (Attributes) Optional when the `type` is one of `FLOW_BUTTON`, `FLOW_LINK`, `SUBMIT_BUTTON`.  A single object that describes style settings for the field. (see [below for nested schema](#nestedatt--components--fields--styles))
 - `theme` (String) **Required** when the `type` is one of `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA theme.  Options are `DARK`, `LIGHT`.
 - `validation` (Attributes) **Required** when the `type` is one of `TEXT`, optional when the `type` is one of `PASSWORD`, `PASSWORD_VERIFY`.  An object containing validation data for the field. (see [below for nested schema](#nestedatt--components--fields--validation))

--- a/docs/resources/form.md
+++ b/docs/resources/form.md
@@ -216,7 +216,7 @@ resource "pingone_form" "my_awesome_form" {
 
 ### Read-Only
 
-- `field_types` (Set of String) A set of strings that specifies the field types in the form.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
+- `field_types` (Set of String) A set of strings that specifies the field types in the form.  Options are `AGREEMENT`, `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FIDO2`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
 - `id` (String) The ID of this resource.
 - `language_bundle` (Map of String) An object that provides a map of i18n keys to their translations. This object includes both the keys and their default translations. The PingOne language management service finds this object, and creates the new keys for translation for this form.
 
@@ -233,17 +233,20 @@ Required:
 Required:
 
 - `position` (Attributes) A single object that specifies the position of the form field in the form.  The combination of `col` and `row` must be unique between form fields. (see [below for nested schema](#nestedatt--components--fields--position))
-- `type` (String) A string that specifies the type of form field.  Options are `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
+- `type` (String) A string that specifies the type of form field.  Options are `AGREEMENT`, `CHECKBOX`, `COMBOBOX`, `DIVIDER`, `DROPDOWN`, `EMPTY_FIELD`, `ERROR_DISPLAY`, `FIDO2`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `RECAPTCHA_V2`, `SLATE_TEXTBLOB`, `SUBMIT_BUTTON`, `TEXT`.
 
 Optional:
 
+- `action` (String) **Required** when the `type` is one of `FIDO2`.  A string that specifies the FIDO2 action.  Options are `AUTHENTICATE`, `REGISTER`.
+- `agreement` (Attributes) **Required** when the `type` is one of `AGREEMENT`.  A single object that contains the agreement configuration (see [below for nested schema](#nestedatt--components--fields--agreement))
 - `alignment` (String) **Required** when the `type` is one of `QR_CODE`, `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA alignment.  Options are `CENTER`, `LEFT`, `RIGHT`.
 - `attribute_disabled` (Boolean) Optional when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `TEXT`.  A boolean that specifies whether the linked directory attribute is disabled.
 - `content` (String) Optional when the `type` is one of `SLATE_TEXTBLOB`.  A string that specifies the field's content (for example, escaped JSON string when the field type is `SLATE_TEXTBLOB` - use `jsonencode` to convert JSON to escaped JSON string.)
 - `fallback_text` (String) Optional when the `type` is one of `QR_CODE`.  A string that specifies the text label for fallback under the QR code.
 - `icon` (Attributes) Optional when the `type` is one of `SLATE_TEXTBLOB`.  An object that specifies the icon. (see [below for nested schema](#nestedatt--components--fields--icon))
-- `key` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `TEXT`, optional when the `type` is one of `SLATE_TEXTBLOB`.  A string that specifies an identifier for the field component.
-- `label` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `SUBMIT_BUTTON`, `TEXT`.  A string that specifies the field label.
+- `input_type` (String) **Required** when the `type` is one of `AGREEMENT`.  A string that specifies the type of field.  Options are `READ_ONLY_TEXT`.
+- `key` (String) **Required** when the `type` is one of `AGREEMENT`, `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FIDO2`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `POLLING`, `QR_CODE`, `RADIO`, `TEXT`, optional when the `type` is one of `SLATE_TEXTBLOB`.  A string that specifies an identifier for the field component.
+- `label` (String) **Required** when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `FIDO2`, `FLOW_BUTTON`, `FLOW_LINK`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `SUBMIT_BUTTON`, `TEXT`.  A string that specifies the field label.
 - `label_mode` (String) Optional when the `type` is one of `CHECKBOX`, `COMBOBOX`, `DROPDOWN`, `PASSWORD`, `PASSWORD_VERIFY`, `RADIO`, `TEXT`.  A string that specifies how the field is rendered.  Options are `DEFAULT`, `FLOAT`.
 - `label_password_verify` (String) Optional when the `type` is one of `PASSWORD_VERIFY`.  A string that when a second field for verifies password is used, this property specifies the field label for that verify field.
 - `layout` (String) **Required** when the `type` is one of `CHECKBOX`, `RADIO`, optional when the `type` is one of `COMBOBOX`, `DROPDOWN`, `PASSWORD`, `PASSWORD_VERIFY`, `TEXT`.  A string that specifies layout attributes for radio button and checkbox fields.  Options are `HORIZONTAL`, `VERTICAL`.
@@ -259,6 +262,8 @@ Optional:
 - `size` (String) **Required** when the `type` is one of `POLLING`, `QR_CODE`, `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA size or the QR code/polling size. For reCAPTCHA fields, options are `NORMAL`, `COMPACT`. For QR code and polling fields, options are `SMALL`, `MEDIUM`, `LARGE`.
 - `styles` (Attributes) Optional when the `type` is one of `FLOW_BUTTON`, `FLOW_LINK`, `SUBMIT_BUTTON`.  A single object that describes style settings for the field. (see [below for nested schema](#nestedatt--components--fields--styles))
 - `theme` (String) **Required** when the `type` is one of `RECAPTCHA_V2`.  A string that specifies the reCAPTCHA theme.  Options are `DARK`, `LIGHT`.
+- `title_enabled` (Boolean) **Required** when the `type` is one of `AGREEMENT`.  Specifies whether the title is enabled.
+- `trigger` (String) **Required** when the `type` is one of `FIDO2`.  A string that specifies the FIDO2 UI trigger type.  Options are `AUTOMATIC`, `BUTTON`.
 - `validation` (Attributes) **Required** when the `type` is one of `TEXT`, optional when the `type` is one of `PASSWORD`, `PASSWORD_VERIFY`.  An object containing validation data for the field. (see [below for nested schema](#nestedatt--components--fields--validation))
 - `visibility` (Attributes) An object that specifies the visibility settings for a form field. (see [below for nested schema](#nestedatt--components--fields--visibility))
 
@@ -273,6 +278,15 @@ Required:
 Optional:
 
 - `width` (Number) An integer that specifies the width of the form field in the form (in percentage).
+
+
+<a id="nestedatt--components--fields--agreement"></a>
+### Nested Schema for `components.fields.agreement`
+
+Optional:
+
+- `id` (String) An identifier that specifies the ID of the agreement.
+- `use_dynamic_agreement` (Boolean) An agreement option that specifies whether to use the agreement identified in the DaVinci form node.
 
 
 <a id="nestedatt--components--fields--icon"></a>

--- a/internal/framework/listvalidator/is_required_if_matches_path_value.go
+++ b/internal/framework/listvalidator/is_required_if_matches_path_value.go
@@ -3,18 +3,18 @@
 package listvalidator
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/schemavalidator"
 )
 
-// IsRequiredIfMatchesPathValue validates if the provided string value equals
-// the value at the provided path expression(s).  If matched, the current arguemnt is required.
+// IsRequiredIfMatchesPathValue validates if the provided attribute value equals
+// the value at the provided path expression(s).  If matched, the current argument is required.
 //
 // If a list of expressions is provided, all expressions are checked until a match is found,
 // or the list of expressions is exhausted.
-func IsRequiredIfMatchesPathValue(targetValue basetypes.StringValue, expressions ...path.Expression) validator.List {
+func IsRequiredIfMatchesPathValue(targetValue attr.Value, expressions ...path.Expression) validator.List {
 	return schemavalidator.IsRequiredIfMatchesPathValueValidator{
 		TargetValue: targetValue,
 		Expressions: expressions,

--- a/internal/framework/mapvalidator/is_required_if_matches_path_value.go
+++ b/internal/framework/mapvalidator/is_required_if_matches_path_value.go
@@ -3,18 +3,18 @@
 package mapvalidator
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/schemavalidator"
 )
 
-// IsRequiredIfMatchesPathValue validates if the provided string value equals
-// the value at the provided path expression(s).  If matched, the current arguemnt is required.
+// IsRequiredIfMatchesPathValue validates if the provided attribute value equals
+// the value at the provided path expression(s).  If matched, the current argument is required.
 //
 // If a list of expressions is provided, all expressions are checked until a match is found,
 // or the list of expressions is exhausted.
-func IsRequiredIfMatchesPathValue(targetValue basetypes.StringValue, expressions ...path.Expression) validator.Map {
+func IsRequiredIfMatchesPathValue(targetValue attr.Value, expressions ...path.Expression) validator.Map {
 	return schemavalidator.IsRequiredIfMatchesPathValueValidator{
 		TargetValue: targetValue,
 		Expressions: expressions,

--- a/internal/framework/objectvalidator/is_required_if_matches_path_value.go
+++ b/internal/framework/objectvalidator/is_required_if_matches_path_value.go
@@ -3,18 +3,18 @@
 package objectvalidator
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/schemavalidator"
 )
 
-// IsRequiredIfMatchesPathValue validates if the provided string value equals
-// the value at the provided path expression(s).  If matched, the current arguemnt is required.
+// IsRequiredIfMatchesPathValue validates if the provided attribute value equals
+// the value at the provided path expression(s).  If matched, the current argument is required.
 //
 // If a list of expressions is provided, all expressions are checked until a match is found,
 // or the list of expressions is exhausted.
-func IsRequiredIfMatchesPathValue(targetValue basetypes.StringValue, expressions ...path.Expression) validator.Object {
+func IsRequiredIfMatchesPathValue(targetValue attr.Value, expressions ...path.Expression) validator.Object {
 	return schemavalidator.IsRequiredIfMatchesPathValueValidator{
 		TargetValue: targetValue,
 		Expressions: expressions,

--- a/internal/framework/schemavalidator/is_required_if_matches_path_value.go
+++ b/internal/framework/schemavalidator/is_required_if_matches_path_value.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var (
@@ -30,13 +29,13 @@ var (
 	_ validator.String  = IsRequiredIfMatchesPathValueValidator{}
 )
 
-// IsRequiredIfMatchesPathValueValidator validates if the provided string value equals
-// the value at the provided path expression(s).  If matched, the current arguemnt is required.
+// IsRequiredIfMatchesPathValueValidator validates if the provided attribute value equals
+// the value at the provided path expression(s).  If matched, the current argument is required.
 //
 // If a list of expressions is provided, all expressions are checked until a match is found,
 // or the list of expressions is exhausted.
 type IsRequiredIfMatchesPathValueValidator struct {
-	TargetValue basetypes.StringValue
+	TargetValue attr.Value
 	Expressions path.Expressions
 }
 
@@ -53,7 +52,7 @@ type IsRequiredIfMatchesPathValueValidatorResponse struct {
 
 // Description describes the validation in plain text formatting.
 func (v IsRequiredIfMatchesPathValueValidator) Description(_ context.Context) string {
-	return fmt.Sprintf("The argument is required if the value %s is present at the defined path: %v", v.TargetValue.ValueString(), v.Expressions)
+	return fmt.Sprintf("The argument is required if the value %s is present at the defined path: %v", v.TargetValue.String(), v.Expressions)
 }
 
 // MarkdownDescription describes the validation in Markdown formatting.

--- a/internal/framework/setvalidator/is_required_if_matches_path_value.go
+++ b/internal/framework/setvalidator/is_required_if_matches_path_value.go
@@ -3,18 +3,18 @@
 package setvalidator
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/schemavalidator"
 )
 
-// IsRequiredIfMatchesPathValue validates if the provided string value equals
-// the value at the provided path expression(s).  If matched, the current arguemnt is required.
+// IsRequiredIfMatchesPathValue validates if the provided attribute value equals
+// the value at the provided path expression(s).  If matched, the current argument is required.
 //
 // If a list of expressions is provided, all expressions are checked until a match is found,
 // or the list of expressions is exhausted.
-func IsRequiredIfMatchesPathValue(targetValue basetypes.StringValue, expressions ...path.Expression) validator.Set {
+func IsRequiredIfMatchesPathValue(targetValue attr.Value, expressions ...path.Expression) validator.Set {
 	return schemavalidator.IsRequiredIfMatchesPathValueValidator{
 		TargetValue: targetValue,
 		Expressions: expressions,

--- a/internal/framework/stringvalidator/is_required_if_matches_path_value.go
+++ b/internal/framework/stringvalidator/is_required_if_matches_path_value.go
@@ -3,18 +3,18 @@
 package stringvalidator
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/schemavalidator"
 )
 
-// IsRequiredIfMatchesPathValue validates if the provided string value equals
-// the value at the provided path expression(s).  If matched, the current arguemnt is required.
+// IsRequiredIfMatchesPathValue validates if the provided attribute value equals
+// the value at the provided path expression(s).  If matched, the current argument is required.
 //
 // If a list of expressions is provided, all expressions are checked until a match is found,
 // or the list of expressions is exhausted.
-func IsRequiredIfMatchesPathValue(targetValue basetypes.StringValue, expressions ...path.Expression) validator.String {
+func IsRequiredIfMatchesPathValue(targetValue attr.Value, expressions ...path.Expression) validator.String {
 	return schemavalidator.IsRequiredIfMatchesPathValueValidator{
 		TargetValue: targetValue,
 		Expressions: expressions,

--- a/internal/service/base/resource_form.go
+++ b/internal/service/base/resource_form.go
@@ -62,10 +62,13 @@ type formComponentsResourceModel struct {
 
 type formComponentsFieldResourceModel struct {
 	Alignment                    types.String `tfsdk:"alignment"`
+	Action                       types.String `tfsdk:"action"`
+	Agreement                    types.Object `tfsdk:"agreement"`
 	AttributeDisabled            types.Bool   `tfsdk:"attribute_disabled"`
 	Content                      types.String `tfsdk:"content"`
 	FallbackText                 types.String `tfsdk:"fallback_text"`
 	Icon                         types.Object `tfsdk:"icon"`
+	InputType                    types.String `tfsdk:"input_type"`
 	Key                          types.String `tfsdk:"key"`
 	Label                        types.String `tfsdk:"label"`
 	LabelMode                    types.String `tfsdk:"label_mode"`
@@ -84,9 +87,16 @@ type formComponentsFieldResourceModel struct {
 	Size                         types.String `tfsdk:"size"`
 	Styles                       types.Object `tfsdk:"styles"`
 	Theme                        types.String `tfsdk:"theme"`
+	TitleEnabled                 types.Bool   `tfsdk:"title_enabled"`
+	Trigger                      types.String `tfsdk:"trigger"`
 	Type                         types.String `tfsdk:"type"`
 	Validation                   types.Object `tfsdk:"validation"`
 	Visibility                   types.Object `tfsdk:"visibility"`
+}
+
+type formComponentsFieldAgreementResourceModel struct {
+	Id                  pingonetypes.ResourceIDValue `tfsdk:"id"`
+	UseDynamicAgreement types.Bool                   `tfsdk:"use_dynamic_agreement"`
 }
 
 type formComponentsFieldPositionResourceModel struct {
@@ -155,10 +165,13 @@ var (
 	// Form Components Fields
 	formComponentsFieldsTFObjectTypes = map[string]attr.Type{
 		"alignment":                       types.StringType,
+		"action":                          types.StringType,
+		"agreement":                       types.ObjectType{AttrTypes: formComponentsFieldsAgreementTFObjectTypes},
 		"attribute_disabled":              types.BoolType,
 		"content":                         types.StringType,
 		"fallback_text":                   types.StringType,
 		"icon":                            types.ObjectType{AttrTypes: formComponentsFieldsIconTFObjectTypes},
+		"input_type":                      types.StringType,
 		"key":                             types.StringType,
 		"label_mode":                      types.StringType,
 		"label_password_verify":           types.StringType,
@@ -177,9 +190,16 @@ var (
 		"size":                            types.StringType,
 		"styles":                          types.ObjectType{AttrTypes: formComponentsFieldsFieldStylesTFObjectTypes},
 		"theme":                           types.StringType,
+		"title_enabled":                   types.BoolType,
+		"trigger":                         types.StringType,
 		"type":                            types.StringType,
 		"validation":                      types.ObjectType{AttrTypes: formComponentsFieldsFieldElementValidationTFObjectTypes},
 		"visibility":                      types.ObjectType{AttrTypes: formComponentsFieldsVisibilityTFObjectTypes},
+	}
+
+	formComponentsFieldsAgreementTFObjectTypes = map[string]attr.Type{
+		"id":                    pingonetypes.ResourceIDType{},
+		"use_dynamic_agreement": types.BoolType,
 	}
 
 	// Form Components Fields Position
@@ -237,6 +257,19 @@ var (
 	}
 
 	formComponentsFieldsSchemaDefMap = map[management.EnumFormFieldType]formComponentsFieldsSchemaDef{
+		management.ENUMFORMFIELDTYPE_AGREEMENT: {
+			Required: []string{
+				"type",
+				"position",
+				"key",
+				"input_type",
+				"title_enabled",
+				"agreement",
+			},
+			Optional: []string{
+				"visibility",
+			},
+		},
 		management.ENUMFORMFIELDTYPE_CHECKBOX: {
 			Required: []string{
 				"type",
@@ -333,6 +366,19 @@ var (
 			},
 			Optional: []string{
 				"styles",
+				"visibility",
+			},
+		},
+		management.ENUMFORMFIELDTYPE_FIDO2: {
+			Required: []string{
+				"type",
+				"position",
+				"key",
+				"trigger",
+				"action",
+				"label",
+			},
+			Optional: []string{
 				"visibility",
 			},
 		},
@@ -496,6 +542,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 	const colMaxValue = 3
 
 	supportedFormFieldTypes := []management.EnumFormFieldType{
+		management.ENUMFORMFIELDTYPE_AGREEMENT,
 		management.ENUMFORMFIELDTYPE_TEXT,
 		management.ENUMFORMFIELDTYPE_PASSWORD,
 		management.ENUMFORMFIELDTYPE_PASSWORD_VERIFY,
@@ -511,6 +558,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 		management.ENUMFORMFIELDTYPE_FLOW_LINK,
 		management.ENUMFORMFIELDTYPE_FLOW_BUTTON,
 		management.ENUMFORMFIELDTYPE_POLLING,
+		management.ENUMFORMFIELDTYPE_FIDO2,
 		management.ENUMFORMFIELDTYPE_RECAPTCHA_V2,
 		management.ENUMFORMFIELDTYPE_QR_CODE,
 	}
@@ -688,6 +736,18 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 		"A string that specifies the polling activity indicator appearance.",
 	).AllowedValuesEnum(management.AllowedEnumFormPollingAppearanceEnumValues)
 
+	componentsFieldsTriggerDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		formFieldValidationDocumentation("trigger"),
+	).AppendMarkdownString(
+		"A string that specifies the FIDO2 UI trigger type.",
+	).AllowedValuesEnum(management.AllowedEnumFormFIDO2TriggerEnumValues)
+
+	componentsFieldsActionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		formFieldValidationDocumentation("action"),
+	).AppendMarkdownString(
+		"A string that specifies the FIDO2 action.",
+	).AllowedValuesEnum(management.AllowedEnumFormFIDO2ActionEnumValues)
+
 	componentsFieldsStylesDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		formFieldValidationDocumentation("styles"),
 	).AppendMarkdownString(
@@ -788,6 +848,32 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 		formFieldValidationDocumentation("fallback_text"),
 	).AppendMarkdownString(
 		"A string that specifies the text label for fallback under the QR code.",
+	)
+
+	componentsFieldsInputTypeDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		formFieldValidationDocumentation("input_type"),
+	).AppendMarkdownString(
+		"A string that specifies the type of field.",
+	).AllowedValuesEnum(management.AllowedEnumFormAgreementInputTypeEnumValues)
+
+	componentsFieldsTitleEnabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		formFieldValidationDocumentation("title_enabled"),
+	).AppendMarkdownString(
+		"Specifies whether the title is enabled.",
+	)
+
+	componentsFieldsAgreementDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		formFieldValidationDocumentation("agreement"),
+	).AppendMarkdownString(
+		"A single object that contains the agreement configuration",
+	)
+
+	componentsFieldsAgreementIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An identifier that specifies the ID of the agreement.",
+	)
+
+	componentsFieldsAgreementUseDynamicAgreementDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An agreement option that specifies whether to use the agreement identified in the DaVinci form node.",
 	)
 
 	componentsFieldsVisibilityDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -984,6 +1070,16 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 									},
 								},
 
+								"input_type": schema.StringAttribute{
+									Description:         componentsFieldsInputTypeDescription.Description,
+									MarkdownDescription: componentsFieldsInputTypeDescription.MarkdownDescription,
+									Optional:            true,
+
+									Validators: []validator.String{
+										stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumFormAgreementInputTypeEnumValues)...),
+									},
+								},
+
 								"key": schema.StringAttribute{
 									Description:         componentsFieldsKeyDescription.Description,
 									MarkdownDescription: componentsFieldsKeyDescription.MarkdownDescription,
@@ -1140,6 +1236,26 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 									Optional:            true,
 								},
 
+								"trigger": schema.StringAttribute{
+									Description:         componentsFieldsTriggerDescription.Description,
+									MarkdownDescription: componentsFieldsTriggerDescription.MarkdownDescription,
+									Optional:            true,
+
+									Validators: []validator.String{
+										stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumFormFIDO2TriggerEnumValues)...),
+									},
+								},
+
+								"action": schema.StringAttribute{
+									Description:         componentsFieldsActionDescription.Description,
+									MarkdownDescription: componentsFieldsActionDescription.MarkdownDescription,
+									Optional:            true,
+
+									Validators: []validator.String{
+										stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumFormFIDO2ActionEnumValues)...),
+									},
+								},
+
 								"styles": schema.SingleNestedAttribute{
 									Description:         componentsFieldsStylesDescription.Description,
 									MarkdownDescription: componentsFieldsStylesDescription.MarkdownDescription,
@@ -1283,6 +1399,12 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 									Optional:            true,
 								},
 
+								"title_enabled": schema.BoolAttribute{
+									Description:         componentsFieldsTitleEnabledDescription.Description,
+									MarkdownDescription: componentsFieldsTitleEnabledDescription.MarkdownDescription,
+									Optional:            true,
+								},
+
 								"alignment": schema.StringAttribute{
 									Description:         componentsFieldsAlignmentDescription.Description,
 									MarkdownDescription: componentsFieldsAlignmentDescription.MarkdownDescription,
@@ -1319,6 +1441,34 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 													path.MatchRelative().AtParent().AtName("type"),
 												),
 											},
+										},
+									},
+								},
+
+								"agreement": schema.SingleNestedAttribute{
+									Description:         componentsFieldsAgreementDescription.Description,
+									MarkdownDescription: componentsFieldsAgreementDescription.MarkdownDescription,
+									Optional:            true,
+
+									Attributes: map[string]schema.Attribute{
+										"id": schema.StringAttribute{
+											Description:         componentsFieldsAgreementIdDescription.Description,
+											MarkdownDescription: componentsFieldsAgreementIdDescription.MarkdownDescription,
+											Optional:            true,
+											CustomType:          pingonetypes.ResourceIDType{},
+
+											Validators: []validator.String{
+												stringvalidatorinternal.IsRequiredIfMatchesPathValue(
+													types.BoolValue(false),
+													path.MatchRelative().AtParent().AtName("use_dynamic_agreement"),
+												),
+											},
+										},
+
+										"use_dynamic_agreement": schema.BoolAttribute{
+											Description:         componentsFieldsAgreementUseDynamicAgreementDescription.Description,
+											MarkdownDescription: componentsFieldsAgreementUseDynamicAgreementDescription.MarkdownDescription,
+											Optional:            true,
 										},
 									},
 								},
@@ -1449,6 +1599,10 @@ func (r *formComponentsFieldResourceModel) validateFieldSet(field string) bool {
 	switch field {
 	case "alignment":
 		return !r.Alignment.IsNull()
+	case "action":
+		return !r.Action.IsNull()
+	case "agreement":
+		return !r.Agreement.IsNull()
 	case "attribute_disabled":
 		return !r.AttributeDisabled.IsNull()
 	case "content":
@@ -1457,6 +1611,8 @@ func (r *formComponentsFieldResourceModel) validateFieldSet(field string) bool {
 		return !r.FallbackText.IsNull()
 	case "icon":
 		return !r.Icon.IsNull()
+	case "input_type":
+		return !r.InputType.IsNull()
 	case "key":
 		return !r.Key.IsNull()
 	case "label":
@@ -1493,6 +1649,10 @@ func (r *formComponentsFieldResourceModel) validateFieldSet(field string) bool {
 		return !r.Styles.IsNull()
 	case "theme":
 		return !r.Theme.IsNull()
+	case "title_enabled":
+		return !r.TitleEnabled.IsNull()
+	case "trigger":
+		return !r.Trigger.IsNull()
 	case "type":
 		return !r.Type.IsNull()
 	case "validation":
@@ -2155,6 +2315,8 @@ func (p *formComponentsFieldResourceModel) expand(ctx context.Context) (*managem
 	positionData := positionPlan.expand()
 
 	switch p.Type.ValueString() {
+	case string(management.ENUMFORMFIELDTYPE_AGREEMENT):
+		data.FormFieldFormAgreement, d = p.expandItemAgreement(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_CHECKBOX):
 		data.FormFieldCheckbox, d = p.expandFieldCheckbox(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_COMBOBOX):
@@ -2167,6 +2329,8 @@ func (p *formComponentsFieldResourceModel) expand(ctx context.Context) (*managem
 		data.FormFieldEmptyField, d = p.expandItemEmptyField(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_ERROR_DISPLAY):
 		data.FormFieldErrorDisplay, d = p.expandItemErrorDisplay(ctx, positionData)
+	case string(management.ENUMFORMFIELDTYPE_FIDO2):
+		data.FormFieldFIDO2, d = p.expandItemFIDO2(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_FLOW_BUTTON):
 		data.FormFieldFlowButton, d = p.expandItemFlowButton(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_FLOW_LINK):
@@ -2998,6 +3162,31 @@ func (p *formComponentsFieldResourceModel) expandItemPolling(ctx context.Context
 	return data, diags
 }
 
+func (p *formComponentsFieldResourceModel) expandItemFIDO2(ctx context.Context, positionData *management.FormFieldCommonPosition) (*management.FormFieldFIDO2, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	data := management.NewFormFieldFIDO2(
+		management.ENUMFORMFIELDTYPE_FIDO2,
+		*positionData,
+		p.Key.ValueString(),
+		management.EnumFormFIDO2Trigger(p.Trigger.ValueString()),
+		management.EnumFormFIDO2Action(p.Action.ValueString()),
+		p.Label.ValueString(),
+	)
+
+	if !p.Visibility.IsNull() && !p.Visibility.IsUnknown() {
+		var plan formComponentsFieldVisibilityResourceModel
+		diags.Append(p.Visibility.As(ctx, &plan, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		data.SetVisibility(*plan.expand())
+	}
+
+	return data, diags
+}
+
 func (p *formComponentsFieldResourceModel) expandItemQRCode(ctx context.Context, positionData *management.FormFieldCommonPosition) (*management.FormFieldQrCode, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	data := management.NewFormFieldQrCode(
@@ -3081,6 +3270,52 @@ func (p *formComponentsFieldResourceModel) expandItemSlateTextblob(ctx context.C
 		)
 
 		data.SetIcon(*icon)
+	}
+
+	if !p.Visibility.IsNull() && !p.Visibility.IsUnknown() {
+		var plan formComponentsFieldVisibilityResourceModel
+		diags.Append(p.Visibility.As(ctx, &plan, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		data.SetVisibility(*plan.expand())
+	}
+
+	return data, diags
+}
+
+func (p *formComponentsFieldResourceModel) expandItemAgreement(ctx context.Context, positionData *management.FormFieldCommonPosition) (*management.FormFieldFormAgreement, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	data := management.NewFormFieldFormAgreement(
+		management.ENUMFORMFIELDTYPE_AGREEMENT,
+		*positionData,
+		p.Key.ValueString(),
+		management.EnumFormAgreementInputType(p.InputType.ValueString()),
+		p.TitleEnabled.ValueBool(),
+	)
+
+	if !p.Agreement.IsNull() && !p.Agreement.IsUnknown() {
+		var plan formComponentsFieldAgreementResourceModel
+		diags.Append(p.Agreement.As(ctx, &plan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		agreement := management.NewFormAgreementAllOfAgreement()
+		if !plan.Id.IsNull() && !plan.Id.IsUnknown() {
+			agreement.SetId(plan.Id.ValueString())
+		}
+
+		if !plan.UseDynamicAgreement.IsNull() && !plan.UseDynamicAgreement.IsUnknown() {
+			agreement.SetUseDynamicAgreement(plan.UseDynamicAgreement.ValueBool())
+		}
+
+		data.SetAgreement(*agreement)
 	}
 
 	if !p.Visibility.IsNull() && !p.Visibility.IsUnknown() {
@@ -3312,6 +3547,26 @@ func formComponentsFieldsOkToTF(apiObject []management.FormField, ok bool) (base
 		fieldObject := v.GetActualInstance()
 
 		switch t := fieldObject.(type) {
+		case *management.FormFieldFormAgreement:
+			position, d := formComponentsFieldsPositionOkToTF(t.GetPositionOk())
+			diags.Append(d...)
+
+			agreement, d := formComponentsFieldsAgreementOkToTF(t.GetAgreementOk())
+			diags.Append(d...)
+
+			visibility, d := formComponentsFieldsVisibilityOkToTF(t.GetVisibilityOk())
+			diags.Append(d...)
+
+			attributeMap = map[string]attr.Value{
+				"agreement":     agreement,
+				"input_type":    framework.EnumOkToTF(t.GetInputTypeOk()),
+				"key":           framework.StringOkToTF(t.GetKeyOk()),
+				"position":      position,
+				"title_enabled": framework.BoolOkToTF(t.GetTitleEnabledOk()),
+				"type":          framework.EnumOkToTF(t.GetTypeOk()),
+				"visibility":    visibility,
+			}
+
 		case *management.FormFieldCheckbox:
 			position, d := formComponentsFieldsPositionOkToTF(t.GetPositionOk())
 			diags.Append(d...)
@@ -3443,6 +3698,23 @@ func formComponentsFieldsOkToTF(apiObject []management.FormField, ok bool) (base
 
 			attributeMap = map[string]attr.Value{
 				"position":   position,
+				"type":       framework.EnumOkToTF(t.GetTypeOk()),
+				"visibility": visibility,
+			}
+
+		case *management.FormFieldFIDO2:
+			position, d := formComponentsFieldsPositionOkToTF(t.GetPositionOk())
+			diags.Append(d...)
+
+			visibility, d := formComponentsFieldsVisibilityOkToTF(t.GetVisibilityOk())
+			diags.Append(d...)
+
+			attributeMap = map[string]attr.Value{
+				"action":     framework.EnumOkToTF(t.GetActionOk()),
+				"key":        framework.StringOkToTF(t.GetKeyOk()),
+				"label":      framework.StringOkToTF(t.GetLabelOk()),
+				"position":   position,
+				"trigger":    framework.EnumOkToTF(t.GetTriggerOk()),
 				"type":       framework.EnumOkToTF(t.GetTypeOk()),
 				"visibility": visibility,
 			}
@@ -3719,10 +3991,13 @@ func formComponentsFieldsOkToTF(apiObject []management.FormField, ok bool) (base
 func formComponentsFieldsConvertEmptyValuesToTFNulls(attributeMap map[string]attr.Value) map[string]attr.Value {
 	nullMap := map[string]attr.Value{
 		"alignment":                       types.StringNull(),
+		"action":                          types.StringNull(),
+		"agreement":                       types.ObjectNull(formComponentsFieldsAgreementTFObjectTypes),
 		"attribute_disabled":              types.BoolNull(),
 		"content":                         types.StringNull(),
 		"fallback_text":                   types.StringNull(),
 		"icon":                            types.ObjectNull(formComponentsFieldsIconTFObjectTypes),
+		"input_type":                      types.StringNull(),
 		"key":                             types.StringNull(),
 		"label_mode":                      types.StringNull(),
 		"label_password_verify":           types.StringNull(),
@@ -3741,6 +4016,8 @@ func formComponentsFieldsConvertEmptyValuesToTFNulls(attributeMap map[string]att
 		"size":                            types.StringNull(),
 		"styles":                          types.ObjectNull(formComponentsFieldsFieldStylesTFObjectTypes),
 		"theme":                           types.StringNull(),
+		"title_enabled":                   types.BoolNull(),
+		"trigger":                         types.StringNull(),
 		"type":                            types.StringNull(),
 		"validation":                      types.ObjectNull(formComponentsFieldsFieldElementValidationTFObjectTypes),
 		"visibility":                      types.ObjectNull(formComponentsFieldsVisibilityTFObjectTypes),
@@ -3908,6 +4185,22 @@ func formComponentsFieldsVisibilityOkToTF(apiObject *management.FormFieldCommonV
 	objValue, d := types.ObjectValue(formComponentsFieldsVisibilityTFObjectTypes, map[string]attr.Value{
 		"type": framework.EnumOkToTF(apiObject.GetTypeOk()),
 		"key":  framework.StringOkToTF(apiObject.GetKeyOk()),
+	})
+	diags.Append(d...)
+
+	return objValue, diags
+}
+
+func formComponentsFieldsAgreementOkToTF(apiObject *management.FormAgreementAllOfAgreement, ok bool) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(formComponentsFieldsAgreementTFObjectTypes), diags
+	}
+
+	objValue, d := types.ObjectValue(formComponentsFieldsAgreementTFObjectTypes, map[string]attr.Value{
+		"id":                    framework.PingOneResourceIDOkToTF(apiObject.GetIdOk()),
+		"use_dynamic_agreement": framework.BoolOkToTF(apiObject.GetUseDynamicAgreementOk()),
 	})
 	diags.Append(d...)
 

--- a/internal/service/base/resource_form.go
+++ b/internal/service/base/resource_form.go
@@ -77,6 +77,7 @@ type formComponentsFieldResourceModel struct {
 	OtherOptionInputLabel        types.String `tfsdk:"other_option_input_label"`
 	OtherOptionKey               types.String `tfsdk:"other_option_key"`
 	OtherOptionLabel             types.String `tfsdk:"other_option_label"`
+	PollingAppearance            types.String `tfsdk:"polling_appearance"`
 	Position                     types.Object `tfsdk:"position"`
 	Required                     types.Bool   `tfsdk:"required"`
 	ShowPasswordRequirements     types.Bool   `tfsdk:"show_password_requirements"`
@@ -169,6 +170,7 @@ var (
 		"other_option_input_label":        types.StringType,
 		"other_option_key":                types.StringType,
 		"other_option_label":              types.StringType,
+		"polling_appearance":              types.StringType,
 		"position":                        types.ObjectType{AttrTypes: formComponentsFieldsPositionTFObjectTypes},
 		"required":                        types.BoolType,
 		"show_password_requirements":      types.BoolType,
@@ -369,6 +371,18 @@ var (
 				"visibility",
 			},
 		},
+		management.ENUMFORMFIELDTYPE_POLLING: {
+			Required: []string{
+				"type",
+				"position",
+				"key",
+				"polling_appearance",
+				"size",
+			},
+			Optional: []string{
+				"visibility",
+			},
+		},
 		management.ENUMFORMFIELDTYPE_QR_CODE: {
 			Required: []string{
 				"type",
@@ -496,6 +510,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 		management.ENUMFORMFIELDTYPE_ERROR_DISPLAY,
 		management.ENUMFORMFIELDTYPE_FLOW_LINK,
 		management.ENUMFORMFIELDTYPE_FLOW_BUTTON,
+		management.ENUMFORMFIELDTYPE_POLLING,
 		management.ENUMFORMFIELDTYPE_RECAPTCHA_V2,
 		management.ENUMFORMFIELDTYPE_QR_CODE,
 	}
@@ -667,6 +682,12 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 		"A boolean that specifies whether to display password requirements to the user.",
 	)
 
+	componentsFieldsPollingAppearanceDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		formFieldValidationDocumentation("polling_appearance"),
+	).AppendMarkdownString(
+		"A string that specifies the polling activity indicator appearance.",
+	).AllowedValuesEnum(management.AllowedEnumFormPollingAppearanceEnumValues)
+
 	componentsFieldsStylesDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		formFieldValidationDocumentation("styles"),
 	).AppendMarkdownString(
@@ -746,7 +767,7 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 	componentsFieldsSizeDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		formFieldValidationDocumentation("size"),
 	).AppendMarkdownString(
-		fmt.Sprintf("A string that specifies the reCAPTCHA size or the QR code size. For reCAPTCHA fields, options are `%s`. For QR code fields, options are `%s`.",
+		fmt.Sprintf("A string that specifies the reCAPTCHA size or the QR code/polling size. For reCAPTCHA fields, options are `%s`. For QR code and polling fields, options are `%s`.",
 			strings.Join(reCaptchaSizeAllowedValues, "`, `"),
 			strings.Join(genericSizeAllowedValues, "`, `")),
 	)
@@ -1113,6 +1134,12 @@ func (r *FormResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 									Computed:            true,
 								},
 
+								"polling_appearance": schema.StringAttribute{
+									Description:         componentsFieldsPollingAppearanceDescription.Description,
+									MarkdownDescription: componentsFieldsPollingAppearanceDescription.MarkdownDescription,
+									Optional:            true,
+								},
+
 								"styles": schema.SingleNestedAttribute{
 									Description:         componentsFieldsStylesDescription.Description,
 									MarkdownDescription: componentsFieldsStylesDescription.MarkdownDescription,
@@ -1452,6 +1479,8 @@ func (r *formComponentsFieldResourceModel) validateFieldSet(field string) bool {
 		return !r.OtherOptionKey.IsNull()
 	case "other_option_label":
 		return !r.OtherOptionLabel.IsNull()
+	case "polling_appearance":
+		return !r.PollingAppearance.IsNull()
 	case "position":
 		return !r.Position.IsNull()
 	case "required":
@@ -1999,8 +2028,8 @@ func (p *formResourceModel) validate(ctx context.Context, allowUnknowns bool) di
 					}
 				}
 
-				// Validate size value for QR_CODE and RECAPTCHA_V2
-				if field.Type.ValueString() == string(management.ENUMFORMFIELDTYPE_QR_CODE) {
+				// Validate size value for QR_CODE, POLLING and RECAPTCHA_V2
+				if field.Type.ValueString() == string(management.ENUMFORMFIELDTYPE_QR_CODE) || field.Type.ValueString() == string(management.ENUMFORMFIELDTYPE_POLLING) {
 					sizeValue := field.Size.ValueString()
 					validSizes := utils.EnumSliceToStringSlice(management.AllowedEnumFormItemSizeEnumValues)
 					if !slices.Contains(validSizes, sizeValue) {
@@ -2146,6 +2175,8 @@ func (p *formComponentsFieldResourceModel) expand(ctx context.Context) (*managem
 		data.FormFieldPassword, d = p.expandFieldPassword(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_PASSWORD_VERIFY):
 		data.FormFieldPasswordVerify, d = p.expandFieldPasswordVerify(ctx, positionData)
+	case string(management.ENUMFORMFIELDTYPE_POLLING):
+		data.FormFieldPolling, d = p.expandItemPolling(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_QR_CODE):
 		data.FormFieldQrCode, d = p.expandItemQRCode(ctx, positionData)
 	case string(management.ENUMFORMFIELDTYPE_RADIO):
@@ -2943,6 +2974,30 @@ func (p *formComponentsFieldVisibilityResourceModel) expand() *management.FormFi
 	return visibility
 }
 
+func (p *formComponentsFieldResourceModel) expandItemPolling(ctx context.Context, positionData *management.FormFieldCommonPosition) (*management.FormFieldPolling, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	data := management.NewFormFieldPolling(
+		management.ENUMFORMFIELDTYPE_POLLING,
+		*positionData,
+		p.Key.ValueString(),
+		management.EnumFormPollingAppearance(p.PollingAppearance.ValueString()),
+		management.EnumFormItemSize(p.Size.ValueString()),
+	)
+
+	if !p.Visibility.IsNull() && !p.Visibility.IsUnknown() {
+		var plan formComponentsFieldVisibilityResourceModel
+		diags.Append(p.Visibility.As(ctx, &plan, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		data.SetVisibility(*plan.expand())
+	}
+
+	return data, diags
+}
+
 func (p *formComponentsFieldResourceModel) expandItemQRCode(ctx context.Context, positionData *management.FormFieldCommonPosition) (*management.FormFieldQrCode, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	data := management.NewFormFieldQrCode(
@@ -3497,6 +3552,22 @@ func formComponentsFieldsOkToTF(apiObject []management.FormField, ok bool) (base
 				"visibility":                      visibility,
 			}
 
+		case *management.FormFieldPolling:
+			position, d := formComponentsFieldsPositionOkToTF(t.GetPositionOk())
+			diags.Append(d...)
+
+			visibility, d := formComponentsFieldsVisibilityOkToTF(t.GetVisibilityOk())
+			diags.Append(d...)
+
+			attributeMap = map[string]attr.Value{
+				"key":                framework.StringOkToTF(t.GetKeyOk()),
+				"polling_appearance": framework.EnumOkToTF(t.GetPollingAppearanceOk()),
+				"position":           position,
+				"size":               framework.EnumOkToTF(t.GetSizeOk()),
+				"type":               framework.EnumOkToTF(t.GetTypeOk()),
+				"visibility":         visibility,
+			}
+
 		case *management.FormFieldQrCode:
 			position, d := formComponentsFieldsPositionOkToTF(t.GetPositionOk())
 			diags.Append(d...)
@@ -3663,6 +3734,7 @@ func formComponentsFieldsConvertEmptyValuesToTFNulls(attributeMap map[string]att
 		"other_option_input_label":        types.StringNull(),
 		"other_option_key":                types.StringNull(),
 		"other_option_label":              types.StringNull(),
+		"polling_appearance":              types.StringNull(),
 		"position":                        types.ObjectNull(formComponentsFieldsPositionTFObjectTypes),
 		"required":                        types.BoolNull(),
 		"show_password_requirements":      types.BoolNull(),

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -1850,6 +1850,97 @@ func TestAccForm_ItemRecaptchaV2(t *testing.T) {
 	})
 }
 
+func TestAccForm_ItemFIDO2(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_form.%s", resourceName)
+
+	name := resourceName
+
+	fullStep := resource.TestStep{
+		Config: testAccFormConfig_ItemFIDO2Full(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "FIDO2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "fido2-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.trigger", "BUTTON"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.action", "AUTHENTICATE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Use passkey\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.type", "ALWAYS_VISIBLE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.key", "mykey"),
+			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
+		),
+	}
+
+	minimalStep := resource.TestStep{
+		Config: testAccFormConfig_ItemFIDO2Minimal(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "FIDO2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "fido2-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.trigger", "AUTOMATIC"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.action", "REGISTER"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.label", "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Use passkey\"}]}]"),
+			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoBeta(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             base.Form_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			// Full step
+			fullStep,
+			{
+				Config:  testAccFormConfig_ItemFIDO2Full(resourceName, name),
+				Destroy: true,
+			},
+			// Minimal step
+			minimalStep,
+			{
+				Config:  testAccFormConfig_ItemFIDO2Minimal(resourceName, name),
+				Destroy: true,
+			},
+			// Change
+			fullStep,
+			minimalStep,
+			fullStep,
+			// Test importing the resource
+			{
+				ResourceName: resourceFullName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceFullName]
+						if !ok {
+							return "", fmt.Errorf("resource not found: %s", resourceFullName)
+						}
+
+						return fmt.Sprintf("%s/%s", rs.Primary.Attributes["environment_id"], rs.Primary.ID), nil
+					}
+				}(),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This computed attribute may be affected by other tests. Just ignore it here since it's fully computed.
+					"language_bundle",
+				},
+			},
+		},
+	})
+}
+
 func TestAccForm_ItemPolling(t *testing.T) {
 	t.Parallel()
 
@@ -1909,6 +2000,99 @@ func TestAccForm_ItemPolling(t *testing.T) {
 			minimalStep,
 			{
 				Config:  testAccFormConfig_ItemPollingMinimal(resourceName, name),
+				Destroy: true,
+			},
+			// Change
+			fullStep,
+			minimalStep,
+			fullStep,
+			// Test importing the resource
+			{
+				ResourceName: resourceFullName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceFullName]
+						if !ok {
+							return "", fmt.Errorf("resource not found: %s", resourceFullName)
+						}
+
+						return fmt.Sprintf("%s/%s", rs.Primary.Attributes["environment_id"], rs.Primary.ID), nil
+					}
+				}(),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This computed attribute may be affected by other tests. Just ignore it here since it's fully computed.
+					"language_bundle",
+				},
+			},
+		},
+	})
+}
+
+func TestAccForm_ItemAgreement(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_form.%s", resourceName)
+
+	name := resourceName
+
+	fullStep := resource.TestStep{
+		Config: testAccFormConfig_ItemAgreementFull(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "AGREEMENT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "agreement-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.input_type", "READ_ONLY_TEXT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.title_enabled", "true"),
+			resource.TestMatchResourceAttr(resourceFullName, "components.fields.0.agreement.id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.agreement.use_dynamic_agreement", "false"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.type", "ALWAYS_VISIBLE"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.key", "mykey"),
+			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
+		),
+	}
+
+	minimalStep := resource.TestStep{
+		Config: testAccFormConfig_ItemAgreementMinimal(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "AGREEMENT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "agreement-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.input_type", "READ_ONLY_TEXT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.title_enabled", "false"),
+			resource.TestCheckNoResourceAttr(resourceFullName, "components.fields.0.agreement.id"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.agreement.use_dynamic_agreement", "true"),
+			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoBeta(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             base.Form_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			// Full step
+			fullStep,
+			{
+				Config:  testAccFormConfig_ItemAgreementFull(resourceName, name),
+				Destroy: true,
+			},
+			// Minimal step
+			minimalStep,
+			{
+				Config:  testAccFormConfig_ItemAgreementMinimal(resourceName, name),
 				Destroy: true,
 			},
 			// Change
@@ -4866,6 +5050,99 @@ resource "pingone_form" "%[2]s" {
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
+func testAccFormConfig_ItemFIDO2Full(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "FIDO2"
+
+        position = {
+          row   = 0
+          col   = 0
+          width = 50
+        }
+
+        key     = "fido2-field"
+        trigger = "BUTTON"
+        action  = "AUTHENTICATE"
+        label   = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Use passkey\"}]}]"
+        visibility = {
+          type = "ALWAYS_VISIBLE"
+          key  = "mykey"
+        }
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccFormConfig_ItemFIDO2Minimal(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "FIDO2"
+
+        position = {
+          row = 0
+          col = 0
+        }
+
+        key     = "fido2-field"
+        trigger = "AUTOMATIC"
+        action  = "REGISTER"
+        label   = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Use passkey\"}]}]"
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
 func testAccFormConfig_ItemPollingFull(resourceName, name string) string {
 	return fmt.Sprintf(`
 	%[1]s
@@ -4955,6 +5232,113 @@ resource "pingone_form" "%[2]s" {
     ]
   }
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccFormConfig_ItemAgreementFull(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_agreement" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+}
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "AGREEMENT"
+
+        position = {
+          row   = 0
+          col   = 0
+          width = 50
+        }
+
+        key           = "agreement-field"
+        input_type    = "READ_ONLY_TEXT"
+        title_enabled = true
+        agreement = {
+          id                    = pingone_agreement.%[2]s.id
+          use_dynamic_agreement = false
+        }
+        visibility = {
+          type = "ALWAYS_VISIBLE"
+          key  = "mykey"
+        }
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccFormConfig_ItemAgreementMinimal(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "AGREEMENT"
+
+        position = {
+          row = 0
+          col = 0
+        }
+
+        key           = "agreement-field"
+        input_type    = "READ_ONLY_TEXT"
+        title_enabled = false
+        agreement = {
+          use_dynamic_agreement = true
+        }
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
 
 func testAccFormConfig_ItemSlateTextblobFull(resourceName, name string) string {

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -1869,7 +1869,7 @@ func TestAccForm_ItemPolling(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "polling-field"),
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.polling_appearance", "SPINNER"),
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.size", "MEDIUM"),
-			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.type", "SHOW_BY_DEFAULT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.type", "ALWAYS_VISIBLE"),
 			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.key", "mykey"),
 			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
 		),
@@ -4895,7 +4895,7 @@ resource "pingone_form" "%[2]s" {
         polling_appearance = "SPINNER"
         size               = "MEDIUM"
         visibility = {
-          type = "SHOW_BY_DEFAULT"
+          type = "ALWAYS_VISIBLE"
           key  = "mykey"
         }
       },

--- a/internal/service/base/resource_form_test.go
+++ b/internal/service/base/resource_form_test.go
@@ -1850,6 +1850,95 @@ func TestAccForm_ItemRecaptchaV2(t *testing.T) {
 	})
 }
 
+func TestAccForm_ItemPolling(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_form.%s", resourceName)
+
+	name := resourceName
+
+	fullStep := resource.TestStep{
+		Config: testAccFormConfig_ItemPollingFull(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.width", "50"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "POLLING"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "polling-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.polling_appearance", "SPINNER"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.size", "MEDIUM"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.type", "SHOW_BY_DEFAULT"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.visibility.key", "mykey"),
+			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
+		),
+	}
+
+	minimalStep := resource.TestStep{
+		Config: testAccFormConfig_ItemPollingMinimal(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.#", "2"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.row", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.position.col", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.type", "POLLING"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.key", "polling-field"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.polling_appearance", "DOTS"),
+			resource.TestCheckResourceAttr(resourceFullName, "components.fields.0.size", "SMALL"),
+			resource.TestCheckResourceAttr(resourceFullName, "language_bundle.%", "1"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoBeta(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             base.Form_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			// Full step
+			fullStep,
+			{
+				Config:  testAccFormConfig_ItemPollingFull(resourceName, name),
+				Destroy: true,
+			},
+			// Minimal step
+			minimalStep,
+			{
+				Config:  testAccFormConfig_ItemPollingMinimal(resourceName, name),
+				Destroy: true,
+			},
+			// Change
+			fullStep,
+			minimalStep,
+			fullStep,
+			// Test importing the resource
+			{
+				ResourceName: resourceFullName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceFullName]
+						if !ok {
+							return "", fmt.Errorf("resource not found: %s", resourceFullName)
+						}
+
+						return fmt.Sprintf("%s/%s", rs.Primary.Attributes["environment_id"], rs.Primary.ID), nil
+					}
+				}(),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// This computed attribute may be affected by other tests. Just ignore it here since it's fully computed.
+					"language_bundle",
+				},
+			},
+		},
+	})
+}
+
 func TestAccForm_ItemSlateTextblob(t *testing.T) {
 	t.Parallel()
 
@@ -4761,6 +4850,97 @@ resource "pingone_form" "%[2]s" {
           row = 0
           col = 0
         }
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccFormConfig_ItemPollingFull(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "POLLING"
+
+        position = {
+          row   = 0
+          col   = 0
+          width = 50
+        }
+
+        key                = "polling-field"
+        polling_appearance = "SPINNER"
+        size               = "MEDIUM"
+        visibility = {
+          type = "SHOW_BY_DEFAULT"
+          key  = "mykey"
+        }
+      },
+      {
+        type = "SUBMIT_BUTTON"
+
+        position = {
+          row = 1
+          col = 0
+        }
+
+        label = "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"},{\"type\":\"i18n\",\"key\":\"button.text\",\"defaultTranslation\":\"Submit\",\"inline\":true,\"children\":[{\"text\":\"\"}]},{\"text\":\"\"}]}]"
+      }
+    ]
+  }
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccFormConfig_ItemPollingMinimal(resourceName, name string) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "pingone_form" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  mark_required = true
+  mark_optional = false
+
+  cols = 4
+
+  components = {
+    fields = [
+      {
+        type = "POLLING"
+
+        position = {
+          row = 0
+          col = 0
+        }
+
+        key                = "polling-field"
+        polling_appearance = "DOTS"
+        size               = "SMALL"
       },
       {
         type = "SUBMIT_BUTTON"


### PR DESCRIPTION
## Change Description
- Support the POLLING field type in the `pingone_form` resource
- CDI-406

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run TestAccForm_ github.com/pingidentity/terraform-provider-pingone/internal/service/base
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== CONT  TestAccForm_ItemFlowButton
--- PASS: TestAccForm_BadParameters (42.36s)
=== CONT  TestAccForm_FieldCombobox
--- PASS: TestAccForm_ItemErrorDisplay (75.57s)
=== CONT  TestAccForm_NewEnv
--- PASS: TestAccForm_Full (76.70s)
=== CONT  TestAccForm_ItemEmptyField
--- PASS: TestAccForm_FieldText (82.11s)
=== CONT  TestAccForm_ItemDivider
--- PASS: TestAccForm_ItemSlateTextblob (83.48s)
=== CONT  TestAccForm_FieldCheckbox
--- PASS: TestAccForm_FieldDropdown (83.79s)
=== CONT  TestAccForm_Multiple
--- PASS: TestAccForm_ItemRecaptchaV2 (88.29s)
--- PASS: TestAccForm_FieldSubmitButton (89.27s)
--- PASS: TestAccForm_FieldRadio (89.29s)
--- PASS: TestAccForm_FieldPasswordVerify (90.35s)
--- PASS: TestAccForm_ItemQRCode (90.75s)
--- PASS: TestAccForm_ItemPolling (91.30s)
--- PASS: TestAccForm_ItemFlowButton (91.49s)
--- PASS: TestAccForm_FieldPassword (91.71s)
--- PASS: TestAccForm_ItemFlowLink (94.33s)
--- PASS: TestAccForm_Multiple (22.41s)
--- PASS: TestAccForm_FieldCombobox (65.91s)
--- PASS: TestAccForm_RemovalDrift (116.62s)
--- PASS: TestAccForm_ItemEmptyField (41.57s)
--- PASS: TestAccForm_ItemDivider (37.14s)
--- PASS: TestAccForm_FieldCheckbox (39.60s)
--- PASS: TestAccForm_NewEnv (47.51s)
PASS
ok  	github.com/pingidentity/terraform-provider-pingone/internal/service/base	123.870s
```

</details>
