### PR TITLE
Add missing attributes to `pingone_mfa_device_policy`

### DIFF
--- a/.changelog/pr-1301.txt
+++ b/.changelog/pr-1301.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_mfa_device_policy`: Added support for `notifications_policy.id`, `ignore_user_lock`, `remember_me`, `mobile.applications.push.number_matching`, `totp.passcode_grace_period`, and `whats_app` attributes
+```

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -202,7 +202,7 @@ resource "pingone_mfa_device_policy" "my_awesome_mfa_device_policy" {
 - `new_device_notification` (String) A string that defines whether a user should be notified if a new authentication method has been added to their account.  Options are `EMAIL_THEN_SMS`, `NONE`, `SMS_THEN_EMAIL`.  Defaults to `NONE`.
 - `notifications_policy` (Attributes) A single object that specifies the notification policy to use for this MFA device policy. If not specified, the default notification policy for the environment will be used. (see [below for nested schema](#nestedatt--notifications_policy))
 - `remember_me` (Attributes) A single object that specifies 'remember me' settings so that users do not have to authenticate when accessing applications from a device they have used already. (see [below for nested schema](#nestedatt--remember_me))
-- `whats_app` (Attributes) A single object that allows configuration of WhatsApp OTP device authentication policy settings. (see [below for nested schema](#nestedatt--whats_app))
+- `whats_app` (Attributes) A single object that allows configuration of WhatsApp OTP device authentication policy settings. To set `enabled = true`, WhatsApp sender settings must already be configured in PingOne. (see [below for nested schema](#nestedatt--whats_app))
 
 ### Read-Only
 
@@ -644,21 +644,24 @@ Required:
 Required:
 
 - `enabled` (Boolean) A boolean that specifies whether the WhatsApp OTP method is enabled or disabled in the policy.
+- `otp` (Attributes) A single object that allows configuration of WhatsApp OTP settings. (see [below for nested schema](#nestedatt--whats_app--otp))
 
 Optional:
 
-- `otp` (Attributes) A single object that allows configuration of WhatsApp OTP settings. (see [below for nested schema](#nestedatt--whats_app--otp))
-- `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the WhatsApp OTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
+- `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the WhatsApp OTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.
 - `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
 
 <a id="nestedatt--whats_app--otp"></a>
 ### Nested Schema for `whats_app.otp`
 
-Optional:
+Required:
 
 - `failure` (Attributes) A single object that allows configuration of WhatsApp OTP failure settings. (see [below for nested schema](#nestedatt--whats_app--otp--failure))
 - `lifetime` (Attributes) A single object that allows configuration of WhatsApp OTP lifetime settings. (see [below for nested schema](#nestedatt--whats_app--otp--lifetime))
-- `otp_length` (Number) An integer that specifies the length of the OTP that is shown to users.  Minimum length is `6` digits and maximum is `10` digits.  Defaults to `6`.
+
+Optional:
+
+- `otp_length` (Number) An integer that specifies the length of the OTP that is shown to users.  Minimum length is `6` digits and maximum is `10` digits.
 
 <a id="nestedatt--whats_app--otp--failure"></a>
 ### Nested Schema for `whats_app.otp.failure`
@@ -666,7 +669,7 @@ Optional:
 Required:
 
 - `cool_down` (Attributes) A single object that allows configuration of WhatsApp OTP failure cool down settings. (see [below for nested schema](#nestedatt--whats_app--otp--failure--cool_down))
-- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `1` and maximum is `7`.  Defaults to `3`.
+- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `1` and maximum is `7`.
 
 <a id="nestedatt--whats_app--otp--failure--cool_down"></a>
 ### Nested Schema for `whats_app.otp.failure.cool_down`

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -202,6 +202,7 @@ resource "pingone_mfa_device_policy" "my_awesome_mfa_device_policy" {
 - `new_device_notification` (String) A string that defines whether a user should be notified if a new authentication method has been added to their account.  Options are `EMAIL_THEN_SMS`, `NONE`, `SMS_THEN_EMAIL`.  Defaults to `NONE`.
 - `notifications_policy` (Attributes) A single object that specifies the notification policy to use for this MFA device policy. If not specified, the default notification policy for the environment will be used. (see [below for nested schema](#nestedatt--notifications_policy))
 - `remember_me` (Attributes) A single object that specifies 'remember me' settings so that users do not have to authenticate when accessing applications from a device they have used already. (see [below for nested schema](#nestedatt--remember_me))
+- `whats_app` (Attributes) A single object that allows configuration of WhatsApp OTP device authentication policy settings. (see [below for nested schema](#nestedatt--whats_app))
 
 ### Read-Only
 
@@ -633,6 +634,57 @@ Required:
 
 - `duration` (Number) An integer that, used in conjunction with `time_unit`, defines the 'remember me' period.
 - `time_unit` (String) A string that specifies the time unit to use for the 'remember me' period.  Options are `DAYS`, `HOURS`, `MINUTES`.
+
+
+
+
+<a id="nestedatt--whats_app"></a>
+### Nested Schema for `whats_app`
+
+Required:
+
+- `enabled` (Boolean) A boolean that specifies whether the WhatsApp OTP method is enabled or disabled in the policy.
+
+Optional:
+
+- `otp` (Attributes) A single object that allows configuration of WhatsApp OTP settings. (see [below for nested schema](#nestedatt--whats_app--otp))
+- `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the WhatsApp OTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
+- `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
+
+<a id="nestedatt--whats_app--otp"></a>
+### Nested Schema for `whats_app.otp`
+
+Optional:
+
+- `failure` (Attributes) A single object that allows configuration of WhatsApp OTP failure settings. (see [below for nested schema](#nestedatt--whats_app--otp--failure))
+- `lifetime` (Attributes) A single object that allows configuration of WhatsApp OTP lifetime settings. (see [below for nested schema](#nestedatt--whats_app--otp--lifetime))
+- `otp_length` (Number) An integer that specifies the length of the OTP that is shown to users.  Minimum length is `6` digits and maximum is `10` digits.  Defaults to `6`.
+
+<a id="nestedatt--whats_app--otp--failure"></a>
+### Nested Schema for `whats_app.otp.failure`
+
+Required:
+
+- `cool_down` (Attributes) A single object that allows configuration of WhatsApp OTP failure cool down settings. (see [below for nested schema](#nestedatt--whats_app--otp--failure--cool_down))
+- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.
+
+<a id="nestedatt--whats_app--otp--failure--cool_down"></a>
+### Nested Schema for `whats_app.otp.failure.cool_down`
+
+Required:
+
+- `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+
+
+
+<a id="nestedatt--whats_app--otp--lifetime"></a>
+### Nested Schema for `whats_app.otp.lifetime`
+
+Required:
+
+- `duration` (Number) An integer that defines the duration (number of time units) that the passcode is valid before it expires.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
 
 ## Import
 

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -201,6 +201,7 @@ resource "pingone_mfa_device_policy" "my_awesome_mfa_device_policy" {
 - `ignore_user_lock` (Boolean) A boolean that, when set to `true`, allows PingOne to skip the account lock check during MFA authentication.  Defaults to `false`.
 - `new_device_notification` (String) A string that defines whether a user should be notified if a new authentication method has been added to their account.  Options are `EMAIL_THEN_SMS`, `NONE`, `SMS_THEN_EMAIL`.  Defaults to `NONE`.
 - `notifications_policy` (Attributes) A single object that specifies the notification policy to use for this MFA device policy. If not specified, the default notification policy for the environment will be used. (see [below for nested schema](#nestedatt--notifications_policy))
+- `remember_me` (Attributes) A single object that specifies 'remember me' settings so that users do not have to authenticate when accessing applications from a device they have used already. (see [below for nested schema](#nestedatt--remember_me))
 
 ### Read-Only
 
@@ -595,6 +596,30 @@ Required:
 Required:
 
 - `id` (String) A string that specifies the ID of the notification policy to use.
+
+
+<a id="nestedatt--remember_me"></a>
+### Nested Schema for `remember_me`
+
+Required:
+
+- `web` (Attributes) A single object that contains the 'remember me' settings for accessing applications from a browser. (see [below for nested schema](#nestedatt--remember_me--web))
+
+<a id="nestedatt--remember_me--web"></a>
+### Nested Schema for `remember_me.web`
+
+Required:
+
+- `enabled` (Boolean) A boolean that, when set to `true`, enables the 'remember me' option in the MFA policy.
+- `life_time` (Attributes) A single object that defines the period during which users will not have to authenticate if they are accessing applications from a device they have used before. The 'remember me' period can be anywhere from `1` minute to `90` days. (see [below for nested schema](#nestedatt--remember_me--web--life_time))
+
+<a id="nestedatt--remember_me--web--life_time"></a>
+### Nested Schema for `remember_me.web.life_time`
+
+Required:
+
+- `duration` (Number) An integer that, used in conjunction with `time_unit`, defines the 'remember me' period.
+- `time_unit` (String) A string that specifies the time unit to use for the 'remember me' period.  Options are `DAYS`, `HOURS`, `MINUTES`.
 
 ## Import
 

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -200,6 +200,7 @@ resource "pingone_mfa_device_policy" "my_awesome_mfa_device_policy" {
 - `fido2` (Attributes) A single object that allows configuration of FIDO2 device authentication policy settings. (see [below for nested schema](#nestedatt--fido2))
 - `ignore_user_lock` (Boolean) A boolean that, when set to `true`, allows PingOne to skip the account lock check during MFA authentication.  Defaults to `false`.
 - `new_device_notification` (String) A string that defines whether a user should be notified if a new authentication method has been added to their account.  Options are `EMAIL_THEN_SMS`, `NONE`, `SMS_THEN_EMAIL`.  Defaults to `NONE`.
+- `notifications_policy` (Attributes) A single object that specifies the notification policy to use for this MFA device policy. If not specified, the default notification policy for the environment will be used. (see [below for nested schema](#nestedatt--notifications_policy))
 
 ### Read-Only
 
@@ -584,6 +585,16 @@ Required:
 
 - `duration` (Number) An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `2` minutes and the maximum value is `30` minutes.  Defaults to `2`.
 - `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.  Defaults to `MINUTES`.
+
+
+
+
+<a id="nestedatt--notifications_policy"></a>
+### Nested Schema for `notifications_policy`
+
+Required:
+
+- `id` (String) A string that specifies the ID of the notification policy to use.
 
 ## Import
 

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -477,6 +477,7 @@ Optional:
 
 - `otp` (Attributes) A single object that allows configuration of TOTP OTP settings. (see [below for nested schema](#nestedatt--totp--otp))
 - `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the TOTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
+- `passcode_grace_period` (Number) An integer that specifies the TOTP passcode grace period in 30-second windows. The minimum value is `1` and the maximum value is `10`.
 - `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
 - `uri_parameters` (Map of String) A map of string key:value pairs that specifies `otpauth` URI parameters. For example, if you provide a value for the `issuer` parameter, then authenticators that support that parameter will display the text you specify together with the OTP (in addition to the username). This can help users recognize which application the OTP is for. If you intend on using the same MFA policy for multiple applications, choose a name that reflects the group of applications.
 

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -198,6 +198,7 @@ resource "pingone_mfa_device_policy" "my_awesome_mfa_device_policy" {
 
 - `authentication` (Attributes) A single object that allows configuration of authentication settings in the device policy. (see [below for nested schema](#nestedatt--authentication))
 - `fido2` (Attributes) A single object that allows configuration of FIDO2 device authentication policy settings. (see [below for nested schema](#nestedatt--fido2))
+- `ignore_user_lock` (Boolean) A boolean that, when set to `true`, allows PingOne to skip the account lock check during MFA authentication.  Defaults to `false`.
 - `new_device_notification` (String) A string that defines whether a user should be notified if a new authentication method has been added to their account.  Options are `EMAIL_THEN_SMS`, `NONE`, `SMS_THEN_EMAIL`.  Defaults to `NONE`.
 
 ### Read-Only

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -331,6 +331,18 @@ Required:
 
 - `enabled` (Boolean) A boolean that specifies whether push notification is enabled or disabled for the application in the policy.
 
+Optional:
+
+- `number_matching` (Attributes) A single object that configures number matching for push notifications. (see [below for nested schema](#nestedatt--mobile--applications--push--number_matching))
+
+<a id="nestedatt--mobile--applications--push--number_matching"></a>
+### Nested Schema for `mobile.applications.push.number_matching`
+
+Required:
+
+- `enabled` (Boolean) A boolean that, when set to `true`, requires the authenticating user to select a number that was displayed to them on the accessing device.
+
+
 
 <a id="nestedatt--mobile--applications--push_limit"></a>
 ### Nested Schema for `mobile.applications.push_limit`

--- a/docs/resources/mfa_device_policy.md
+++ b/docs/resources/mfa_device_policy.md
@@ -237,7 +237,7 @@ Optional:
 Required:
 
 - `cool_down` (Attributes) A single object that allows configuration of email OTP failure cool down settings. (see [below for nested schema](#nestedatt--email--otp--failure--cool_down))
-- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.
+- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `1` and maximum is `7`.  Defaults to `3`.
 
 <a id="nestedatt--email--otp--failure--cool_down"></a>
 ### Nested Schema for `email.otp.failure.cool_down`
@@ -444,7 +444,7 @@ Optional:
 Required:
 
 - `cool_down` (Attributes) A single object that allows configuration of SMS OTP failure cool down settings. (see [below for nested schema](#nestedatt--sms--otp--failure--cool_down))
-- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.
+- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `1` and maximum is `7`.  Defaults to `3`.
 
 <a id="nestedatt--sms--otp--failure--cool_down"></a>
 ### Nested Schema for `sms.otp.failure.cool_down`
@@ -478,7 +478,7 @@ Optional:
 
 - `otp` (Attributes) A single object that allows configuration of TOTP OTP settings. (see [below for nested schema](#nestedatt--totp--otp))
 - `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the TOTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
-- `passcode_grace_period` (Number) An integer that specifies the TOTP passcode grace period in 30-second windows. The minimum value is `1` and the maximum value is `10`.
+- `passcode_grace_period` (Number) An integer that specifies the TOTP passcode grace period in 30-second windows. The minimum value is `1` and the maximum value is `10`.  Defaults to `5`.
 - `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
 - `uri_parameters` (Map of String) A map of string key:value pairs that specifies `otpauth` URI parameters. For example, if you provide a value for the `issuer` parameter, then authenticators that support that parameter will display the text you specify together with the OTP (in addition to the username). This can help users recognize which application the OTP is for. If you intend on using the same MFA policy for multiple applications, choose a name that reflects the group of applications.
 
@@ -540,7 +540,7 @@ Optional:
 Required:
 
 - `cool_down` (Attributes) A single object that allows configuration of voice OTP failure cool down settings. (see [below for nested schema](#nestedatt--voice--otp--failure--cool_down))
-- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.
+- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `1` and maximum is `7`.  Defaults to `3`.
 
 <a id="nestedatt--voice--otp--failure--cool_down"></a>
 ### Nested Schema for `voice.otp.failure.cool_down`
@@ -666,7 +666,7 @@ Optional:
 Required:
 
 - `cool_down` (Attributes) A single object that allows configuration of WhatsApp OTP failure cool down settings. (see [below for nested schema](#nestedatt--whats_app--otp--failure--cool_down))
-- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.
+- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `1` and maximum is `7`.  Defaults to `3`.
 
 <a id="nestedatt--whats_app--otp--failure--cool_down"></a>
 ### Nested Schema for `whats_app.otp.failure.cool_down`

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -52,6 +52,7 @@ type MFADevicePolicyResourceModel struct {
 	Sms                   types.Object                 `tfsdk:"sms"`
 	Voice                 types.Object                 `tfsdk:"voice"`
 	Email                 types.Object                 `tfsdk:"email"`
+	WhatsApp              types.Object                 `tfsdk:"whats_app"`
 	Mobile                types.Object                 `tfsdk:"mobile"`
 	Totp                  types.Object                 `tfsdk:"totp"`
 	Fido2                 types.Object                 `tfsdk:"fido2"`
@@ -64,6 +65,7 @@ type MFADevicePolicyAuthenticationResourceModel struct {
 type MFADevicePolicySmsResourceModel MFADevicePolicyOfflineDeviceResourceModel
 type MFADevicePolicyVoiceResourceModel MFADevicePolicyOfflineDeviceResourceModel
 type MFADevicePolicyEmailResourceModel MFADevicePolicyOfflineDeviceResourceModel
+type MFADevicePolicyWhatsAppResourceModel MFADevicePolicyOfflineDeviceResourceModel
 
 type MFADevicePolicyTotpResourceModel struct {
 	Enabled                    types.Bool   `tfsdk:"enabled"`
@@ -674,6 +676,8 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 			"voice": r.devicePolicyOfflineDeviceSchemaAttribute("voice OTP"),
 
 			"email": r.devicePolicyOfflineDeviceSchemaAttribute("email OTP"),
+
+			"whats_app": r.devicePolicyOfflineDeviceSchemaAttributeOptional("WhatsApp OTP"),
 
 			"mobile": schema.SingleNestedAttribute{
 				Description:         mobileDescription.Description,
@@ -1396,6 +1400,55 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 	}
 }
 
+func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttributeOptional(descriptionMethod string) schema.SingleNestedAttribute {
+
+	const otpFailureCountDefault = 3
+	const otpFailureCoolDownDurationDefault = 0
+	const otpLifetimeDurationDefault = 30
+	const otpOtpLengthDefault = 6
+
+	a := r.devicePolicyOfflineDeviceSchemaAttribute(descriptionMethod)
+	a.Required = false
+	a.Optional = true
+	a.Computed = true
+	a.Default = objectdefault.StaticValue(types.ObjectValueMust(
+		MFADevicePolicyOfflineDeviceTFObjectTypes,
+		map[string]attr.Value{
+			"enabled":          types.BoolValue(false),
+			"pairing_disabled": types.BoolValue(false),
+			"otp": types.ObjectValueMust(
+				MFADevicePolicyOfflineDeviceOtpTFObjectTypes,
+				map[string]attr.Value{
+					"failure": types.ObjectValueMust(
+						MFADevicePolicyFailureTFObjectTypes,
+						map[string]attr.Value{
+							"count": types.Int32Value(otpFailureCountDefault),
+							"cool_down": types.ObjectValueMust(
+								MFADevicePolicyTimePeriodTFObjectTypes,
+								map[string]attr.Value{
+									"duration":  types.Int32Value(otpFailureCoolDownDurationDefault),
+									"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+								},
+							),
+						},
+					),
+					"lifetime": types.ObjectValueMust(
+						MFADevicePolicyTimePeriodTFObjectTypes,
+						map[string]attr.Value{
+							"duration":  types.Int32Value(otpLifetimeDurationDefault),
+							"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+						},
+					),
+					"otp_length": types.Int32Value(otpOtpLengthDefault),
+				},
+			),
+			"prompt_for_nickname_on_pairing": types.BoolNull(),
+		},
+	))
+
+	return a
+}
+
 func (r *MFADevicePolicyResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
@@ -1703,6 +1756,24 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 		return nil, diags
 	}
 
+	// WhatsApp
+	var whatsApp *mfa.DeviceAuthenticationPolicyOfflineDevice
+	if !p.WhatsApp.IsNull() && !p.WhatsApp.IsUnknown() {
+		var whatsAppPlan MFADevicePolicyWhatsAppResourceModel
+		diags.Append(p.WhatsApp.As(ctx, &whatsAppPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		whatsApp, d = whatsAppPlan.expand(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+	}
+
 	// Mobile
 	var mobilePlan MFADevicePolicyMobileResourceModel
 	diags.Append(p.Mobile.As(ctx, &mobilePlan, basetypes.ObjectAsOptions{
@@ -1744,6 +1815,10 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 		false, // default
 		false, // forSignOnPolicy
 	)
+
+	if whatsApp != nil {
+		policy.SetWhatsapp(*whatsApp)
+	}
 
 	// FIDO2
 	if !p.Fido2.IsNull() && !p.Fido2.IsUnknown() {
@@ -1881,6 +1956,11 @@ func (p *MFADevicePolicyVoiceResourceModel) expand(ctx context.Context) (*mfa.De
 }
 
 func (p *MFADevicePolicyEmailResourceModel) expand(ctx context.Context) (*mfa.DeviceAuthenticationPolicyOfflineDevice, diag.Diagnostics) {
+	data := MFADevicePolicyOfflineDeviceResourceModel(*p)
+	return data.expand(ctx)
+}
+
+func (p *MFADevicePolicyWhatsAppResourceModel) expand(ctx context.Context) (*mfa.DeviceAuthenticationPolicyOfflineDevice, diag.Diagnostics) {
 	data := MFADevicePolicyOfflineDeviceResourceModel(*p)
 	return data.expand(ctx)
 }
@@ -2472,6 +2552,9 @@ func (p *MFADevicePolicyResourceModel) toState(apiObject *mfa.DeviceAuthenticati
 	p.Email, d = toStateMfaDevicePolicyEmail(apiObject.GetEmailOk())
 	diags.Append(d...)
 
+	p.WhatsApp, d = toStateMfaDevicePolicyWhatsApp(apiObject.GetWhatsappOk())
+	diags.Append(d...)
+
 	p.Mobile, d = toStateMfaDevicePolicyMobile(apiObject.GetMobileOk())
 	diags.Append(d...)
 
@@ -2649,6 +2732,10 @@ func toStateMfaDevicePolicyVoice(apiObject *mfa.DeviceAuthenticationPolicyOfflin
 }
 
 func toStateMfaDevicePolicyEmail(apiObject *mfa.DeviceAuthenticationPolicyOfflineDevice, ok bool) (types.Object, diag.Diagnostics) {
+	return toStateMfaDevicePolicyOfflineDevice(apiObject, ok)
+}
+
+func toStateMfaDevicePolicyWhatsApp(apiObject *mfa.DeviceAuthenticationPolicyOfflineDevice, ok bool) (types.Object, diag.Diagnostics) {
 	return toStateMfaDevicePolicyOfflineDevice(apiObject, ok)
 }
 

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -154,7 +154,11 @@ type MFADevicePolicyMobileApplicationDeviceAuthorizationResourceModel struct {
 }
 
 type MFADevicePolicyMobileApplicationOtpResourceModel MFADevicePolicyEnabledResourceModel
-type MFADevicePolicyMobileApplicationPushResourceModel MFADevicePolicyEnabledResourceModel
+type MFADevicePolicyMobileApplicationPushResourceModel struct {
+	Enabled        types.Bool   `tfsdk:"enabled"`
+	NumberMatching types.Object `tfsdk:"number_matching"`
+}
+type MFADevicePolicyMobileApplicationPushNumberMatchingResourceModel MFADevicePolicyEnabledResourceModel
 type MFADevicePolicyEnabledResourceModel struct {
 	Enabled types.Bool `tfsdk:"enabled"`
 }
@@ -226,6 +230,11 @@ var (
 	}
 
 	MFADevicePolicyMobileApplicationPushTFObjectTypes = map[string]attr.Type{
+		"enabled":         types.BoolType,
+		"number_matching": types.ObjectType{AttrTypes: MFADevicePolicyMobileApplicationPushNumberMatchingTFObjectTypes},
+	}
+
+	MFADevicePolicyMobileApplicationPushNumberMatchingTFObjectTypes = map[string]attr.Type{
 		"enabled": types.BoolType,
 	}
 
@@ -425,6 +434,14 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 
 	mobileApplicationsPushTimeoutDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"An integer that defines the length of time that push notifications should be blocked for the application if the defined limit has been reached. The minimum value is `1` minute and the maximum value is `120` minutes. If this parameter is not provided, the default value is `30` minutes.",
+	)
+
+	mobileApplicationsPushNumberMatchingDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that configures number matching for push notifications.",
+	)
+
+	mobileApplicationsPushNumberMatchingEnabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A boolean that, when set to `true`, requires the authenticating user to select a number that was displayed to them on the accessing device.",
 	)
 
 	mobileOtpFailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -762,6 +779,28 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 										"enabled": schema.BoolAttribute{
 											Description: framework.SchemaAttributeDescriptionFromMarkdown("A boolean that specifies whether push notification is enabled or disabled for the application in the policy.").Description,
 											Required:    true,
+										},
+
+										"number_matching": schema.SingleNestedAttribute{
+											Description:         mobileApplicationsPushNumberMatchingDescription.Description,
+											MarkdownDescription: mobileApplicationsPushNumberMatchingDescription.MarkdownDescription,
+											Optional:            true,
+											Computed:            true,
+
+											Default: objectdefault.StaticValue(types.ObjectValueMust(
+												MFADevicePolicyMobileApplicationPushNumberMatchingTFObjectTypes,
+												map[string]attr.Value{
+													"enabled": types.BoolValue(false),
+												},
+											)),
+
+											Attributes: map[string]schema.Attribute{
+												"enabled": schema.BoolAttribute{
+													Description:         mobileApplicationsPushNumberMatchingEnabledDescription.Description,
+													MarkdownDescription: mobileApplicationsPushNumberMatchingEnabledDescription.MarkdownDescription,
+													Required:            true,
+												},
+											},
 										},
 									},
 								},
@@ -2146,6 +2185,22 @@ func (p *MFADevicePolicyMobileApplicationResourceModel) expand(ctx context.Conte
 				plan.Enabled.ValueBool(),
 			),
 		)
+
+		if !plan.NumberMatching.IsNull() && !plan.NumberMatching.IsUnknown() {
+			var numberMatchingPlan MFADevicePolicyMobileApplicationPushNumberMatchingResourceModel
+			diags.Append(plan.NumberMatching.As(ctx, &numberMatchingPlan, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    false,
+				UnhandledUnknownAsEmpty: false,
+			})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			if push, ok := data.GetPushOk(); ok && push != nil {
+				push.SetNumberMatching(*mfa.NewDeviceAuthenticationPolicyCommonMobileApplicationsInnerPushNumberMatching(numberMatchingPlan.Enabled.ValueBool()))
+				data.SetPush(*push)
+			}
+		}
 	}
 
 	// Push Limit
@@ -2743,11 +2798,35 @@ func toStateMfaDevicePolicyMobileApplicationsPush(apiObject *mfa.DeviceAuthentic
 		return types.ObjectNull(MFADevicePolicyMobileApplicationPushTFObjectTypes), nil
 	}
 
+	numberMatching, d := toStateMfaDevicePolicyMobileApplicationsPushNumberMatching(apiObject.GetNumberMatchingOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(MFADevicePolicyMobileApplicationPushTFObjectTypes), diags
+	}
+
+	o := map[string]attr.Value{
+		"enabled":         framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"number_matching": numberMatching,
+	}
+
+	objValue, d := types.ObjectValue(MFADevicePolicyMobileApplicationPushTFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
+}
+
+func toStateMfaDevicePolicyMobileApplicationsPushNumberMatching(apiObject *mfa.DeviceAuthenticationPolicyCommonMobileApplicationsInnerPushNumberMatching, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFADevicePolicyMobileApplicationPushNumberMatchingTFObjectTypes), nil
+	}
+
 	o := map[string]attr.Value{
 		"enabled": framework.BoolOkToTF(apiObject.GetEnabledOk()),
 	}
 
-	objValue, d := types.ObjectValue(MFADevicePolicyMobileApplicationPushTFObjectTypes, o)
+	objValue, d := types.ObjectValue(MFADevicePolicyMobileApplicationPushNumberMatchingTFObjectTypes, o)
 	diags.Append(d...)
 
 	return objValue, diags

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/patrickcping/pingone-go-sdk-v2/pingone/model"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/customtypes/pingonetypes"
+	int32validatorinternal "github.com/pingidentity/terraform-provider-pingone/internal/framework/int32validator"
 	"github.com/pingidentity/terraform-provider-pingone/internal/framework/legacysdk"
 	"github.com/pingidentity/terraform-provider-pingone/internal/sdk"
 	"github.com/pingidentity/terraform-provider-pingone/internal/utils"
@@ -46,6 +47,7 @@ type MFADevicePolicyResourceModel struct {
 	NewDeviceNotification types.String                 `tfsdk:"new_device_notification"`
 	IgnoreUserLock        types.Bool                   `tfsdk:"ignore_user_lock"`
 	NotificationsPolicy   types.Object                 `tfsdk:"notifications_policy"`
+	RememberMe            types.Object                 `tfsdk:"remember_me"`
 	Default               types.Bool                   `tfsdk:"default"`
 	Sms                   types.Object                 `tfsdk:"sms"`
 	Voice                 types.Object                 `tfsdk:"voice"`
@@ -73,6 +75,15 @@ type MFADevicePolicyTotpResourceModel struct {
 
 type MFADevicePolicyNotificationsPolicyResourceModel struct {
 	Id types.String `tfsdk:"id"`
+}
+
+type MFADevicePolicyRememberMeResourceModel struct {
+	Web types.Object `tfsdk:"web"`
+}
+
+type MFADevicePolicyRememberMeWebResourceModel struct {
+	Enabled  types.Bool   `tfsdk:"enabled"`
+	LifeTime types.Object `tfsdk:"life_time"`
 }
 
 type MFADevicePolicyOfflineDeviceResourceModel struct {
@@ -302,6 +313,14 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	const fido2FailureCoolDownDurationMinSeconds = fido2FailureCoolDownDurationMinMinutes * 60
 	const fido2FailureCoolDownDurationMaxSeconds = fido2FailureCoolDownDurationMaxMinutes * 60
 
+	const rememberMeWebLifeTimeDurationDefault = 30
+	const rememberMeWebLifeTimeDurationMinMinutes = 1
+	const rememberMeWebLifeTimeDurationMaxMinutes = 129600
+	const rememberMeWebLifeTimeDurationMinHours = 1
+	const rememberMeWebLifeTimeDurationMaxHours = 2160
+	const rememberMeWebLifeTimeDurationMinDays = 1
+	const rememberMeWebLifeTimeDurationMaxDays = 90
+
 	// schema descriptions and validation settings
 	deviceSelectionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that defines the device selection method.",
@@ -322,6 +341,49 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	notificationsPolicyIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that specifies the ID of the notification policy to use.",
 	)
+
+	rememberMeDefault := types.ObjectValueMust(
+		MFADevicePolicyRememberMeTFObjectTypes,
+		map[string]attr.Value{
+			"web": types.ObjectValueMust(
+				MFADevicePolicyRememberMeWebTFObjectTypes,
+				map[string]attr.Value{
+					"enabled": types.BoolValue(false),
+					"life_time": types.ObjectValueMust(
+						MFADevicePolicyTimePeriodTFObjectTypes,
+						map[string]attr.Value{
+							"duration":  types.Int32Value(rememberMeWebLifeTimeDurationDefault),
+							"time_unit": types.StringValue(string(mfa.ENUMTIMEUNITREMEMBERMEWEBLIFETIME_MINUTES)),
+						},
+					),
+				},
+			),
+		},
+	)
+
+	rememberMeDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that specifies 'remember me' settings so that users do not have to authenticate when accessing applications from a device they have used already.",
+	)
+
+	rememberMeWebDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that contains the 'remember me' settings for accessing applications from a browser.",
+	)
+
+	rememberMeWebEnabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A boolean that, when set to `true`, enables the 'remember me' option in the MFA policy.",
+	)
+
+	rememberMeWebLifeTimeDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("A single object that defines the period during which users will not have to authenticate if they are accessing applications from a device they have used before. The 'remember me' period can be anywhere from `%d` minute to `%d` days.", rememberMeWebLifeTimeDurationMinMinutes, rememberMeWebLifeTimeDurationMaxDays),
+	)
+
+	rememberMeWebLifeTimeDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that, used in conjunction with `time_unit`, defines the 'remember me' period.",
+	)
+
+	rememberMeWebLifeTimeTimeUnitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A string that specifies the time unit to use for the 'remember me' period.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitRememberMeWebLifeTimeEnumValues)
 
 	defaultDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that specifies whether this MFA device policy is enforced as the default within the environment. When set to `true`, all other MFA device policies are `false`.",
@@ -488,6 +550,84 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 
 						Validators: []validator.String{
 							verify.P1ResourceIDValidator(),
+						},
+					},
+				},
+			},
+
+			"remember_me": schema.SingleNestedAttribute{
+				Description:         rememberMeDescription.Description,
+				MarkdownDescription: rememberMeDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: objectdefault.StaticValue(rememberMeDefault),
+
+				Attributes: map[string]schema.Attribute{
+					"web": schema.SingleNestedAttribute{
+						Description:         rememberMeWebDescription.Description,
+						MarkdownDescription: rememberMeWebDescription.MarkdownDescription,
+						Required:            true,
+
+						Attributes: map[string]schema.Attribute{
+							"enabled": schema.BoolAttribute{
+								Description:         rememberMeWebEnabledDescription.Description,
+								MarkdownDescription: rememberMeWebEnabledDescription.MarkdownDescription,
+								Required:            true,
+							},
+
+							"life_time": schema.SingleNestedAttribute{
+								Description:         rememberMeWebLifeTimeDescription.Description,
+								MarkdownDescription: rememberMeWebLifeTimeDescription.MarkdownDescription,
+								Required:            true,
+
+								Attributes: map[string]schema.Attribute{
+									"duration": schema.Int32Attribute{
+										Description:         rememberMeWebLifeTimeDurationDescription.Description,
+										MarkdownDescription: rememberMeWebLifeTimeDurationDescription.MarkdownDescription,
+										Required:            true,
+
+										Validators: []validator.Int32{
+											int32validator.Any(
+												int32validator.All(
+													int32validator.Between(rememberMeWebLifeTimeDurationMinMinutes, rememberMeWebLifeTimeDurationMaxMinutes),
+													int32validatorinternal.RegexMatchesPathValue(
+														regexp.MustCompile(`MINUTES`),
+														fmt.Sprintf("If `time_unit` is `MINUTES`, the allowed duration range is %d - %d.", rememberMeWebLifeTimeDurationMinMinutes, rememberMeWebLifeTimeDurationMaxMinutes),
+														path.MatchRelative().AtParent().AtName("time_unit"),
+													),
+												),
+												int32validator.All(
+													int32validator.Between(rememberMeWebLifeTimeDurationMinHours, rememberMeWebLifeTimeDurationMaxHours),
+													int32validatorinternal.RegexMatchesPathValue(
+														regexp.MustCompile(`HOURS`),
+														fmt.Sprintf("If `time_unit` is `HOURS`, the allowed duration range is %d - %d.", rememberMeWebLifeTimeDurationMinHours, rememberMeWebLifeTimeDurationMaxHours),
+														path.MatchRelative().AtParent().AtName("time_unit"),
+													),
+												),
+												int32validator.All(
+													int32validator.Between(rememberMeWebLifeTimeDurationMinDays, rememberMeWebLifeTimeDurationMaxDays),
+													int32validatorinternal.RegexMatchesPathValue(
+														regexp.MustCompile(`DAYS`),
+														fmt.Sprintf("If `time_unit` is `DAYS`, the allowed duration range is %d - %d.", rememberMeWebLifeTimeDurationMinDays, rememberMeWebLifeTimeDurationMaxDays),
+														path.MatchRelative().AtParent().AtName("time_unit"),
+													),
+												),
+											),
+										},
+									},
+
+									"time_unit": schema.StringAttribute{
+										Description:         rememberMeWebLifeTimeTimeUnitDescription.Description,
+										MarkdownDescription: rememberMeWebLifeTimeTimeUnitDescription.MarkdownDescription,
+										Required:            true,
+
+										Validators: []validator.String{
+											stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitRememberMeWebLifeTimeEnumValues)...),
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -1607,6 +1747,49 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 		)
 	}
 
+	if !p.RememberMe.IsNull() && !p.RememberMe.IsUnknown() {
+		var rememberMePlan MFADevicePolicyRememberMeResourceModel
+		diags.Append(p.RememberMe.As(ctx, &rememberMePlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		if !rememberMePlan.Web.IsNull() && !rememberMePlan.Web.IsUnknown() {
+			var webPlan MFADevicePolicyRememberMeWebResourceModel
+			diags.Append(rememberMePlan.Web.As(ctx, &webPlan, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    false,
+				UnhandledUnknownAsEmpty: false,
+			})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			var lifeTimePlan MFADevicePolicyTimePeriodResourceModel
+			diags.Append(webPlan.LifeTime.As(ctx, &lifeTimePlan, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    false,
+				UnhandledUnknownAsEmpty: false,
+			})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			lifeTime := mfa.DeviceAuthenticationPolicyCommonRememberMeWebLifeTime{}
+			lifeTime.SetDuration(lifeTimePlan.Duration.ValueInt32())
+			lifeTime.SetTimeUnit(mfa.EnumTimeUnitRememberMeWebLifeTime(lifeTimePlan.TimeUnit.ValueString()))
+
+			web := mfa.NewDeviceAuthenticationPolicyCommonRememberMeWeb(
+				webPlan.Enabled.ValueBool(),
+				lifeTime,
+			)
+
+			rememberMe := mfa.NewDeviceAuthenticationPolicyCommonRememberMe(*web)
+			policy.SetRememberMe(*rememberMe)
+		}
+	}
+
 	if !p.Default.IsNull() && !p.Default.IsUnknown() {
 		policy.SetDefault(p.Default.ValueBool())
 	} else {
@@ -2195,6 +2378,9 @@ func (p *MFADevicePolicyResourceModel) toState(apiObject *mfa.DeviceAuthenticati
 	p.IgnoreUserLock = framework.BoolOkToTF(apiObject.GetIgnoreUserLockOk())
 
 	p.NotificationsPolicy, d = toStateMfaDevicePolicyNotificationsPolicy(apiObject.GetNotificationsPolicyOk())
+	diags.Append(d...)
+
+	p.RememberMe, d = toStateMfaDevicePolicyRememberMe(apiObject.GetRememberMeOk())
 	diags.Append(d...)
 
 	p.Default = framework.BoolOkToTF(apiObject.GetDefaultOk())

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -68,6 +68,7 @@ type MFADevicePolicyEmailResourceModel MFADevicePolicyOfflineDeviceResourceModel
 type MFADevicePolicyTotpResourceModel struct {
 	Enabled                    types.Bool   `tfsdk:"enabled"`
 	Otp                        types.Object `tfsdk:"otp"`
+	PasscodeGracePeriod        types.Int32  `tfsdk:"passcode_grace_period"`
 	PairingDisabled            types.Bool   `tfsdk:"pairing_disabled"`
 	PromptForNicknameOnPairing types.Bool   `tfsdk:"prompt_for_nickname_on_pairing"`
 	UriParameters              types.Map    `tfsdk:"uri_parameters"`
@@ -256,6 +257,7 @@ var (
 	MFADevicePolicyTotpTFObjectTypes = map[string]attr.Type{
 		"enabled":                        types.BoolType,
 		"otp":                            types.ObjectType{AttrTypes: MFADevicePolicyTotpOtpTFObjectTypes},
+		"passcode_grace_period":          types.Int32Type,
 		"pairing_disabled":               types.BoolType,
 		"prompt_for_nickname_on_pairing": types.BoolType,
 		"uri_parameters":                 types.MapType{ElemType: types.StringType},
@@ -321,6 +323,9 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	const fido2FailureCoolDownDurationMaxMinutes = 30
 	const fido2FailureCoolDownDurationMinSeconds = fido2FailureCoolDownDurationMinMinutes * 60
 	const fido2FailureCoolDownDurationMaxSeconds = fido2FailureCoolDownDurationMaxMinutes * 60
+
+	const totpPasscodeGracePeriodMin = 1
+	const totpPasscodeGracePeriodMax = 10
 
 	const rememberMeWebLifeTimeDurationDefault = 30
 	const rememberMeWebLifeTimeDurationMinMinutes = 1
@@ -470,6 +475,10 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 
 	totpUriParametersDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A map of string key:value pairs that specifies `otpauth` URI parameters. For example, if you provide a value for the `issuer` parameter, then authenticators that support that parameter will display the text you specify together with the OTP (in addition to the username). This can help users recognize which application the OTP is for. If you intend on using the same MFA policy for multiple applications, choose a name that reflects the group of applications.",
+	)
+
+	totpPasscodeGracePeriodDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"An integer that specifies the TOTP passcode grace period in 30-second windows. The minimum value is `1` and the maximum value is `10`.",
 	)
 
 	fido2PairingDisabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -1015,6 +1024,16 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 						Computed:            true,
 
 						Default: booldefault.StaticBool(false),
+					},
+
+					"passcode_grace_period": schema.Int32Attribute{
+						Description:         totpPasscodeGracePeriodDescription.Description,
+						MarkdownDescription: totpPasscodeGracePeriodDescription.MarkdownDescription,
+						Optional:            true,
+
+						Validators: []validator.Int32{
+							int32validator.Between(totpPasscodeGracePeriodMin, totpPasscodeGracePeriodMax),
+						},
 					},
 
 					"otp": schema.SingleNestedAttribute{
@@ -2336,6 +2355,10 @@ func (p *MFADevicePolicyTotpResourceModel) expand(ctx context.Context) (*mfa.Dev
 		data.SetPairingDisabled(p.PairingDisabled.ValueBool())
 	}
 
+	if !p.PasscodeGracePeriod.IsNull() && !p.PasscodeGracePeriod.IsUnknown() {
+		data.SetPasscodeGracePeriod(p.PasscodeGracePeriod.ValueInt32())
+	}
+
 	// Prompt for Nickname on Pairing
 	if !p.PromptForNicknameOnPairing.IsNull() && !p.PromptForNicknameOnPairing.IsUnknown() {
 		data.SetPromptForNicknameOnPairing(p.PromptForNicknameOnPairing.ValueBool())
@@ -3016,6 +3039,7 @@ func toStateMfaDevicePolicyTotp(apiObject *mfa.DeviceAuthenticationPolicyCommonT
 	o := map[string]attr.Value{
 		"enabled":                        framework.BoolOkToTF(apiObject.GetEnabledOk()),
 		"otp":                            otp,
+		"passcode_grace_period":          framework.Int32OkToTF(apiObject.GetPasscodeGracePeriodOk()),
 		"pairing_disabled":               framework.BoolOkToTF(apiObject.GetPairingDisabledOk()),
 		"prompt_for_nickname_on_pairing": framework.BoolOkToTF(apiObject.GetPromptForNicknameOnPairingOk()),
 		"uri_parameters":                 framework.StringMapOkToTF(apiObject.GetUriParametersOk()),

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -326,6 +326,7 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	const fido2FailureCoolDownDurationMinSeconds = fido2FailureCoolDownDurationMinMinutes * 60
 	const fido2FailureCoolDownDurationMaxSeconds = fido2FailureCoolDownDurationMaxMinutes * 60
 
+	const totpPasscodeGracePeriodDefault = 5
 	const totpPasscodeGracePeriodMin = 1
 	const totpPasscodeGracePeriodMax = 10
 
@@ -480,8 +481,8 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	)
 
 	totpPasscodeGracePeriodDescription := framework.SchemaAttributeDescriptionFromMarkdown(
-		"An integer that specifies the TOTP passcode grace period in 30-second windows. The minimum value is `1` and the maximum value is `10`.",
-	)
+		fmt.Sprintf("An integer that specifies the TOTP passcode grace period in 30-second windows. The minimum value is `%d` and the maximum value is `%d`.", totpPasscodeGracePeriodMin, totpPasscodeGracePeriodMax),
+	).DefaultValue(totpPasscodeGracePeriodDefault)
 
 	fido2PairingDisabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that, when set to `true`, prevents users from pairing new devices with the FIDO2 method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.",
@@ -1034,6 +1035,9 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 						Description:         totpPasscodeGracePeriodDescription.Description,
 						MarkdownDescription: totpPasscodeGracePeriodDescription.MarkdownDescription,
 						Optional:            true,
+						Computed:            true,
+
+						Default: int32default.StaticInt32(totpPasscodeGracePeriodDefault),
 
 						Validators: []validator.Int32{
 							int32validator.Between(totpPasscodeGracePeriodMin, totpPasscodeGracePeriodMax),
@@ -1243,10 +1247,13 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descriptionMethod string) schema.SingleNestedAttribute {
 
 	const otpFailureCountDefault = 3
+	const otpFailureCountMin = 1
+	const otpFailureCountMax = 7
+
 	const otpFailureCoolDownDurationDefault = 0
 	const otpLifetimeDurationDefault = 30
-	const otpOtpLengthDefault = 6
 
+	const otpOtpLengthDefault = 6
 	const otpOtpLengthMin = 6
 	const otpOtpLengthMax = 10
 
@@ -1265,6 +1272,10 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 	promptForNicknameOnPairingDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.",
 	)
+
+	otpFailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `%d` and maximum is `%d`.", otpFailureCountMin, otpFailureCountMax),
+	).DefaultValue(otpFailureCountDefault)
 
 	return schema.SingleNestedAttribute{
 		Description: framework.SchemaAttributeDescriptionFromMarkdown(fmt.Sprintf("A single object that allows configuration of %s device authentication policy settings.", descriptionMethod)).Description,
@@ -1346,8 +1357,13 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 							},
 
 							"count": schema.Int32Attribute{
-								Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked.").Description,
-								Required:    true,
+								Description:         otpFailureCountDescription.Description,
+								MarkdownDescription: otpFailureCountDescription.MarkdownDescription,
+								Required:            true,
+
+								Validators: []validator.Int32{
+									int32validator.Between(otpFailureCountMin, otpFailureCountMax),
+								},
 							},
 						},
 					},
@@ -1756,24 +1772,6 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 		return nil, diags
 	}
 
-	// WhatsApp
-	var whatsApp *mfa.DeviceAuthenticationPolicyOfflineDevice
-	if !p.WhatsApp.IsNull() && !p.WhatsApp.IsUnknown() {
-		var whatsAppPlan MFADevicePolicyWhatsAppResourceModel
-		diags.Append(p.WhatsApp.As(ctx, &whatsAppPlan, basetypes.ObjectAsOptions{
-			UnhandledNullAsEmpty:    false,
-			UnhandledUnknownAsEmpty: false,
-		})...)
-		if diags.HasError() {
-			return nil, diags
-		}
-		whatsApp, d = whatsAppPlan.expand(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-	}
-
 	// Mobile
 	var mobilePlan MFADevicePolicyMobileResourceModel
 	diags.Append(p.Mobile.As(ctx, &mobilePlan, basetypes.ObjectAsOptions{
@@ -1816,7 +1814,22 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 		false, // forSignOnPolicy
 	)
 
-	if whatsApp != nil {
+	// WhatsApp
+	if !p.WhatsApp.IsNull() && !p.WhatsApp.IsUnknown() {
+		var whatsAppPlan MFADevicePolicyWhatsAppResourceModel
+		diags.Append(p.WhatsApp.As(ctx, &whatsAppPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		whatsApp, d := whatsAppPlan.expand(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
 		policy.SetWhatsapp(*whatsApp)
 	}
 

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -45,6 +45,7 @@ type MFADevicePolicyResourceModel struct {
 	Authentication        types.Object                 `tfsdk:"authentication"`
 	NewDeviceNotification types.String                 `tfsdk:"new_device_notification"`
 	IgnoreUserLock        types.Bool                   `tfsdk:"ignore_user_lock"`
+	NotificationsPolicy   types.Object                 `tfsdk:"notifications_policy"`
 	Default               types.Bool                   `tfsdk:"default"`
 	Sms                   types.Object                 `tfsdk:"sms"`
 	Voice                 types.Object                 `tfsdk:"voice"`
@@ -68,6 +69,10 @@ type MFADevicePolicyTotpResourceModel struct {
 	PairingDisabled            types.Bool   `tfsdk:"pairing_disabled"`
 	PromptForNicknameOnPairing types.Bool   `tfsdk:"prompt_for_nickname_on_pairing"`
 	UriParameters              types.Map    `tfsdk:"uri_parameters"`
+}
+
+type MFADevicePolicyNotificationsPolicyResourceModel struct {
+	Id types.String `tfsdk:"id"`
 }
 
 type MFADevicePolicyOfflineDeviceResourceModel struct {
@@ -310,6 +315,14 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 		"A boolean that, when set to `true`, allows PingOne to skip the account lock check during MFA authentication.",
 	).DefaultValue(false)
 
+	notificationsPolicyDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that specifies the notification policy to use for this MFA device policy. If not specified, the default notification policy for the environment will be used.",
+	)
+
+	notificationsPolicyIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A string that specifies the ID of the notification policy to use.",
+	)
+
 	defaultDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that specifies whether this MFA device policy is enforced as the default within the environment. When set to `true`, all other MFA device policies are `false`.",
 	).DefaultValue(false)
@@ -460,6 +473,24 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 				Computed:            true,
 
 				Default: booldefault.StaticBool(false),
+			},
+
+			"notifications_policy": schema.SingleNestedAttribute{
+				Description:         notificationsPolicyDescription.Description,
+				MarkdownDescription: notificationsPolicyDescription.MarkdownDescription,
+				Optional:            true,
+
+				Attributes: map[string]schema.Attribute{
+					"id": schema.StringAttribute{
+						Description:         notificationsPolicyIdDescription.Description,
+						MarkdownDescription: notificationsPolicyIdDescription.MarkdownDescription,
+						Required:            true,
+
+						Validators: []validator.String{
+							verify.P1ResourceIDValidator(),
+						},
+					},
+				},
 			},
 
 			"default": schema.BoolAttribute{
@@ -1561,6 +1592,21 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 		policy.SetIgnoreUserLock(p.IgnoreUserLock.ValueBool())
 	}
 
+	if !p.NotificationsPolicy.IsNull() && !p.NotificationsPolicy.IsUnknown() {
+		var notificationsPolicyPlan MFADevicePolicyNotificationsPolicyResourceModel
+		diags.Append(p.NotificationsPolicy.As(ctx, &notificationsPolicyPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		policy.SetNotificationsPolicy(
+			*mfa.NewDeviceAuthenticationPolicyCommonNotificationsPolicy(notificationsPolicyPlan.Id.ValueString()),
+		)
+	}
+
 	if !p.Default.IsNull() && !p.Default.IsUnknown() {
 		policy.SetDefault(p.Default.ValueBool())
 	} else {
@@ -2147,6 +2193,9 @@ func (p *MFADevicePolicyResourceModel) toState(apiObject *mfa.DeviceAuthenticati
 	p.NewDeviceNotification = framework.EnumOkToTF(apiObject.GetNewDeviceNotificationOk())
 
 	p.IgnoreUserLock = framework.BoolOkToTF(apiObject.GetIgnoreUserLockOk())
+
+	p.NotificationsPolicy, d = toStateMfaDevicePolicyNotificationsPolicy(apiObject.GetNotificationsPolicyOk())
+	diags.Append(d...)
 
 	p.Default = framework.BoolOkToTF(apiObject.GetDefaultOk())
 

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -338,6 +338,15 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	const rememberMeWebLifeTimeDurationMinDays = 1
 	const rememberMeWebLifeTimeDurationMaxDays = 90
 
+	const whatsAppOtpFailureCountDefault = 3
+	const whatsAppOtpFailureCountMin = 1
+	const whatsAppOtpFailureCountMax = 7
+	const whatsAppOtpFailureCoolDownDurationDefault = 0
+	const whatsAppOtpLifetimeDurationDefault = 30
+	const whatsAppOtpLengthDefault = 6
+	const whatsAppOtpLengthMin = 6
+	const whatsAppOtpLengthMax = 10
+
 	// schema descriptions and validation settings
 	deviceSelectionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that defines the device selection method.",
@@ -495,6 +504,26 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 	fido2FailureCoolDownDurationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("An integer that defines the length of time that the user is blocked after reaching the maximum number of failures. The minimum value is `%d` minutes and the maximum value is `%d` minutes.", fido2FailureCoolDownDurationMinMinutes, fido2FailureCoolDownDurationMaxMinutes),
 	).DefaultValue(fido2FailureCoolDownDurationDefault)
+
+	whatsAppDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that allows configuration of WhatsApp OTP device authentication policy settings. To set `enabled = true`, WhatsApp sender settings must already be configured in PingOne.",
+	)
+
+	whatsAppPairingDisabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A boolean that, when set to `true`, prevents users from pairing new devices with the WhatsApp OTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.",
+	)
+
+	whatsAppOtpFailureCountDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. Minimum is `%d` and maximum is `%d`.", whatsAppOtpFailureCountMin, whatsAppOtpFailureCountMax),
+	)
+
+	whatsAppOtpLengthDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that specifies the length of the OTP that is shown to users.  Minimum length is `%d` digits and maximum is `%d` digits.", whatsAppOtpLengthMin, whatsAppOtpLengthMax),
+	)
+
+	whatsAppOtpTimeUnitDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A string that specifies the type of time unit for `duration`.",
+	).AllowedValuesEnum(mfa.AllowedEnumTimeUnitEnumValues)
 
 	promptForNicknameOnPairingDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.",
@@ -678,7 +707,146 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 
 			"email": r.devicePolicyOfflineDeviceSchemaAttribute("email OTP"),
 
-			"whats_app": r.devicePolicyOfflineDeviceSchemaAttributeOptional("WhatsApp OTP"),
+			"whats_app": schema.SingleNestedAttribute{
+				Description:         whatsAppDescription.Description,
+				MarkdownDescription: whatsAppDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: objectdefault.StaticValue(types.ObjectValueMust(
+					MFADevicePolicyOfflineDeviceTFObjectTypes,
+					map[string]attr.Value{
+						"enabled": types.BoolValue(false),
+						"otp": types.ObjectValueMust(
+							MFADevicePolicyOfflineDeviceOtpTFObjectTypes,
+							map[string]attr.Value{
+								"failure": types.ObjectValueMust(
+									MFADevicePolicyFailureTFObjectTypes,
+									map[string]attr.Value{
+										"count": types.Int32Value(whatsAppOtpFailureCountDefault),
+										"cool_down": types.ObjectValueMust(
+											MFADevicePolicyTimePeriodTFObjectTypes,
+											map[string]attr.Value{
+												"duration":  types.Int32Value(whatsAppOtpFailureCoolDownDurationDefault),
+												"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+											},
+										),
+									},
+								),
+								"lifetime": types.ObjectValueMust(
+									MFADevicePolicyTimePeriodTFObjectTypes,
+									map[string]attr.Value{
+										"duration":  types.Int32Value(whatsAppOtpLifetimeDurationDefault),
+										"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+									},
+								),
+								"otp_length": types.Int32Value(whatsAppOtpLengthDefault),
+							},
+						),
+						"pairing_disabled":               types.BoolNull(),
+						"prompt_for_nickname_on_pairing": types.BoolNull(),
+					},
+				)),
+
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("A boolean that specifies whether the WhatsApp OTP method is enabled or disabled in the policy.").Description,
+						Required:    true,
+					},
+
+					"pairing_disabled": schema.BoolAttribute{
+						Description:         whatsAppPairingDisabledDescription.Description,
+						MarkdownDescription: whatsAppPairingDisabledDescription.MarkdownDescription,
+						Optional:            true,
+					},
+
+					"otp": schema.SingleNestedAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that allows configuration of WhatsApp OTP settings.").Description,
+						Required:    true,
+
+						Attributes: map[string]schema.Attribute{
+							"failure": schema.SingleNestedAttribute{
+								Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that allows configuration of WhatsApp OTP failure settings.").Description,
+								Required:    true,
+
+								Attributes: map[string]schema.Attribute{
+									"cool_down": schema.SingleNestedAttribute{
+										Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that allows configuration of WhatsApp OTP failure cool down settings.").Description,
+										Required:    true,
+
+										Attributes: map[string]schema.Attribute{
+											"duration": schema.Int32Attribute{
+												Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.").Description,
+												Required:    true,
+											},
+
+											"time_unit": schema.StringAttribute{
+												Description:         whatsAppOtpTimeUnitDescription.Description,
+												MarkdownDescription: whatsAppOtpTimeUnitDescription.MarkdownDescription,
+												Required:            true,
+
+												Validators: []validator.String{
+													stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+												},
+											},
+										},
+									},
+
+									"count": schema.Int32Attribute{
+										Description:         whatsAppOtpFailureCountDescription.Description,
+										MarkdownDescription: whatsAppOtpFailureCountDescription.MarkdownDescription,
+										Required:            true,
+
+										Validators: []validator.Int32{
+											int32validator.Between(whatsAppOtpFailureCountMin, whatsAppOtpFailureCountMax),
+										},
+									},
+								},
+							},
+
+							"lifetime": schema.SingleNestedAttribute{
+								Description: framework.SchemaAttributeDescriptionFromMarkdown("A single object that allows configuration of WhatsApp OTP lifetime settings.").Description,
+								Required:    true,
+
+								Attributes: map[string]schema.Attribute{
+									"duration": schema.Int32Attribute{
+										Description: framework.SchemaAttributeDescriptionFromMarkdown("An integer that defines the duration (number of time units) that the passcode is valid before it expires.").Description,
+										Required:    true,
+									},
+
+									"time_unit": schema.StringAttribute{
+										Description:         whatsAppOtpTimeUnitDescription.Description,
+										MarkdownDescription: whatsAppOtpTimeUnitDescription.MarkdownDescription,
+										Required:            true,
+
+										Validators: []validator.String{
+											stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumTimeUnitEnumValues)...),
+										},
+									},
+								},
+							},
+
+							"otp_length": schema.Int32Attribute{
+								Description:         whatsAppOtpLengthDescription.Description,
+								MarkdownDescription: whatsAppOtpLengthDescription.MarkdownDescription,
+								Optional:            true,
+								Computed:            true,
+
+								Default: int32default.StaticInt32(whatsAppOtpLengthDefault),
+								Validators: []validator.Int32{
+									int32validator.Between(whatsAppOtpLengthMin, whatsAppOtpLengthMax),
+								},
+							},
+						},
+					},
+
+					"prompt_for_nickname_on_pairing": schema.BoolAttribute{
+						Description:         promptForNicknameOnPairingDescription.Description,
+						MarkdownDescription: promptForNicknameOnPairingDescription.MarkdownDescription,
+						Optional:            true,
+					},
+				},
+			},
 
 			"mobile": schema.SingleNestedAttribute{
 				Description:         mobileDescription.Description,
@@ -1416,55 +1584,6 @@ func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttribute(descr
 	}
 }
 
-func (r *MFADevicePolicyResource) devicePolicyOfflineDeviceSchemaAttributeOptional(descriptionMethod string) schema.SingleNestedAttribute {
-
-	const otpFailureCountDefault = 3
-	const otpFailureCoolDownDurationDefault = 0
-	const otpLifetimeDurationDefault = 30
-	const otpOtpLengthDefault = 6
-
-	a := r.devicePolicyOfflineDeviceSchemaAttribute(descriptionMethod)
-	a.Required = false
-	a.Optional = true
-	a.Computed = true
-	a.Default = objectdefault.StaticValue(types.ObjectValueMust(
-		MFADevicePolicyOfflineDeviceTFObjectTypes,
-		map[string]attr.Value{
-			"enabled":          types.BoolValue(false),
-			"pairing_disabled": types.BoolValue(false),
-			"otp": types.ObjectValueMust(
-				MFADevicePolicyOfflineDeviceOtpTFObjectTypes,
-				map[string]attr.Value{
-					"failure": types.ObjectValueMust(
-						MFADevicePolicyFailureTFObjectTypes,
-						map[string]attr.Value{
-							"count": types.Int32Value(otpFailureCountDefault),
-							"cool_down": types.ObjectValueMust(
-								MFADevicePolicyTimePeriodTFObjectTypes,
-								map[string]attr.Value{
-									"duration":  types.Int32Value(otpFailureCoolDownDurationDefault),
-									"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
-								},
-							),
-						},
-					),
-					"lifetime": types.ObjectValueMust(
-						MFADevicePolicyTimePeriodTFObjectTypes,
-						map[string]attr.Value{
-							"duration":  types.Int32Value(otpLifetimeDurationDefault),
-							"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
-						},
-					),
-					"otp_length": types.Int32Value(otpOtpLengthDefault),
-				},
-			),
-			"prompt_for_nickname_on_pairing": types.BoolNull(),
-		},
-	))
-
-	return a
-}
-
 func (r *MFADevicePolicyResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
@@ -1830,7 +1949,7 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 			return nil, diags
 		}
 
-		policy.SetWhatsapp(*whatsApp)
+		policy.SetWhatsApp(*whatsApp)
 	}
 
 	// FIDO2
@@ -2565,7 +2684,7 @@ func (p *MFADevicePolicyResourceModel) toState(apiObject *mfa.DeviceAuthenticati
 	p.Email, d = toStateMfaDevicePolicyEmail(apiObject.GetEmailOk())
 	diags.Append(d...)
 
-	p.WhatsApp, d = toStateMfaDevicePolicyWhatsApp(apiObject.GetWhatsappOk())
+	p.WhatsApp, d = toStateMfaDevicePolicyWhatsApp(apiObject.GetWhatsAppOk())
 	diags.Append(d...)
 
 	p.Mobile, d = toStateMfaDevicePolicyMobile(apiObject.GetMobileOk())

--- a/internal/service/mfa/resource_mfa_device_policy.go
+++ b/internal/service/mfa/resource_mfa_device_policy.go
@@ -44,6 +44,7 @@ type MFADevicePolicyResourceModel struct {
 	Name                  types.String                 `tfsdk:"name"`
 	Authentication        types.Object                 `tfsdk:"authentication"`
 	NewDeviceNotification types.String                 `tfsdk:"new_device_notification"`
+	IgnoreUserLock        types.Bool                   `tfsdk:"ignore_user_lock"`
 	Default               types.Bool                   `tfsdk:"default"`
 	Sms                   types.Object                 `tfsdk:"sms"`
 	Voice                 types.Object                 `tfsdk:"voice"`
@@ -305,6 +306,10 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 		"A string that defines whether a user should be notified if a new authentication method has been added to their account.",
 	).AllowedValuesEnum(mfa.AllowedEnumMFADevicePolicyNewDeviceNotificationEnumValues).DefaultValue(string(mfa.ENUMMFADEVICEPOLICYNEWDEVICENOTIFICATION_NONE))
 
+	ignoreUserLockDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A boolean that, when set to `true`, allows PingOne to skip the account lock check during MFA authentication.",
+	).DefaultValue(false)
+
 	defaultDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that specifies whether this MFA device policy is enforced as the default within the environment. When set to `true`, all other MFA device policies are `false`.",
 	).DefaultValue(false)
@@ -446,6 +451,15 @@ func (r *MFADevicePolicyResource) Schema(ctx context.Context, req resource.Schem
 				Validators: []validator.String{
 					stringvalidator.OneOf(utils.EnumSliceToStringSlice(mfa.AllowedEnumMFADevicePolicyNewDeviceNotificationEnumValues)...),
 				},
+			},
+
+			"ignore_user_lock": schema.BoolAttribute{
+				Description:         ignoreUserLockDescription.Description,
+				MarkdownDescription: ignoreUserLockDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+
+				Default: booldefault.StaticBool(false),
 			},
 
 			"default": schema.BoolAttribute{
@@ -1543,6 +1557,10 @@ func (p *MFADevicePolicyResourceModel) expand(ctx context.Context, apiClient *ma
 		)
 	}
 
+	if !p.IgnoreUserLock.IsNull() && !p.IgnoreUserLock.IsUnknown() {
+		policy.SetIgnoreUserLock(p.IgnoreUserLock.ValueBool())
+	}
+
 	if !p.Default.IsNull() && !p.Default.IsUnknown() {
 		policy.SetDefault(p.Default.ValueBool())
 	} else {
@@ -2127,6 +2145,8 @@ func (p *MFADevicePolicyResourceModel) toState(apiObject *mfa.DeviceAuthenticati
 	diags.Append(d...)
 
 	p.NewDeviceNotification = framework.EnumOkToTF(apiObject.GetNewDeviceNotificationOk())
+
+	p.IgnoreUserLock = framework.BoolOkToTF(apiObject.GetIgnoreUserLockOk())
 
 	p.Default = framework.BoolOkToTF(apiObject.GetDefaultOk())
 

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -133,6 +133,7 @@ func TestAccMFADevicePolicy_SMS_Full(t *testing.T) {
 				Config: testAccMFADevicePolicyConfig_FullSMS(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
+					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "75"),
@@ -192,6 +193,7 @@ func TestAccMFADevicePolicy_SMS_Minimal(t *testing.T) {
 				Config: testAccMFADevicePolicyConfig_MinimalSMS(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
+					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "30"),
@@ -235,6 +237,7 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 				Config: testAccMFADevicePolicyConfig_FullSMS(resourceName, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
+					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "75"),
@@ -1707,6 +1710,7 @@ resource "pingone_mfa_device_policy" "%[2]s" {
   name           = "%[3]s"
 
   new_device_notification = "SMS_THEN_EMAIL"
+  ignore_user_lock        = true
 
   authentication = {
     device_selection = "DEFAULT_TO_FIRST"

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -726,6 +726,7 @@ func TestAccMFADevicePolicy_Mobile_Full(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.pairing_disabled", "true"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push.enabled", "true"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push.number_matching.enabled", "true"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push_timeout.duration", "100"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push_timeout.time_unit", "SECONDS"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.pairing_key_lifetime.duration", "3"),
@@ -743,6 +744,7 @@ func TestAccMFADevicePolicy_Mobile_Full(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.pairing_disabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push.enabled", "false"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push.number_matching.enabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push_timeout.duration"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push_timeout.time_unit"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.pairing_key_lifetime.duration"),
@@ -758,6 +760,7 @@ func TestAccMFADevicePolicy_Mobile_Full(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.pairing_disabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push.enabled", "true"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push.number_matching.enabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push_timeout.duration"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push_timeout.time_unit"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.pairing_key_lifetime.duration", "55"),
@@ -943,6 +946,7 @@ func TestAccMFADevicePolicy_Mobile_Change(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.pairing_disabled", "true"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push.enabled", "true"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push.number_matching.enabled", "true"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push_timeout.duration", "100"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push_timeout.time_unit", "SECONDS"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.pairing_key_lifetime.duration", "3"),
@@ -960,6 +964,7 @@ func TestAccMFADevicePolicy_Mobile_Change(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.pairing_disabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push.enabled", "false"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push.number_matching.enabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push_timeout.duration"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push_timeout.time_unit"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.pairing_key_lifetime.duration"),
@@ -975,6 +980,7 @@ func TestAccMFADevicePolicy_Mobile_Change(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.pairing_disabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push.enabled", "true"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push.number_matching.enabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push_timeout.duration"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push_timeout.time_unit"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.pairing_key_lifetime.duration", "55"),
@@ -1027,6 +1033,7 @@ func TestAccMFADevicePolicy_Mobile_Change(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.pairing_disabled", "true"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push.enabled", "true"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push.number_matching.enabled", "true"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push_timeout.duration", "100"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.push_timeout.time_unit", "SECONDS"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application1FullName, "mobile.applications.%s.pairing_key_lifetime.duration", "3"),
@@ -1044,6 +1051,7 @@ func TestAccMFADevicePolicy_Mobile_Change(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.pairing_disabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push.enabled", "false"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push.number_matching.enabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push_timeout.duration"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.push_timeout.time_unit"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application2FullName, "mobile.applications.%s.pairing_key_lifetime.duration"),
@@ -1059,6 +1067,7 @@ func TestAccMFADevicePolicy_Mobile_Change(t *testing.T) {
 
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.pairing_disabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push.enabled", "true"),
+					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push.number_matching.enabled", "false"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push_timeout.duration"),
 					mfa.TestCheckMFADevicePolicyApplicationMapNoResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.push_timeout.time_unit"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, application3FullName, "mobile.applications.%s.pairing_key_lifetime.duration", "55"),
@@ -2235,6 +2244,9 @@ resource "pingone_mfa_device_policy" "%[2]s" {
 
         push = {
           enabled = true
+          number_matching = {
+            enabled = true
+          }
         }
 
         push_timeout = {

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -134,6 +134,7 @@ func TestAccMFADevicePolicy_SMS_Full(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "true"),
+					resource.TestMatchResourceAttr(resourceFullName, "notifications_policy.id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "75"),
@@ -194,6 +195,7 @@ func TestAccMFADevicePolicy_SMS_Minimal(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "false"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "notifications_policy.id"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "30"),
@@ -238,6 +240,7 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "true"),
+					resource.TestMatchResourceAttr(resourceFullName, "notifications_policy.id", verify.P1ResourceIDRegexpFullString),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "75"),
@@ -1705,12 +1708,25 @@ func testAccMFADevicePolicyConfig_FullSMS(resourceName, name string) string {
 	return fmt.Sprintf(`
 		%[1]s
 
+resource "pingone_notification_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "pingone_mfa_device_policy" "%[2]s" {
   environment_id = data.pingone_environment.general_test.id
   name           = "%[3]s"
 
   new_device_notification = "SMS_THEN_EMAIL"
   ignore_user_lock        = true
+
+  notifications_policy = {
+    id = pingone_notification_policy.%[2]s.id
+  }
 
   authentication = {
     device_selection = "DEFAULT_TO_FIRST"

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -135,6 +135,9 @@ func TestAccMFADevicePolicy_SMS_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "notifications_policy.id", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.life_time.duration", "60"),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.life_time.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "75"),
@@ -196,6 +199,9 @@ func TestAccMFADevicePolicy_SMS_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "false"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "notifications_policy.id"),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.life_time.duration", "30"),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.life_time.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "30"),
@@ -241,6 +247,9 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "authentication.device_selection", "DEFAULT_TO_FIRST"),
 					resource.TestCheckResourceAttr(resourceFullName, "ignore_user_lock", "true"),
 					resource.TestMatchResourceAttr(resourceFullName, "notifications_policy.id", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.life_time.duration", "60"),
+					resource.TestCheckResourceAttr(resourceFullName, "remember_me.web.life_time.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.pairing_disabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "sms.otp.lifetime.duration", "75"),
@@ -1726,6 +1735,16 @@ resource "pingone_mfa_device_policy" "%[2]s" {
 
   notifications_policy = {
     id = pingone_notification_policy.%[2]s.id
+  }
+
+  remember_me = {
+    web = {
+      enabled = true
+      life_time = {
+        duration  = 60
+        time_unit = "MINUTES"
+      }
+    }
   }
 
   authentication = {

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -1121,6 +1121,7 @@ func TestAccMFADevicePolicy_Totp_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.count", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.duration", "125"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.time_unit", "SECONDS"),
@@ -1180,6 +1181,7 @@ func TestAccMFADevicePolicy_Totp_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "totp.passcode_grace_period"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.count", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.duration", "2"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.time_unit", "MINUTES"),
@@ -1220,6 +1222,7 @@ func TestAccMFADevicePolicy_Totp_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.count", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.duration", "125"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.time_unit", "SECONDS"),
@@ -1241,6 +1244,7 @@ func TestAccMFADevicePolicy_Totp_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "totp.passcode_grace_period"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.count", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.duration", "2"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.time_unit", "MINUTES"),
@@ -1259,6 +1263,7 @@ func TestAccMFADevicePolicy_Totp_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.count", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.duration", "125"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.time_unit", "SECONDS"),
@@ -2952,8 +2957,9 @@ resource "pingone_mfa_device_policy" "%[2]s" {
   }
 
   totp = {
-    enabled          = true
-    pairing_disabled = true
+    enabled               = true
+    pairing_disabled      = true
+    passcode_grace_period = 5
 
     prompt_for_nickname_on_pairing = true
 

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -149,15 +149,7 @@ func TestAccMFADevicePolicy_SMS_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "70"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "SECONDS"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "6"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "10"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "SECONDS"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "8"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -223,7 +215,7 @@ func TestAccMFADevicePolicy_SMS_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "whats_app.pairing_disabled"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "30"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "3"),
@@ -279,15 +271,7 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "70"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "SECONDS"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "6"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "10"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "SECONDS"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "8"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -310,7 +294,7 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "false"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "whats_app.pairing_disabled"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "30"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "MINUTES"),
 					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "3"),
@@ -339,15 +323,7 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "true"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "70"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "SECONDS"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "6"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "10"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "SECONDS"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "8"),
-					resource.TestCheckResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -1226,7 +1202,7 @@ func TestAccMFADevicePolicy_Totp_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "false"),
-					resource.TestCheckNoResourceAttr(resourceFullName, "totp.passcode_grace_period"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.count", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.duration", "2"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.time_unit", "MINUTES"),
@@ -1289,7 +1265,7 @@ func TestAccMFADevicePolicy_Totp_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "false"),
-					resource.TestCheckNoResourceAttr(resourceFullName, "totp.passcode_grace_period"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.count", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.duration", "2"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.otp.failure.cool_down.time_unit", "MINUTES"),
@@ -1844,27 +1820,28 @@ resource "pingone_mfa_device_policy" "%[2]s" {
   }
 
   whats_app = {
-    enabled          = true
+    enabled = false
+
     pairing_disabled = true
 
     prompt_for_nickname_on_pairing = true
 
     otp = {
       lifetime = {
-        duration  = 70
-        time_unit = "SECONDS"
+        duration  = 30
+        time_unit = "MINUTES"
       }
 
       failure = {
-        count = 6
+        count = 3
 
         cool_down = {
-          duration  = 10
-          time_unit = "SECONDS"
+          duration  = 0
+          time_unit = "MINUTES"
         }
       }
 
-      otp_length = 8
+      otp_length = 7
     }
   }
 

--- a/internal/service/mfa/resource_mfa_device_policy_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_test.go
@@ -149,6 +149,15 @@ func TestAccMFADevicePolicy_SMS_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "70"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "SECONDS"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "6"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "10"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "SECONDS"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "8"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -213,6 +222,15 @@ func TestAccMFADevicePolicy_SMS_Minimal(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "30"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "MINUTES"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "3"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "MINUTES"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "6"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -261,6 +279,15 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "70"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "SECONDS"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "6"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "10"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "SECONDS"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "8"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -282,6 +309,15 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "30"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "MINUTES"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "3"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "MINUTES"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "6"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -303,6 +339,15 @@ func TestAccMFADevicePolicy_SMS_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "sms.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "70"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "SECONDS"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "6"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "10"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "SECONDS"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "8"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.prompt_for_nickname_on_pairing", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
@@ -1796,6 +1841,31 @@ resource "pingone_mfa_device_policy" "%[2]s" {
 
   email = {
     enabled = false
+  }
+
+  whats_app = {
+    enabled          = true
+    pairing_disabled = true
+
+    prompt_for_nickname_on_pairing = true
+
+    otp = {
+      lifetime = {
+        duration  = 70
+        time_unit = "SECONDS"
+      }
+
+      failure = {
+        count = 6
+
+        cool_down = {
+          duration  = 10
+          time_unit = "SECONDS"
+        }
+      }
+
+      otp_length = 8
+    }
   }
 
   mobile = {


### PR DESCRIPTION
## Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
**CDI-890**: Add these attributes to `pingone_mfa_device_policy`, already supported in SDK:
- `ignoreUserLock`
- `notificationsPolicy.id`
- `rememberMe`
- `mobile.applications.push.numberMatching`
- `totp.passcodeGracePeriod`
- `whatsApp`

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->
- `github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1`

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 go test ./internal/service/mfa -count=1 -run=TestAccMFADevicePolicy_ -v
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->
- 2 failures due to missing `PINGONE_GOOGLE_FIREBASE_CREDENTIALS`
<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccMFADevicePolicy_RemovalDrift
=== PAUSE TestAccMFADevicePolicy_RemovalDrift
=== RUN   TestAccMFADevicePolicy_NewEnv
=== PAUSE TestAccMFADevicePolicy_NewEnv
=== RUN   TestAccMFADevicePolicy_SMS_Full
=== PAUSE TestAccMFADevicePolicy_SMS_Full
=== RUN   TestAccMFADevicePolicy_SMS_Minimal
=== PAUSE TestAccMFADevicePolicy_SMS_Minimal
=== RUN   TestAccMFADevicePolicy_SMS_Change
=== PAUSE TestAccMFADevicePolicy_SMS_Change
=== RUN   TestAccMFADevicePolicy_Voice_Full
=== PAUSE TestAccMFADevicePolicy_Voice_Full
=== RUN   TestAccMFADevicePolicy_Voice_Minimal
=== PAUSE TestAccMFADevicePolicy_Voice_Minimal
=== RUN   TestAccMFADevicePolicy_Voice_Change
=== PAUSE TestAccMFADevicePolicy_Voice_Change
=== RUN   TestAccMFADevicePolicy_Email_Full
=== PAUSE TestAccMFADevicePolicy_Email_Full
=== RUN   TestAccMFADevicePolicy_Email_Minimal
=== PAUSE TestAccMFADevicePolicy_Email_Minimal
=== RUN   TestAccMFADevicePolicy_Email_Change
=== PAUSE TestAccMFADevicePolicy_Email_Change
=== RUN   TestAccMFADevicePolicy_Mobile_Full
=== PAUSE TestAccMFADevicePolicy_Mobile_Full
=== RUN   TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== RUN   TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== RUN   TestAccMFADevicePolicy_Mobile_Minimal
=== PAUSE TestAccMFADevicePolicy_Mobile_Minimal
=== RUN   TestAccMFADevicePolicy_Mobile_Change
=== PAUSE TestAccMFADevicePolicy_Mobile_Change
=== RUN   TestAccMFADevicePolicy_Totp_Full
=== PAUSE TestAccMFADevicePolicy_Totp_Full
=== RUN   TestAccMFADevicePolicy_Totp_Minimal
=== PAUSE TestAccMFADevicePolicy_Totp_Minimal
=== RUN   TestAccMFADevicePolicy_Totp_Change
=== PAUSE TestAccMFADevicePolicy_Totp_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Full
=== PAUSE TestAccMFADevicePolicy_FIDO2_Full
=== RUN   TestAccMFADevicePolicy_FIDO2_Minimal
=== PAUSE TestAccMFADevicePolicy_FIDO2_Minimal
=== RUN   TestAccMFADevicePolicy_FIDO2_Change
=== PAUSE TestAccMFADevicePolicy_FIDO2_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Disabled
=== PAUSE TestAccMFADevicePolicy_FIDO2_Disabled
=== RUN   TestAccMFADevicePolicy_DataModel
=== PAUSE TestAccMFADevicePolicy_DataModel
=== RUN   TestAccMFADevicePolicy_BadParameters
=== PAUSE TestAccMFADevicePolicy_BadParameters
=== RUN   TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== PAUSE TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicy_RemovalDrift
=== CONT  TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== CONT  TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicy_FIDO2_Full
=== CONT  TestAccMFADevicePolicy_Totp_Full
=== CONT  TestAccMFADevicePolicy_FIDO2_Disabled
=== CONT  TestAccMFADevicePolicy_Mobile_Minimal
=== CONT  TestAccMFADevicePolicy_Totp_Change
=== CONT  TestAccMFADevicePolicy_Totp_Minimal
=== CONT  TestAccMFADevicePolicy_BadParameters
=== CONT  TestAccMFADevicePolicy_FIDO2_Change
=== CONT  TestAccMFADevicePolicy_DataModel
=== CONT  TestAccMFADevicePolicy_Voice_Change
=== CONT  TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== CONT  TestAccMFADevicePolicy_Mobile_Full
=== CONT  TestAccMFADevicePolicy_Email_Change
=== NAME  TestAccMFADevicePolicy_Mobile_Full
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
=== CONT  TestAccMFADevicePolicy_Email_Minimal
--- FAIL: TestAccMFADevicePolicy_Mobile_Full (0.00s)
--- PASS: TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors (10.52s)
=== CONT  TestAccMFADevicePolicy_Email_Full
--- PASS: TestAccMFADevicePolicy_Mobile_Minimal (10.82s)
=== CONT  TestAccMFADevicePolicy_SMS_Change
--- PASS: TestAccMFADevicePolicy_FIDO2_Full (13.84s)
=== CONT  TestAccMFADevicePolicy_Voice_Minimal
--- PASS: TestAccMFADevicePolicy_Email_Minimal (15.11s)
=== CONT  TestAccMFADevicePolicy_Voice_Full
--- PASS: TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors (17.12s)
=== CONT  TestAccMFADevicePolicy_SMS_Full
--- PASS: TestAccMFADevicePolicy_Totp_Minimal (17.56s)
=== CONT  TestAccMFADevicePolicy_FIDO2_Minimal
--- PASS: TestAccMFADevicePolicy_DeleteDependentSOPFinalAction (19.21s)
=== CONT  TestAccMFADevicePolicy_SMS_Minimal
--- PASS: TestAccMFADevicePolicy_FIDO2_Change (21.11s)
=== CONT  TestAccMFADevicePolicy_NewEnv
--- PASS: TestAccMFADevicePolicy_Voice_Minimal (9.52s)
=== CONT  TestAccMFADevicePolicy_Mobile_Change
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
--- FAIL: TestAccMFADevicePolicy_Mobile_Change (0.00s)
--- PASS: TestAccMFADevicePolicy_Voice_Full (8.39s)
--- PASS: TestAccMFADevicePolicy_SMS_Minimal (9.31s)
--- PASS: TestAccMFADevicePolicy_Email_Change (29.08s)
--- PASS: TestAccMFADevicePolicy_BadParameters (32.50s)
--- PASS: TestAccMFADevicePolicy_Email_Full (23.20s)
--- PASS: TestAccMFADevicePolicy_Voice_Change (34.51s)
--- PASS: TestAccMFADevicePolicy_FIDO2_Minimal (21.05s)
--- PASS: TestAccMFADevicePolicy_SMS_Full (23.53s)
--- PASS: TestAccMFADevicePolicy_Totp_Full (43.42s)
--- PASS: TestAccMFADevicePolicy_Totp_Change (49.22s)
--- PASS: TestAccMFADevicePolicy_FIDO2_Disabled (50.97s)
--- PASS: TestAccMFADevicePolicy_SMS_Change (46.71s)
--- PASS: TestAccMFADevicePolicy_DataModel (62.85s)
--- PASS: TestAccMFADevicePolicy_NewEnv (42.19s)
--- PASS: TestAccMFADevicePolicy_RemovalDrift (82.09s)
FAIL
FAIL    github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 82.806s
FAIL
```

</details>

### End-to-end Tests Workflow Links
<!-- Use the following section to list the URLs to the end-to-end test action workflow runs -->
- N/A