### PR TITLE
Separate totp model for default and non-default resources

### DIFF
--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -94,6 +94,14 @@ type MFADevicePolicyDefaultMobileResourceModel struct {
 	PromptForNicknameOnPairing types.Bool   `tfsdk:"prompt_for_nickname_on_pairing"`
 }
 
+type MFADevicePolicyDefaultTotpResourceModel struct {
+	Enabled                    types.Bool   `tfsdk:"enabled"`
+	Otp                        types.Object `tfsdk:"otp"`
+	PairingDisabled            types.Bool   `tfsdk:"pairing_disabled"`
+	PromptForNicknameOnPairing types.Bool   `tfsdk:"prompt_for_nickname_on_pairing"`
+	UriParameters              types.Map    `tfsdk:"uri_parameters"`
+}
+
 type MFADevicePolicyDefaultMobileApplicationResourceModel struct {
 	AutoEnrolment                   types.Object `tfsdk:"auto_enrollment"`
 	BiometricsEnabled               types.Bool   `tfsdk:"biometrics_enabled"`
@@ -216,6 +224,14 @@ var (
 		"enabled":                        types.BoolType,
 		"otp":                            types.ObjectType{AttrTypes: MFADevicePolicyMobileOtpTFObjectTypes},
 		"prompt_for_nickname_on_pairing": types.BoolType,
+	}
+
+	MFADevicePolicyDefaultTotpTFObjectTypes = map[string]attr.Type{
+		"enabled":                        types.BoolType,
+		"otp":                            types.ObjectType{AttrTypes: MFADevicePolicyTotpOtpTFObjectTypes},
+		"pairing_disabled":               types.BoolType,
+		"prompt_for_nickname_on_pairing": types.BoolType,
+		"uri_parameters":                 types.MapType{ElemType: types.StringType},
 	}
 )
 
@@ -3436,7 +3452,7 @@ func (p *MFADevicePolicyDefaultResourceModel) expand(ctx context.Context) (mfa.D
 	}
 
 	// TOTP
