### PR TITLE
Add missing attributes to `pingone_mfa_device_policy_default`

### DIFF
--- a/.changelog/pr-1309.txt
+++ b/.changelog/pr-1309.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_mfa_device_policy_default`: Added support for `totp.passcode_grace_period` and `whats_app` attributes
+```

--- a/docs/resources/mfa_device_policy_default.md
+++ b/docs/resources/mfa_device_policy_default.md
@@ -163,6 +163,7 @@ resource "pingone_mfa_device_policy_default" "my_awesome_mfa_device_policy_defau
 
   totp = {
     enabled                        = true
+    passcode_grace_period          = 5
     pairing_disabled               = false
     prompt_for_nickname_on_pairing = false
     otp = {
@@ -676,6 +677,7 @@ Optional:
 
 - `otp` (Attributes) A single object that allows configuration of TOTP OTP settings. (see [below for nested schema](#nestedatt--totp--otp))
 - `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the TOTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
+- `passcode_grace_period` (Number) An integer that specifies the passcode grace period window count for TOTP. Minimum is `1` and maximum is `10`.  Defaults to `5`.
 - `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
 - `uri_parameters` (Map of String) A map of string key:value pairs that specifies `otpauth` URI parameters. For example, if you provide a value for the `issuer` parameter, then authenticators that support that parameter will display the text you specify together with the OTP (in addition to the username). This can help users recognize which application the OTP is for. If you intend on using the same MFA policy for multiple applications, choose a name that reflects the group of applications.
 

--- a/docs/resources/mfa_device_policy_default.md
+++ b/docs/resources/mfa_device_policy_default.md
@@ -105,6 +105,26 @@ resource "pingone_mfa_device_policy_default" "my_awesome_mfa_device_policy_defau
     }
   }
 
+  whats_app = {
+    enabled                        = true
+    pairing_disabled               = false
+    prompt_for_nickname_on_pairing = false
+    otp = {
+      failure = {
+        count = 3
+        cool_down = {
+          duration  = 2
+          time_unit = "MINUTES"
+        }
+      }
+      lifetime = {
+        duration  = 30
+        time_unit = "MINUTES"
+      }
+      otp_length = 6
+    }
+  }
+
   mobile = {
     enabled                        = true
     prompt_for_nickname_on_pairing = false
@@ -358,6 +378,7 @@ resource "pingone_environment" "my_environment" {
 - `notifications_policy` (Attributes) A single object that specifies the notification policy to use for this MFA device policy. If not specified, the default notification policy for the environment will be used.  **Note:** When destroying this resource, the `notifications_policy` will be unset (set to null) to release any dependencies, allowing the referenced notification policy to be deleted if needed. (see [below for nested schema](#nestedatt--notifications_policy))
 - `oath_token` (Attributes) A single object that allows configuration of OATH token device authentication policy settings. (see [below for nested schema](#nestedatt--oath_token))
 - `remember_me` (Attributes) A single object that specifies 'remember me' settings so that users do not have to authenticate when accessing applications from a device they have used already. (see [below for nested schema](#nestedatt--remember_me))
+- `whats_app` (Attributes) A single object that allows configuration of WhatsApp OTP device authentication policy settings. Only applicable for PING_ONE_MFA policies. (see [below for nested schema](#nestedatt--whats_app))
 - `yubikey` (Attributes) A single object that allows configuration of PingID Yubikey device authentication policy settings. Only applicable when `policy_type` is `PING_ONE_ID`. (see [below for nested schema](#nestedatt--yubikey))
 
 ### Read-Only
@@ -930,6 +951,57 @@ Required:
 
 - `duration` (Number) An integer that, used in conjunction with `time_unit`, defines the 'remember me' period.
 - `time_unit` (String) A string that specifies the time unit to use for the 'remember me' period.  Options are `DAYS`, `HOURS`, `MINUTES`.
+
+
+
+
+<a id="nestedatt--whats_app"></a>
+### Nested Schema for `whats_app`
+
+Required:
+
+- `enabled` (Boolean) A boolean that specifies whether the WhatsApp OTP method is enabled or disabled in the policy.
+
+Optional:
+
+- `otp` (Attributes) A single object that allows configuration of WhatsApp OTP settings. (see [below for nested schema](#nestedatt--whats_app--otp))
+- `pairing_disabled` (Boolean) A boolean that, when set to `true`, prevents users from pairing new devices with the WhatsApp OTP method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.  Defaults to `false`.
+- `prompt_for_nickname_on_pairing` (Boolean) A boolean that, when set to `true`, prompts users to provide nicknames for devices during pairing.
+
+<a id="nestedatt--whats_app--otp"></a>
+### Nested Schema for `whats_app.otp`
+
+Optional:
+
+- `failure` (Attributes) A single object that allows configuration of WhatsApp OTP failure settings. (see [below for nested schema](#nestedatt--whats_app--otp--failure))
+- `lifetime` (Attributes) A single object that allows configuration of WhatsApp OTP lifetime settings. (see [below for nested schema](#nestedatt--whats_app--otp--lifetime))
+- `otp_length` (Number) An integer that specifies the length of the OTP that is shown to users.  Minimum length is `6` digits and maximum is `10` digits.  Defaults to `6`.
+
+<a id="nestedatt--whats_app--otp--failure"></a>
+### Nested Schema for `whats_app.otp.failure`
+
+Required:
+
+- `cool_down` (Attributes) A single object that allows configuration of WhatsApp OTP failure cool down settings. (see [below for nested schema](#nestedatt--whats_app--otp--failure--cool_down))
+- `count` (Number) An integer that defines the maximum number of times that the OTP entry can fail for a user, before they are blocked. The minimum value is `1` and the maximum value is `7`.
+
+<a id="nestedatt--whats_app--otp--failure--cool_down"></a>
+### Nested Schema for `whats_app.otp.failure.cool_down`
+
+Required:
+
+- `duration` (Number) An integer that defines the duration (number of time units) the user is blocked after reaching the maximum number of passcode failures.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
+
+
+
+<a id="nestedatt--whats_app--otp--lifetime"></a>
+### Nested Schema for `whats_app.otp.lifetime`
+
+Required:
+
+- `duration` (Number) An integer that defines the duration (number of time units) that the passcode is valid before it expires. The minimum value is `1` and the maximum value is `120`.
+- `time_unit` (String) A string that specifies the type of time unit for `duration`.  Options are `MINUTES`, `SECONDS`.
 
 
 

--- a/examples/resources/pingone_mfa_device_policy_default/resource-pingone-mfa.tf
+++ b/examples/resources/pingone_mfa_device_policy_default/resource-pingone-mfa.tf
@@ -143,6 +143,7 @@ resource "pingone_mfa_device_policy_default" "my_awesome_mfa_device_policy_defau
 
   totp = {
     enabled                        = true
+    passcode_grace_period          = 5
     pairing_disabled               = false
     prompt_for_nickname_on_pairing = false
     otp = {

--- a/examples/resources/pingone_mfa_device_policy_default/resource-pingone-mfa.tf
+++ b/examples/resources/pingone_mfa_device_policy_default/resource-pingone-mfa.tf
@@ -85,6 +85,26 @@ resource "pingone_mfa_device_policy_default" "my_awesome_mfa_device_policy_defau
     }
   }
 
+  whats_app = {
+    enabled                        = true
+    pairing_disabled               = false
+    prompt_for_nickname_on_pairing = false
+    otp = {
+      failure = {
+        count = 3
+        cool_down = {
+          duration  = 2
+          time_unit = "MINUTES"
+        }
+      }
+      lifetime = {
+        duration  = 30
+        time_unit = "MINUTES"
+      }
+      otp_length = 6
+    }
+  }
+
   mobile = {
     enabled                        = true
     prompt_for_nickname_on_pairing = false

--- a/internal/acctest/service/mfa/mfa_device_policy_default.go
+++ b/internal/acctest/service/mfa/mfa_device_policy_default.go
@@ -78,8 +78,8 @@ func MFADevicePolicyDefault_CheckDestroy(s *terraform.State) error {
 			return fmt.Errorf("expected SMS Otp.Failure.Count to be 3, got %d", v)
 		}
 
-		if v := policy.Sms.Otp.Failure.CoolDown.GetDuration(); v != 2 {
-			return fmt.Errorf("expected SMS Otp.Failure.CoolDown.Duration to be 2, got %d", v)
+		if v := policy.Sms.Otp.Failure.CoolDown.GetDuration(); v != 0 {
+			return fmt.Errorf("expected SMS Otp.Failure.CoolDown.Duration to be 0, got %d", v)
 		}
 
 		if v := policy.Sms.Otp.Failure.CoolDown.GetTimeUnit(); v != mfa.ENUMTIMEUNIT_MINUTES {
@@ -115,8 +115,8 @@ func MFADevicePolicyDefault_CheckDestroy(s *terraform.State) error {
 			return fmt.Errorf("expected Voice Otp.Failure.Count to be 3, got %d", v)
 		}
 
-		if v := policy.Voice.Otp.Failure.CoolDown.GetDuration(); v != 2 {
-			return fmt.Errorf("expected Voice Otp.Failure.CoolDown.Duration to be 2, got %d", v)
+		if v := policy.Voice.Otp.Failure.CoolDown.GetDuration(); v != 0 {
+			return fmt.Errorf("expected Voice Otp.Failure.CoolDown.Duration to be 0, got %d", v)
 		}
 
 		if v := policy.Voice.Otp.Failure.CoolDown.GetTimeUnit(); v != mfa.ENUMTIMEUNIT_MINUTES {
@@ -152,8 +152,8 @@ func MFADevicePolicyDefault_CheckDestroy(s *terraform.State) error {
 			return fmt.Errorf("expected Email Otp.Failure.Count to be 3, got %d", v)
 		}
 
-		if v := policy.Email.Otp.Failure.CoolDown.GetDuration(); v != 2 {
-			return fmt.Errorf("expected Email Otp.Failure.CoolDown.Duration to be 2, got %d", v)
+		if v := policy.Email.Otp.Failure.CoolDown.GetDuration(); v != 0 {
+			return fmt.Errorf("expected Email Otp.Failure.CoolDown.Duration to be 0, got %d", v)
 		}
 
 		if v := policy.Email.Otp.Failure.CoolDown.GetTimeUnit(); v != mfa.ENUMTIMEUNIT_MINUTES {
@@ -310,8 +310,8 @@ func MFADevicePolicyDefault_CheckDestroy(s *terraform.State) error {
 				return fmt.Errorf("expected WhatsApp Otp.Failure.Count to be 3, got %d", v)
 			}
 
-			if v := policy.WhatsApp.Otp.Failure.CoolDown.GetDuration(); v != 2 {
-				return fmt.Errorf("expected WhatsApp Otp.Failure.CoolDown.Duration to be 2, got %d", v)
+			if v := policy.WhatsApp.Otp.Failure.CoolDown.GetDuration(); v != 0 {
+				return fmt.Errorf("expected WhatsApp Otp.Failure.CoolDown.Duration to be 0, got %d", v)
 			}
 
 			if v := policy.WhatsApp.Otp.Failure.CoolDown.GetTimeUnit(); v != mfa.ENUMTIMEUNIT_MINUTES {

--- a/internal/acctest/service/mfa/mfa_device_policy_default.go
+++ b/internal/acctest/service/mfa/mfa_device_policy_default.go
@@ -283,6 +283,46 @@ func MFADevicePolicyDefault_CheckDestroy(s *terraform.State) error {
 			return fmt.Errorf("expected TOTP PasscodeGracePeriod to be 5, got %d", v)
 		}
 
+		// WhatsApp
+		policyType := rs.Primary.Attributes["policy_type"]
+		if policyType == "PING_ONE_MFA" {
+			if policy.WhatsApp.GetEnabled() {
+				return fmt.Errorf("expected WhatsApp to be disabled")
+			}
+
+			if policy.WhatsApp.GetPairingDisabled() {
+				return fmt.Errorf("expected WhatsApp PairingDisabled to be false")
+			}
+
+			if policy.WhatsApp.GetPromptForNicknameOnPairing() {
+				return fmt.Errorf("expected WhatsApp PromptForNicknameOnPairing to be false")
+			}
+
+			if v := policy.WhatsApp.Otp.LifeTime.GetDuration(); v != 30 {
+				return fmt.Errorf("expected WhatsApp Otp.LifeTime.Duration to be 30, got %d", v)
+			}
+
+			if v := policy.WhatsApp.Otp.LifeTime.GetTimeUnit(); v != mfa.ENUMTIMEUNIT_MINUTES {
+				return fmt.Errorf("expected WhatsApp Otp.LifeTime.TimeUnit to be MINUTES, got %s", v)
+			}
+
+			if v := policy.WhatsApp.Otp.Failure.GetCount(); v != 3 {
+				return fmt.Errorf("expected WhatsApp Otp.Failure.Count to be 3, got %d", v)
+			}
+
+			if v := policy.WhatsApp.Otp.Failure.CoolDown.GetDuration(); v != 2 {
+				return fmt.Errorf("expected WhatsApp Otp.Failure.CoolDown.Duration to be 2, got %d", v)
+			}
+
+			if v := policy.WhatsApp.Otp.Failure.CoolDown.GetTimeUnit(); v != mfa.ENUMTIMEUNIT_MINUTES {
+				return fmt.Errorf("expected WhatsApp Otp.Failure.CoolDown.TimeUnit to be MINUTES, got %s", v)
+			}
+
+			if v := policy.WhatsApp.Otp.GetOtpLength(); v != 6 {
+				return fmt.Errorf("expected WhatsApp Otp.OtpLength to be 6, got %d", v)
+			}
+		}
+
 		// FIDO2
 		if policy.Fido2.GetEnabled() {
 			return fmt.Errorf("expected FIDO2 to be disabled")

--- a/internal/acctest/service/mfa/mfa_device_policy_default.go
+++ b/internal/acctest/service/mfa/mfa_device_policy_default.go
@@ -279,6 +279,10 @@ func MFADevicePolicyDefault_CheckDestroy(s *terraform.State) error {
 			return fmt.Errorf("expected TOTP Otp.Failure.CoolDown.TimeUnit to be MINUTES, got %s", v)
 		}
 
+		if v := policy.Totp.GetPasscodeGracePeriod(); v != 5 {
+			return fmt.Errorf("expected TOTP PasscodeGracePeriod to be 5, got %d", v)
+		}
+
 		// FIDO2
 		if policy.Fido2.GetEnabled() {
 			return fmt.Errorf("expected FIDO2 to be disabled")

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -66,6 +68,7 @@ type MFADevicePolicyDefaultResourceModel struct {
 	Sms                   types.Object                 `tfsdk:"sms"`
 	Voice                 types.Object                 `tfsdk:"voice"`
 	Email                 types.Object                 `tfsdk:"email"`
+	WhatsApp              types.Object                 `tfsdk:"whats_app"`
 	Mobile                types.Object                 `tfsdk:"mobile"`
 	Totp                  types.Object                 `tfsdk:"totp"`
 	Fido2                 types.Object                 `tfsdk:"fido2"`
@@ -387,6 +390,10 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 	deviceSelectionDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that defines the device selection method.",
 	).AllowedValuesEnum(mfa.AllowedEnumMFADevicePolicySelectionEnumValues).DefaultValue(string(mfa.ENUMMFADEVICEPOLICYSELECTION_DEFAULT_TO_FIRST))
+
+	whatsAppDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("A single object that allows configuration of WhatsApp OTP device authentication policy settings. Only applicable for %s policies.", POLICY_TYPE_PINGONE_MFA),
+	)
 
 	newDeviceNotificationDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A string that defines whether a user should be notified if a new authentication method has been added to their account.",
@@ -1007,6 +1014,25 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 			"voice": r.devicePolicyOfflineDeviceSchemaAttribute("voice OTP"),
 
 			"email": r.devicePolicyOfflineDeviceSchemaAttribute("email OTP"),
+
+			"whats_app": schema.SingleNestedAttribute{
+				Description:         whatsAppDescription.Description,
+				MarkdownDescription: whatsAppDescription.MarkdownDescription,
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+
+				Validators: []validator.Object{
+					objectvalidator.ConflictsIfMatchesPathValue(
+						types.StringValue(POLICY_TYPE_PINGID),
+						path.MatchRoot("policy_type"),
+					),
+				},
+
+				Attributes: r.devicePolicyOfflineDeviceSchemaAttribute("WhatsApp OTP").Attributes,
+			},
 
 			"mobile": schema.SingleNestedAttribute{
 				Description:         mobileDescription.Description,
@@ -3680,6 +3706,26 @@ func (p *MFADevicePolicyDefaultResourceModel) expand(ctx context.Context) (mfa.D
 		tflog.Debug(ctx, "oath_token is null or unknown, NOT sending to API")
 	}
 
+	// WhatsApp - only for PingOne MFA
+	if policyType != POLICY_TYPE_PINGID && !p.WhatsApp.IsNull() && !p.WhatsApp.IsUnknown() {
+		var whatsAppPlan MFADevicePolicyWhatsAppResourceModel
+		diags.Append(p.WhatsApp.As(ctx, &whatsAppPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return mfa.DeviceAuthenticationPolicy{}, diags
+		}
+
+		whatsApp, d := whatsAppPlan.expand(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return mfa.DeviceAuthenticationPolicy{}, diags
+		}
+
+		data.SetWhatsApp(*whatsApp)
+	}
+
 	return *data, diags
 }
 
@@ -4186,6 +4232,8 @@ func (p *MFADevicePolicyDefaultResourceModel) toState(apiObject *mfa.DeviceAuthe
 
 	// Policy type specific fields
 	if isPingID {
+		p.WhatsApp = types.ObjectNull(MFADevicePolicyOfflineDeviceTFObjectTypes)
+
 		// PingID-specific devices
 		p.Desktop, d = toStateMfaDevicePolicyPingIDDevice(apiObject.GetDesktopOk())
 		diags.Append(d...)
@@ -4193,6 +4241,9 @@ func (p *MFADevicePolicyDefaultResourceModel) toState(apiObject *mfa.DeviceAuthe
 		p.Yubikey, d = toStateMfaDevicePolicyPingIDDevice(apiObject.GetYubikeyOk())
 		diags.Append(d...)
 	} else {
+		p.WhatsApp, d = toStateMfaDevicePolicyWhatsApp(apiObject.GetWhatsAppOk())
+		diags.Append(d...)
+
 		// Set PingID-specific fields to null for PingOneMFA policies
 		p.Desktop = types.ObjectNull(MFADevicePolicyCommonDeviceTFObjectTypes)
 		p.Yubikey = types.ObjectNull(MFADevicePolicyCommonDeviceTFObjectTypes)

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -3313,28 +3313,29 @@ func FetchDefaultMFADevicePolicyWithTimeout(ctx context.Context, apiClient *mfa.
 
 func (p *MFADevicePolicyDefaultResourceModel) buildDefaultPolicyStruct(mobileAppID string) *mfa.DeviceAuthenticationPolicy {
 	const (
-		defaultOTPPeriodDuration       = 30
-		defaultOTPFailureCount         = 3
-		defaultOTPFailureCooldown      = 2
-		defaultTotpPasscodeGracePeriod = 5
-		defaultOTPLength               = 6
-		defaultPushTimeout             = 100
-		defaultPairingKeyLifetime      = 48
-		defaultPushLimitCount          = 5
-		defaultPushLimitPeriod         = 10
-		defaultPushLimitLockDuration   = 30
-		defaultNewRequestDeviceTimeout = 25
-		defaultNewRequestTotalTimeout  = 40
-		defaultRememberMeDuration      = 30
+		defaultOTPPeriodDuration         = 30
+		defaultOTPFailureCount           = 3
+		defaultOTPFailureCooldown        = 2
+		defaultOfflineOTPFailureCoolDown = 0
+		defaultTotpPasscodeGracePeriod   = 5
+		defaultOTPLength                 = 6
+		defaultPushTimeout               = 100
+		defaultPairingKeyLifetime        = 48
+		defaultPushLimitCount            = 5
+		defaultPushLimitPeriod           = 10
+		defaultPushLimitLockDuration     = 30
+		defaultNewRequestDeviceTimeout   = 25
+		defaultNewRequestTotalTimeout    = 40
+		defaultRememberMeDuration        = 30
 	)
 
 	minutes := mfa.EnumTimeUnit("MINUTES")
 
 	isPingID := !p.PolicyType.IsNull() && !p.PolicyType.IsUnknown() && p.PolicyType.ValueString() == POLICY_TYPE_PINGID
 
-	// Offline OTP Defaults (SMS, Voice, Email)
+	// Offline OTP Defaults (SMS, Voice, Email, WhatsApp)
 	offlineOtpLifetime := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpLifeTime(defaultOTPPeriodDuration, minutes)
-	offlineOtpFailureCooldown := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(defaultOTPFailureCooldown, minutes)
+	offlineOtpFailureCooldown := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailureCoolDown(defaultOfflineOTPFailureCoolDown, minutes)
 	offlineOtpFailure := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtpFailure(defaultOTPFailureCount, *offlineOtpFailureCooldown)
 	offlineOtp := mfa.NewDeviceAuthenticationPolicyOfflineDeviceOtp(*offlineOtpLifetime, *offlineOtpFailure)
 	offlineOtp.SetOtpLength(defaultOTPLength)
@@ -3514,6 +3515,7 @@ func (p *MFADevicePolicyDefaultResourceModel) buildDefaultPolicyStruct(mobileApp
 		data.SetYubikey(*yubikey)
 	} else {
 		whatsApp := mfa.NewDeviceAuthenticationPolicyOfflineDevice(false, *offlineOtp)
+		whatsApp.SetPairingDisabled(false)
 		data.SetWhatsApp(*whatsApp)
 	}
 

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -97,6 +97,7 @@ type MFADevicePolicyDefaultMobileResourceModel struct {
 type MFADevicePolicyDefaultTotpResourceModel struct {
 	Enabled                    types.Bool   `tfsdk:"enabled"`
 	Otp                        types.Object `tfsdk:"otp"`
+	PasscodeGracePeriod        types.Int32  `tfsdk:"passcode_grace_period"`
 	PairingDisabled            types.Bool   `tfsdk:"pairing_disabled"`
 	PromptForNicknameOnPairing types.Bool   `tfsdk:"prompt_for_nickname_on_pairing"`
 	UriParameters              types.Map    `tfsdk:"uri_parameters"`
@@ -229,6 +230,7 @@ var (
 	MFADevicePolicyDefaultTotpTFObjectTypes = map[string]attr.Type{
 		"enabled":                        types.BoolType,
 		"otp":                            types.ObjectType{AttrTypes: MFADevicePolicyTotpOtpTFObjectTypes},
+		"passcode_grace_period":          types.Int32Type,
 		"pairing_disabled":               types.BoolType,
 		"prompt_for_nickname_on_pairing": types.BoolType,
 		"uri_parameters":                 types.MapType{ElemType: types.StringType},
@@ -288,6 +290,9 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 
 	const totpOtpFailureCountDefault = 3
 	const totpOtpFailureCoolDownDurationDefault = 2
+	const totpPasscodeGracePeriodDefault = 5
+	const totpPasscodeGracePeriodMin = 1
+	const totpPasscodeGracePeriodMax = 10
 
 	const fido2FailureCountDefault = 3
 	const fido2FailureCoolDownDurationDefault = 2
@@ -522,6 +527,10 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 	totpUriParametersDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A map of string key:value pairs that specifies `otpauth` URI parameters. For example, if you provide a value for the `issuer` parameter, then authenticators that support that parameter will display the text you specify together with the OTP (in addition to the username). This can help users recognize which application the OTP is for. If you intend on using the same MFA policy for multiple applications, choose a name that reflects the group of applications.",
 	)
+
+	totpPasscodeGracePeriodDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("An integer that specifies the passcode grace period window count for TOTP. Minimum is `%d` and maximum is `%d`.", totpPasscodeGracePeriodMin, totpPasscodeGracePeriodMax),
+	).DefaultValue(totpPasscodeGracePeriodDefault)
 
 	fido2PairingDisabledDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"A boolean that, when set to `true`, prevents users from pairing new devices with the FIDO2 method, though keeping it active in the policy for existing users. You can use this option if you want to phase out an existing authentication method but want to allow users to continue using the method for authentication for existing devices.",
@@ -1652,6 +1661,19 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 						Computed:            true,
 
 						Default: booldefault.StaticBool(false),
+					},
+
+					"passcode_grace_period": schema.Int32Attribute{
+						Description:         totpPasscodeGracePeriodDescription.Description,
+						MarkdownDescription: totpPasscodeGracePeriodDescription.MarkdownDescription,
+						Optional:            true,
+						Computed:            true,
+
+						Default: int32default.StaticInt32(totpPasscodeGracePeriodDefault),
+
+						Validators: []validator.Int32{
+							int32validator.Between(totpPasscodeGracePeriodMin, totpPasscodeGracePeriodMax),
+						},
 					},
 
 					"otp": schema.SingleNestedAttribute{
@@ -3187,6 +3209,7 @@ func (p *MFADevicePolicyDefaultResourceModel) buildDefaultPolicyStruct(mobileApp
 		defaultOTPPeriodDuration       = 30
 		defaultOTPFailureCount         = 3
 		defaultOTPFailureCooldown      = 2
+		defaultTotpPasscodeGracePeriod = 5
 		defaultOTPLength               = 6
 		defaultPushTimeout             = 100
 		defaultPairingKeyLifetime      = 48
@@ -3302,6 +3325,8 @@ func (p *MFADevicePolicyDefaultResourceModel) buildDefaultPolicyStruct(mobileApp
 	totpEnabled := !isPingID
 	totp := mfa.NewDeviceAuthenticationPolicyCommonTotp(totpEnabled, *totpOtp)
 	totp.SetPairingDisabled(false)
+	totp.SetPasscodeGracePeriod(defaultTotpPasscodeGracePeriod)
+
 	totp.SetPromptForNicknameOnPairing(false)
 
 	data := mfa.NewDeviceAuthenticationPolicy(
@@ -3663,7 +3688,7 @@ func (p *MFADevicePolicyDefaultTotpResourceModel) expand(ctx context.Context) (*
 	sharedTotpPlan := MFADevicePolicyTotpResourceModel{
 		Enabled:                    p.Enabled,
 		Otp:                        p.Otp,
-		PasscodeGracePeriod:        types.Int32Null(),
+		PasscodeGracePeriod:        p.PasscodeGracePeriod,
 		PairingDisabled:            p.PairingDisabled,
 		PromptForNicknameOnPairing: p.PromptForNicknameOnPairing,
 		UriParameters:              p.UriParameters,
@@ -4192,6 +4217,7 @@ func toStateMfaDevicePolicyTotpForDefault(apiObject *mfa.DeviceAuthenticationPol
 	o := map[string]attr.Value{
 		"enabled":                        framework.BoolOkToTF(apiObject.GetEnabledOk()),
 		"otp":                            otp,
+		"passcode_grace_period":          framework.Int32OkToTF(apiObject.GetPasscodeGracePeriodOk()),
 		"pairing_disabled":               framework.BoolOkToTF(apiObject.GetPairingDisabledOk()),
 		"prompt_for_nickname_on_pairing": framework.BoolOkToTF(apiObject.GetPromptForNicknameOnPairingOk()),
 		"uri_parameters":                 framework.StringMapOkToTF(apiObject.GetUriParametersOk()),

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -2511,6 +2511,8 @@ func (r *MFADevicePolicyDefaultResource) ModifyPlan(ctx context.Context, req res
 
 	plan.UpdatedAt = state.UpdatedAt
 
+	// `whats_app` has a conditional default, which can create plan noise where Terraform shows `updated_at` as `(known after apply)` even when no configurable values changed.
+	// This check ensures `updated_at` is marked as unknown only when the planned configuration actually differs from state.
 	if !req.Plan.Raw.Equal(req.State.Raw) {
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("updated_at"), timetypes.NewRFC3339Unknown())...)
 	}

--- a/internal/service/mfa/resource_mfa_device_policy_default.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default.go
@@ -23,9 +23,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
-"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -911,6 +912,10 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 				Computed:            true,
 
 				CustomType: timetypes.RFC3339Type{},
+
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseNonNullStateForUnknown(),
+				},
 			},
 
 			"notifications_policy": schema.SingleNestedAttribute{
@@ -1021,7 +1026,7 @@ func (r *MFADevicePolicyDefaultResource) Schema(ctx context.Context, req resourc
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.UseStateForUnknown(),
+					objectplanmodifier.UseNonNullStateForUnknown(),
 				},
 
 				Validators: []validator.Object{
@@ -2475,7 +2480,81 @@ func (r *MFADevicePolicyDefaultResource) ModifyPlan(ctx context.Context, req res
 			"State change warning",
 			"A destroy plan has been detected for the \"pingone_mfa_device_policy_default\" resource.  The default MFA device policy will be removed from Terraform's state.  The policy itself will not be removed from the PingOne service but will be reset to its default configuration.",
 		)
+		return
 	}
+
+	var plan MFADevicePolicyDefaultResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.PolicyType.ValueString() == POLICY_TYPE_PINGONE_MFA && (plan.WhatsApp.IsUnknown() || plan.WhatsApp.IsNull()) {
+		whatsAppDefault := defaultWhatsAppObjectValue()
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("whats_app"), whatsAppDefault)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		plan.WhatsApp = whatsAppDefault
+	}
+
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	var state MFADevicePolicyDefaultResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	plan.UpdatedAt = state.UpdatedAt
+
+	if !req.Plan.Raw.Equal(req.State.Raw) {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("updated_at"), timetypes.NewRFC3339Unknown())...)
+	}
+}
+
+func defaultWhatsAppObjectValue() types.Object {
+	const otpFailureCountDefault = 3
+	const otpLifetimeDurationDefault = 30
+	const otpOtpLengthDefault = 6
+
+	return types.ObjectValueMust(
+		MFADevicePolicyOfflineDeviceTFObjectTypes,
+		map[string]attr.Value{
+			"enabled":          types.BoolValue(false),
+			"pairing_disabled": types.BoolValue(false),
+			"otp": types.ObjectValueMust(
+				MFADevicePolicyOfflineDeviceOtpTFObjectTypes,
+				map[string]attr.Value{
+					"failure": types.ObjectValueMust(
+						MFADevicePolicyFailureTFObjectTypes,
+						map[string]attr.Value{
+							"count": types.Int32Value(otpFailureCountDefault),
+							"cool_down": types.ObjectValueMust(
+								MFADevicePolicyTimePeriodTFObjectTypes,
+								map[string]attr.Value{
+									"duration":  types.Int32Value(0),
+									"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+								},
+							),
+						},
+					),
+					"lifetime": types.ObjectValueMust(
+						MFADevicePolicyTimePeriodTFObjectTypes,
+						map[string]attr.Value{
+							"duration":  types.Int32Value(otpLifetimeDurationDefault),
+							"time_unit": types.StringValue(string(mfa.ENUMTIMEUNIT_MINUTES)),
+						},
+					),
+					"otp_length": types.Int32Value(otpOtpLengthDefault),
+				},
+			),
+			"prompt_for_nickname_on_pairing": types.BoolNull(),
+		},
+	)
 }
 
 func (r *MFADevicePolicyDefaultResource) devicePolicyOfflineDeviceSchemaAttribute(descriptionMethod string) schema.SingleNestedAttribute {
@@ -3431,6 +3510,9 @@ func (p *MFADevicePolicyDefaultResourceModel) buildDefaultPolicyStruct(mobileApp
 		yubikey.SetPairingDisabled(false)
 
 		data.SetYubikey(*yubikey)
+	} else {
+		whatsApp := mfa.NewDeviceAuthenticationPolicyOfflineDevice(false, *offlineOtp)
+		data.SetWhatsApp(*whatsApp)
 	}
 
 	return data

--- a/internal/service/mfa/resource_mfa_device_policy_default_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default_test.go
@@ -125,6 +125,14 @@ func TestAccMFADevicePolicyDefault_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.pairing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.pairing_disabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.count", "4"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.duration", "3"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.failure.cool_down.time_unit", "MINUTES"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.duration", "30"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.lifetime.time_unit", "MINUTES"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.otp.otp_length", "6"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.applications.%", "1"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, fmt.Sprintf("pingone_application.%s", resourceName), "mobile.applications.%s.auto_enrollment.enabled", "true"),
@@ -207,6 +215,7 @@ func TestAccMFADevicePolicyDefault_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "sms.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "voice.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "whats_app.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
@@ -656,6 +665,11 @@ func TestAccMFADevicePolicyDefault_Validation(t *testing.T) {
 					// Yubikey should conflict with PingOneMFA policy type
 					{
 						Config:      testAccMFADevicePolicyDefaultConfig_PingID_YubikeyWithPingOneMFA(resourceName, name),
+						ExpectError: regexp.MustCompile(`Invalid argument combination`),
+					},
+					// WhatsApp should conflict with PingID policy type
+					{
+						Config:      testAccMFADevicePolicyDefaultConfig_PingID_WhatsAppWithPingID(resourceName, name),
 						ExpectError: regexp.MustCompile(`Invalid argument combination`),
 					},
 					// Missing desktop block
@@ -1186,6 +1200,25 @@ resource "pingone_mfa_device_policy_default" "%[3]s" {
     }
   }
 
+  whats_app = {
+    enabled          = false
+    pairing_disabled = false
+    otp = {
+      failure = {
+        count = 4
+        cool_down = {
+          duration  = 3
+          time_unit = "MINUTES"
+        }
+      }
+      lifetime = {
+        duration  = 30
+        time_unit = "MINUTES"
+      }
+      otp_length = 6
+    }
+  }
+
   mobile = {
     enabled                        = true
     prompt_for_nickname_on_pairing = false
@@ -1576,6 +1609,71 @@ resource "pingone_mfa_device_policy_default" "%[2]s" {
   }
 
   totp = {
+    enabled = false
+  }
+}`, acctest.WorkforceV2SandboxEnvironment(), resourceName, name)
+}
+
+func testAccMFADevicePolicyDefaultConfig_PingID_WhatsAppWithPingID(resourceName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "pingone_mfa_device_policy_default" "%[2]s" {
+  environment_id = data.pingone_environment.workforce_test.id
+  policy_type    = "PING_ONE_ID"
+
+  name = "%[3]s"
+
+  sms = {
+    enabled = false
+  }
+
+  voice = {
+    enabled = false
+  }
+
+  email = {
+    enabled = false
+  }
+
+  mobile = {
+    enabled = true
+    applications = {
+      "11111111-1111-1111-1111-111111111111" = {
+        type = "pingIdAppConfig"
+        otp = {
+          enabled = true
+        }
+        new_request_duration_configuration = {
+          device_timeout = {
+            duration  = 30
+            time_unit = "SECONDS"
+          }
+          total_timeout = {
+            duration  = 70
+            time_unit = "SECONDS"
+          }
+        }
+        ip_pairing_configuration = {
+          any_ip_address = true
+        }
+      }
+    }
+  }
+
+  totp = {
+    enabled = false
+  }
+
+  desktop = {
+    enabled = false
+  }
+
+  yubikey = {
+    enabled = false
+  }
+
+  whats_app = {
     enabled = false
   }
 }`, acctest.WorkforceV2SandboxEnvironment(), resourceName, name)

--- a/internal/service/mfa/resource_mfa_device_policy_default_test.go
+++ b/internal/service/mfa/resource_mfa_device_policy_default_test.go
@@ -136,6 +136,7 @@ func TestAccMFADevicePolicyDefault_Full(t *testing.T) {
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, fmt.Sprintf("pingone_application.%s", resourceName), "mobile.applications.%s.pairing_key_lifetime.duration", "10"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, fmt.Sprintf("pingone_application.%s", resourceName), "mobile.applications.%s.push_timeout.duration", "45"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "7"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.pairing_disabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.prompt_for_nickname_on_pairing", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "true"),
@@ -208,6 +209,7 @@ func TestAccMFADevicePolicyDefault_Minimal(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "email.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "mobile.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.count", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "fido2.failure.cool_down.duration", "2"),
@@ -379,6 +381,7 @@ func TestAccMFADevicePolicyDefault_PingID_Full(t *testing.T) {
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, fmt.Sprintf("data.pingone_application.%s", resourceName), "mobile.applications.%s.new_request_duration_configuration.total_timeout.time_unit", "SECONDS"),
 					mfa.TestCheckMFADevicePolicyApplicationMapResourceAttr(resourceFullName, fmt.Sprintf("data.pingone_application.%s", resourceName), "mobile.applications.%s.ip_pairing_configuration.any_ip_address", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "totp.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "totp.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "desktop.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "desktop.otp.failure.count", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "yubikey.enabled", "true"),
@@ -1246,6 +1249,7 @@ resource "pingone_mfa_device_policy_default" "%[3]s" {
 
   totp = {
     enabled                        = true
+    passcode_grace_period          = 7
     pairing_disabled               = false
     prompt_for_nickname_on_pairing = false
     otp = {


### PR DESCRIPTION
## Change Description
<!-- Use this section to describe or list, at a high level, the changes contained in the PR.  Can be in a concise format as you would see on a changelog. -->
**CDI-891**: Add these attributes to pingone_mfa_device_policy_default, already supported in SDK:
- `totp.passcodeGracePeriod`
- `whatsApp` (not valid for PingID policies)

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->
- N/A
<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 go test ./internal/service/mfa -count=1 -run=TestAccMFADevicePolicy -v
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->
- Some failures due to missing `PINGONE_GOOGLE_FIREBASE_CREDENTIALS`
<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccMFADevicePolicyDefault_RemovalDrift
=== PAUSE TestAccMFADevicePolicyDefault_RemovalDrift
=== RUN   TestAccMFADevicePolicyDefault_Full
=== PAUSE TestAccMFADevicePolicyDefault_Full
=== RUN   TestAccMFADevicePolicyDefault_Minimal
=== PAUSE TestAccMFADevicePolicyDefault_Minimal
=== RUN   TestAccMFADevicePolicyDefault_Change
=== PAUSE TestAccMFADevicePolicyDefault_Change
=== RUN   TestAccMFADevicePolicyDefault_BadParameters
=== PAUSE TestAccMFADevicePolicyDefault_BadParameters
=== RUN   TestAccMFADevicePolicyDefault_PingID_Full
--- PASS: TestAccMFADevicePolicyDefault_PingID_Full (12.86s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_Minimal
--- PASS: TestAccMFADevicePolicyDefault_PingID_Minimal (11.27s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_Change
--- PASS: TestAccMFADevicePolicyDefault_PingID_Change (16.16s)
=== RUN   TestAccMFADevicePolicyDefault_PingID_SetOrdering
--- PASS: TestAccMFADevicePolicyDefault_PingID_SetOrdering (14.56s)
=== RUN   TestAccMFADevicePolicyDefault_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation
=== RUN   TestAccMFADevicePolicyDefault_BOMValidation
=== PAUSE TestAccMFADevicePolicyDefault_BOMValidation
=== RUN   TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== PAUSE TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== RUN   TestAccMFADevicePolicyDefault_DriftCorrection
=== PAUSE TestAccMFADevicePolicyDefault_DriftCorrection
=== RUN   TestAccMFADevicePolicy_RemovalDrift
=== PAUSE TestAccMFADevicePolicy_RemovalDrift
=== RUN   TestAccMFADevicePolicy_NewEnv
=== PAUSE TestAccMFADevicePolicy_NewEnv
=== RUN   TestAccMFADevicePolicy_SMS_Full
=== PAUSE TestAccMFADevicePolicy_SMS_Full
=== RUN   TestAccMFADevicePolicy_SMS_Minimal
=== PAUSE TestAccMFADevicePolicy_SMS_Minimal
=== RUN   TestAccMFADevicePolicy_SMS_Change
=== PAUSE TestAccMFADevicePolicy_SMS_Change
=== RUN   TestAccMFADevicePolicy_Voice_Full
=== PAUSE TestAccMFADevicePolicy_Voice_Full
=== RUN   TestAccMFADevicePolicy_Voice_Minimal
=== PAUSE TestAccMFADevicePolicy_Voice_Minimal
=== RUN   TestAccMFADevicePolicy_Voice_Change
=== PAUSE TestAccMFADevicePolicy_Voice_Change
=== RUN   TestAccMFADevicePolicy_Email_Full
=== PAUSE TestAccMFADevicePolicy_Email_Full
=== RUN   TestAccMFADevicePolicy_Email_Minimal
=== PAUSE TestAccMFADevicePolicy_Email_Minimal
=== RUN   TestAccMFADevicePolicy_Email_Change
=== PAUSE TestAccMFADevicePolicy_Email_Change
=== RUN   TestAccMFADevicePolicy_Mobile_Full
=== PAUSE TestAccMFADevicePolicy_Mobile_Full
=== RUN   TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
=== RUN   TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== PAUSE TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
=== RUN   TestAccMFADevicePolicy_Mobile_Minimal
=== PAUSE TestAccMFADevicePolicy_Mobile_Minimal
=== RUN   TestAccMFADevicePolicy_Mobile_Change
=== PAUSE TestAccMFADevicePolicy_Mobile_Change
=== RUN   TestAccMFADevicePolicy_Totp_Full
=== PAUSE TestAccMFADevicePolicy_Totp_Full
=== RUN   TestAccMFADevicePolicy_Totp_Minimal
=== PAUSE TestAccMFADevicePolicy_Totp_Minimal
=== RUN   TestAccMFADevicePolicy_Totp_Change
=== PAUSE TestAccMFADevicePolicy_Totp_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Full
=== PAUSE TestAccMFADevicePolicy_FIDO2_Full
=== RUN   TestAccMFADevicePolicy_FIDO2_Minimal
=== PAUSE TestAccMFADevicePolicy_FIDO2_Minimal
=== RUN   TestAccMFADevicePolicy_FIDO2_Change
=== PAUSE TestAccMFADevicePolicy_FIDO2_Change
=== RUN   TestAccMFADevicePolicy_FIDO2_Disabled
=== PAUSE TestAccMFADevicePolicy_FIDO2_Disabled
=== RUN   TestAccMFADevicePolicy_DataModel
=== PAUSE TestAccMFADevicePolicy_DataModel
=== RUN   TestAccMFADevicePolicy_BadParameters
=== PAUSE TestAccMFADevicePolicy_BadParameters
=== RUN   TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== PAUSE TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
=== CONT  TestAccMFADevicePolicy_Email_Minimal
=== CONT  TestAccMFADevicePolicyDefault_RemovalDrift
=== CONT  TestAccMFADevicePolicy_RemovalDrift
=== CONT  TestAccMFADevicePolicyDefault_DriftCorrection
=== CONT  TestAccMFADevicePolicy_Email_Full
=== CONT  TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes
=== CONT  TestAccMFADevicePolicy_Totp_Change
=== CONT  TestAccMFADevicePolicy_Totp_Full
=== CONT  TestAccMFADevicePolicy_FIDO2_Full
=== CONT  TestAccMFADevicePolicy_Mobile_Change
=== CONT  TestAccMFADevicePolicy_BadParameters
=== CONT  TestAccMFADevicePolicy_DataModel
=== CONT  TestAccMFADevicePolicy_FIDO2_Disabled
=== CONT  TestAccMFADevicePolicy_FIDO2_Change
=== CONT  TestAccMFADevicePolicy_FIDO2_Minimal
=== NAME  TestAccMFADevicePolicy_Mobile_Change
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
--- FAIL: TestAccMFADevicePolicy_Mobile_Change (0.00s)
=== CONT  TestAccMFADevicePolicy_Mobile_Minimal
=== CONT  TestAccMFADevicePolicy_DeleteDependentSOPFinalAction
--- PASS: TestAccMFADevicePolicy_Email_Minimal (10.79s)
=== CONT  TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors
--- PASS: TestAccMFADevicePolicy_Mobile_Minimal (11.75s)
=== CONT  TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors
--- PASS: TestAccMFADevicePolicy_FIDO2_Minimal (12.13s)
=== CONT  TestAccMFADevicePolicy_Mobile_Full
    acctest.go:284: PINGONE_GOOGLE_FIREBASE_CREDENTIALS is missing and must be set
--- FAIL: TestAccMFADevicePolicy_Mobile_Full (0.00s)
=== CONT  TestAccMFADevicePolicy_Email_Change
--- PASS: TestAccMFADevicePolicyDefault_BOMValidation_CrossTypes (12.39s)
=== CONT  TestAccMFADevicePolicyDefault_BOMValidation
--- PASS: TestAccMFADevicePolicy_Email_Full (12.93s)
=== CONT  TestAccMFADevicePolicyDefault_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/General_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/General_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== RUN   TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
=== PAUSE TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
=== CONT  TestAccMFADevicePolicyDefault_BadParameters
--- PASS: TestAccMFADevicePolicyDefault_BOMValidation (6.04s)
=== CONT  TestAccMFADevicePolicyDefault_Change
--- PASS: TestAccMFADevicePolicy_Mobile_IntegrityDetectionErrors (7.77s)
=== CONT  TestAccMFADevicePolicyDefault_Minimal
--- PASS: TestAccMFADevicePolicy_Mobile_BadMFADevicePolicyErrors (11.46s)
=== CONT  TestAccMFADevicePolicyDefault_Full
--- PASS: TestAccMFADevicePolicy_Totp_Full (22.34s)
=== CONT  TestAccMFADevicePolicy_Voice_Change
--- PASS: TestAccMFADevicePolicy_FIDO2_Change (27.57s)
=== CONT  TestAccMFADevicePolicy_Voice_Minimal
--- PASS: TestAccMFADevicePolicy_Totp_Change (28.44s)
=== CONT  TestAccMFADevicePolicy_Voice_Full
--- PASS: TestAccMFADevicePolicy_Voice_Minimal (6.06s)
=== CONT  TestAccMFADevicePolicy_SMS_Change
--- PASS: TestAccMFADevicePolicy_Email_Change (21.96s)
=== CONT  TestAccMFADevicePolicy_SMS_Minimal
--- PASS: TestAccMFADevicePolicy_Voice_Change (17.67s)
=== CONT  TestAccMFADevicePolicy_SMS_Full
--- PASS: TestAccMFADevicePolicy_SMS_Minimal (6.07s)
=== CONT  TestAccMFADevicePolicy_NewEnv
--- PASS: TestAccMFADevicePolicy_DataModel (42.23s)
=== CONT  TestAccMFADevicePolicy_Totp_Minimal
--- PASS: TestAccMFADevicePolicy_DeleteDependentSOPFinalAction (47.09s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation
--- PASS: TestAccMFADevicePolicy_Totp_Minimal (6.00s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/General_Validation
--- PASS: TestAccMFADevicePolicy_SMS_Full (8.50s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation
--- PASS: TestAccMFADevicePolicy_SMS_Change (15.84s)
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation
=== CONT  TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation
--- PASS: TestAccMFADevicePolicyDefault_Validation (0.00s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/General_Validation (2.78s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingID_Field_Validation (5.27s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingOneMFA_Mobile_Validation (5.17s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/Common_Field_Validation (8.34s)
    --- PASS: TestAccMFADevicePolicyDefault_Validation/PingID_Structure_Validation (5.63s)
--- PASS: TestAccMFADevicePolicyDefault_DriftCorrection (59.05s)
--- PASS: TestAccMFADevicePolicyDefault_BadParameters (48.28s)
--- PASS: TestAccMFADevicePolicyDefault_Minimal (44.47s)
--- PASS: TestAccMFADevicePolicy_Voice_Full (38.35s)
--- PASS: TestAccMFADevicePolicyDefault_Full (46.58s)
--- PASS: TestAccMFADevicePolicy_FIDO2_Full (75.34s)
--- PASS: TestAccMFADevicePolicyDefault_RemovalDrift (75.71s)
--- PASS: TestAccMFADevicePolicy_BadParameters (78.01s)
--- PASS: TestAccMFADevicePolicy_FIDO2_Disabled (81.57s)
--- PASS: TestAccMFADevicePolicyDefault_Change (63.28s)
--- PASS: TestAccMFADevicePolicy_NewEnv (42.76s)
--- PASS: TestAccMFADevicePolicy_RemovalDrift (90.25s)
FAIL
FAIL    github.com/pingidentity/terraform-provider-pingone/internal/service/mfa 146.060s
FAIL
```

</details>

### End-to-end Tests Workflow Links
<!-- Use the following section to list the URLs to the end-to-end test action workflow runs -->
- N/A