-	var totpPlan MFADevicePolicyTotpResourceModel
+	var totpPlan MFADevicePolicyDefaultTotpResourceModel
 	diags.Append(p.Totp.As(ctx, &totpPlan, basetypes.ObjectAsOptions{
 		UnhandledNullAsEmpty:    false,
 		UnhandledUnknownAsEmpty: false,
@@ -3640,6 +3656,20 @@ func (p *MFADevicePolicyDefaultResourceModel) expand(ctx context.Context) (mfa.D
 	}
 
 	return *data, diags
+}
+
+func (p *MFADevicePolicyDefaultTotpResourceModel) expand(ctx context.Context) (*mfa.DeviceAuthenticationPolicyCommonTotp, diag.Diagnostics) {
+	// Keep default resource schema decoupled while reusing shared expansion behavior.
+	sharedTotpPlan := MFADevicePolicyTotpResourceModel{
+		Enabled:                    p.Enabled,
+		Otp:                        p.Otp,
+		PasscodeGracePeriod:        types.Int32Null(),
+		PairingDisabled:            p.PairingDisabled,
+		PromptForNicknameOnPairing: p.PromptForNicknameOnPairing,
+		UriParameters:              p.UriParameters,
+	}
+
+	return sharedTotpPlan.expand(ctx)
 }
 
 func (p *MFADevicePolicyDesktopResourceModel) expand(ctx context.Context) (*mfa.DeviceAuthenticationPolicyPingIDDevice, diag.Diagnostics) {
@@ -4120,7 +4150,7 @@ func (p *MFADevicePolicyDefaultResourceModel) toState(apiObject *mfa.DeviceAuthe
 	p.Mobile, d = toStateMfaDevicePolicyMobileForDefault(mobileApiObj, mobileOk, policyType)
 	diags.Append(d...)
 
-	p.Totp, d = toStateMfaDevicePolicyTotp(apiObject.GetTotpOk())
+	p.Totp, d = toStateMfaDevicePolicyTotpForDefault(apiObject.GetTotpOk())
 	diags.Append(d...)
 
 	p.OathToken, d = toStateMfaDevicePolicyOathToken(apiObject.GetOathTokenOk())
@@ -4144,6 +4174,33 @@ func (p *MFADevicePolicyDefaultResourceModel) toState(apiObject *mfa.DeviceAuthe
 	}
 
 	return diags
+}
+
+func toStateMfaDevicePolicyTotpForDefault(apiObject *mfa.DeviceAuthenticationPolicyCommonTotp, ok bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(MFADevicePolicyDefaultTotpTFObjectTypes), nil
+	}
+
+	otp, d := toStateMfaDevicePolicyTotpOtp(apiObject.GetOtpOk())
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ObjectNull(MFADevicePolicyDefaultTotpTFObjectTypes), diags
+	}
+
+	o := map[string]attr.Value{
+		"enabled":                        framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"otp":                            otp,
+		"pairing_disabled":               framework.BoolOkToTF(apiObject.GetPairingDisabledOk()),
+		"prompt_for_nickname_on_pairing": framework.BoolOkToTF(apiObject.GetPromptForNicknameOnPairingOk()),
+		"uri_parameters":                 framework.StringMapOkToTF(apiObject.GetUriParametersOk()),
+	}
+
+	objValue, d := types.ObjectValue(MFADevicePolicyDefaultTotpTFObjectTypes, o)
+	diags.Append(d...)
+
+	return objValue, diags
 }
 
 func toStateMfaDevicePolicyPingIDDevice(apiObject *mfa.DeviceAuthenticationPolicyPingIDDevice, ok bool) (types.Object, diag.Diagnostics) {


### PR DESCRIPTION
## Change Description
Fixes a failing test caused by addition of `passcode_grace_period` to `totp` attribute in `pingone_mfa_device_policy` resource. The `totp` model struct was being shared between this policy and the `pingone_mfa_device_policy_default` resource, but because the `passcode_grace_period` attribute is not yet supported in the default resource this caused type conversion errors in the default tests:
```
Error: Value Conversion Error
        
  with pingone_mfa_device_policy_default.ibrgtcjlws,
An unexpected error was encountered trying to convert tftypes.Value into
mfa.MFADevicePolicyTotpResourceModel. This is always an error in the
provider. Please report the following to the provider developer:

mismatch between struct and object: Struct defines fields not found in
object: passcode_grace_period.
```

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 go test ./internal/service/mfa -count=1 -run=TestAccMFADevicePolicy -v
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->
- Some failures due to missing `PINGONE_GOOGLE_FIREBASE_CREDENTIALS`
<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccMFADevicePolicyDefault_RemovalDrift
=== PAUSE TestAccMFADevicePolicyDefault_RemovalDrift
=== RUN   TestAccMFADevicePolicyDefault_Full
=== PAUSE TestAccMFADevicePolicyDefault_Full
=== RUN   TestAccMFADevicePolicyDefault_Minimal
=== PAUSE TestAccMFADevicePolicyDefault_Minimal
=== RUN   TestAccMFADevicePolicyDefault_Change
=== PAUSE TestAccMFADevicePolicyDefault_Change
=== RUN   TestAccMFADevicePolicyDefault_BadParameters
=== PAUSE TestAccMFADevicePolicyDefault_BadParameters
=== RUN   TestAccMFADevicePolicyDefault_PingID_Full
--- PASS: TestAccMFADevicePolicyDefault_PingID_Full (11.12s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_Minimal
--- PASS: TestAccMFADevicePolicyDefault_PingID_Minimal (9.91s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_Change
--- PASS: TestAccMFADevicePolicyDefault_PingID_Change (14.71s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_SetOrdering
--- PASS: TestAccMFADevicePolicyDefault_PingID_SetOrdering (13.77s)
=== RUN   TestAccMFADevicePolicyDefault_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation
=== RUN   TestAccMFADevicePolicyDefault_BOMValidation
=== PAUSE TestAccMFADevicePolicyDefault_BOMValidation
=== RUN   TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== PAUSE TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== RUN   TestAccMFADevicePolicyDefault_DriftCorrection
=== PAUSE TestAccMFADevicePolicyDefault_DriftCorrection
=== RUN   TestAccMFADevicePolicy_RemovalDrift
=== PAUSE TestAccMFADevicePolicy_RemovalDrift
=== RUN   TestAccMFADevicePolicy_NewEnv
=== PAUSE TestAccMFADevicePolicy_NewEnv
=== RUN   TestAccMFADevicePolicy_SMS_Full
=== PAUSE TestAccMFADevicePolicy_SMS_Full
=== RUN   TestAccMFADevicePolicy_SMS_Minimal
=== PAUSE TestAccMFADevicePolicy_SMS_Minimal
=== RUN   TestAccMFADevicePolicy_SMS_Change
=== PAUSE TestAccMFADevicePolicy_SMS_Change
=== RUN   TestAccMFADevicePolicy_Voice_Full
=== PAUSE TestAccMFADevicePolicy_Voice_Full
=== RUN   TestAccMFADevicePolicy_Voice_Minimal
=== PAUSE TestAccMFADevicePolicy_Voice_Minimal
=== RUN   TestAccMFADevicePolicy_Voice_Change
=== PAUSE TestAccMFADevicePolicy_Voice_Change
=== RUN   TestAccMFADevicePolicy_Email_Full
=== PAUSE TestAccMFADevicePolicy_Email_Full
=== RUN   TestAccMFADevicePolicy_Email_Minimal
=== PAUSE TestAccMFADevicePolicy_Email_Minimal
=== RUN   TestAccMFADevicePolicy_Email_Change
=== PAUSE TestAccMFADevicePolicy_Email_Change
=== RUN   TestAccMFADevicePolicy_Mobile_Full
=== PAUSE TestAccMFADevicePolicy_Mobile_Full
=== RUN   TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== RUN   TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== RUN   TestAccMFADevicePolicy_Mobile_Minimal
=== PAUSE TestAccMFADevicePolicy_Mobile_Minimal
=== RUN   TestAccMFADevicePolicy_Mobile_Change
=== PAUSE TestAccMFADevicePolicy_Mobile_Change
=== RUN   TestAccMFADevicePolicy_Totp_Full
=== PAUSE TestAccMFADevicePolicy_Totp_Full
=== RUN   TestAccMFADevicePolicy_Totp_Minimal
=== PAUSE TestAccMFADevicePolicy_Totp_Minimal
=== RUN   TestAccMFADevicePolicy_Totp_Change
=== PAUSE TestAccMFADevicePolicy_Totp_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Full
=== PAUSE TestAccMFADevicePolicy_FIDO2_Full
=== RUN   TestAccMFADevicePolicy_FIDO2_Minimal
=== PAUSE TestAccMFADevicePolicy_FIDO2_Minimal
=== RUN   TestAccMFADevicePolicy_FIDO2_Change
=== PAUSE TestAccMFADevicePolicy_FIDO2_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Disabled
=== PAUSE TestAccMFADevicePolicy_FIDO2_Disabled
=== RUN   TestAccMFADevicePolicy_DataModel
=== PAUSE TestAccMFADevicePolicy_DataModel
=== RUN   TestAccMFADevicePolicy_BadParameters
=== PAUSE TestAccMFADevicePolicy_BadParameters
=== RUN   TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== PAUSE TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicyDefault_RemovalDrift
=== CONT  TestAccMFADevicePolicy_Email_Minimal
=== CONT  TestAccMFADevicePolicy_RemovalDrift
=== CONT  TestAccMFADevicePolicy_Email_Full
=== CONT  TestAccMFADevicePolicy_Totp_Change
=== CONT  TestAccMFADevicePolicyDefault_DriftCorrection
=== CONT  TestAccMFADevicePolicy_SMS_Change
=== CONT  TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== CONT  TestAccMFADevicePolicy_FIDO2_Disabled
=== CONT  TestAccMFADevicePolicy_SMS_Full
=== CONT  TestAccMFADevicePolicy_Mobile_Minimal
=== CONT  TestAccMFADevicePolicy_Totp_Full
=== CONT  TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== CONT  TestAccMFADevicePolicy_Mobile_Full
=== CONT  TestAccMFADevicePolicyDefault_BadParameters
=== NAME  TestAccMFADevicePolicy_Mobile_Full
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
--- FAIL: TestAccMFADevicePolicy_Mobile_Full (0.01s)
=== CONT  TestAccMFADevicePolicyDefault_Validation
=== CONT  TestAccMFADevicePolicyDefault_BOMValidation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/General_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/General_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== CONT  TestAccMFADevicePolicyDefault_Change
--- PASS: TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors (9.00s)
=== CONT  TestAccMFADevicePolicyDefault_Minimal
--- PASS: TestAccMFADevicePolicyDefault_BOMValidation (11.37s)
=== CONT  TestAccMFADevicePolicyDefault_Full
--- PASS: TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes (12.78s)
=== CONT  TestAccMFADevicePolicy_SMS_Minimal
--- PASS: TestAccMFADevicePolicy_Email_Full (13.40s)
=== CONT  TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
--- PASS: TestAccMFADevicePolicy_Email_Minimal (13.85s)
=== CONT  TestAccMFADevicePolicy_NewEnv
--- PASS: TestAccMFADevicePolicy_Totp_Full (14.28s)
=== CONT  TestAccMFADevicePolicy_Email_Change
--- PASS: TestAccMFADevicePolicy_SMS_Full (14.96s)
=== CONT  TestAccMFADevicePolicy_Mobile_Change
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
--- FAIL: TestAccMFADevicePolicy_Mobile_Change (0.00s)
=== CONT  TestAccMFADevicePolicy_BadParameters
--- PASS: TestAccMFADevicePolicy_Mobile_Minimal (19.48s)
=== CONT  TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
--- PASS: TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors (10.53s)
=== CONT  TestAccMFADevicePolicy_DataModel
--- PASS: TestAccMFADevicePolicy_FIDO2_Disabled (25.84s)
=== CONT  TestAccMFADevicePolicy_FIDO2_Minimal
--- PASS: TestAccMFADevicePolicy_Totp_Change (26.06s)
=== CONT  TestAccMFADevicePolicy_FIDO2_Change
--- PASS: TestAccMFADevicePolicy_SMS_Change (27.07s)
=== CONT  TestAccMFADevicePolicy_FIDO2_Full
--- PASS: TestAccMFADevicePolicy_Email_Change (15.99s)
=== CONT  TestAccMFADevicePolicy_Totp_Minimal
--- PASS: TestAccMFADevicePolicy_FIDO2_Minimal (5.20s)
=== CONT  TestAccMFADevicePolicy_Voice_Change
--- PASS: TestAccMFADevicePolicy_SMS_Minimal (21.36s)
=== CONT  TestAccMFADevicePolicy_Voice_Minimal
--- PASS: TestAccMFADevicePolicy_DeleteDependentSOPFinalAction (15.81s)
=== CONT  TestAccMFADevicePolicy_Voice_Full
--- PASS: TestAccMFADevicePolicy_FIDO2_Full (10.21s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
--- PASS: TestAccMFADevicePolicy_Totp_Minimal (9.97s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/General_Validation
--- PASS: TestAccMFADevicePolicy_Voice_Minimal (7.92s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== CONT  TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
--- PASS: TestAccMFADevicePolicy_FIDO2_Change (20.66s)
--- PASS: TestAccMFADevicePolicy_Voice_Full (16.40s)
--- PASS: TestAccMFADevicePolicyDefault_BadParameters (54.32s)
--- PASS: TestAccMFADevicePolicyDefault_Minimal (47.44s)
--- PASS: TestAccMFADevicePolicyDefault_Validation (0.00s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation (6.66s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/General_Validation (5.89s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation (8.05s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation (11.33s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation (10.81s)
--- PASS: TestAccMFADevicePolicyDefault_DriftCorrection (57.73s)
--- PASS: TestAccMFADevicePolicy_BadParameters (44.54s)
--- PASS: TestAccMFADevicePolicy_NewEnv (45.85s)
--- PASS: TestAccMFADevicePolicy_DataModel (37.20s)
--- PASS: TestAccMFADevicePolicy_Voice_Change (30.29s)
--- PASS: TestAccMFADevicePolicyDefault_Full (52.27s)
--- PASS: TestAccMFADevicePolicyDefault_Change (66.91s)
--- PASS: TestAccMFADevicePolicyDefault_RemovalDrift (77.14s)
--- PASS: TestAccMFADevicePolicy_RemovalDrift (87.41s)
FAIL
FAIL    github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 137.565s
FAIL
```
</details>
