### PR TITLE
Allow Fido2 policy to set the default policy

### DIFF
--- a/internal/service/mfa/resource_fido2_policy.go
+++ b/internal/service/mfa/resource_fido2_policy.go
@@ -286,6 +286,7 @@ func (r *FIDO2PolicyResource) Schema(ctx context.Context, req resource.SchemaReq
 
 			"default": schema.BoolAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("A boolean that describes whether this policy should serve as the default FIDO policy.").Description,
+				Optional:    true,
 				Computed:    true,
 
 				PlanModifiers: []planmodifier.Bool{


### PR DESCRIPTION
## Change Description
Add optional to default for Fido2 policy to allow the policy to be set to default via terraform rather than needing to make an API vs CLI.

As per the following comments

https://github.com/pingidentity/terraform-provider-pingone/pull/1323
https://github.com/pingidentity/terraform-provider-pingone/issues/1322
https://github.com/pingidentity/terraform-provider-pingone/issues/463

By adding `Optional` while keeping `Computed` as a property on `default` then this allows me to select which provider I want to be the default. Have tested this with a test environment I created using the WebUI then imported the existing artefacts in and it worked as expected allowing me to move default to whichever fido2 policy I wanted.
All the other fido2 policies I don't include the default property and it works fine.

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist

- [X] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
N/a

## Testing

This PR has been tested with:

- [X] Unit tests _(please paste commands and results below)_
- [ ] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Example Setup

1. Build this PR and configure the `~/.terraformrc` to use it as per [development-environment.md](https://github.com/pingidentity/terraform-provider-pingone/blob/main/contributing/development-environment.md)
2. Create a new customer identity environment
3. Create fido2.auto.tfvars as needed with the Admin application to connect to the environment and the environment name matching the environment created.

`fido2.auto.tfvars`
```
# Pingone Terraform

## Admin Environment
pingone_admin_environment_id = "..."
pingone_admin_client_id      = "..."
pingone_admin_client_secret  = "..."

# CIAM Environment
pingone_environment_license_id  = "..."
pingone_environment_name        = "PL-Terraform"
pingone_environment_description = "Terraform testing environment"
pingone_environment_domain      = "pingone.com"
```

4. Create `fido2.tf`

```
terraform {
  required_version = "~>1.12.1"
  required_providers {
    pingone = {
      source  = "pingidentity/pingone"
      version = ">= 1.19.1, < 2.0.0"
    }
  }
}

# Ping One Admin environment
variable "pingone_admin_environment_id" {
  type = string
}

variable "pingone_admin_client_id" {
  type = string
}

variable "pingone_admin_client_secret" {
  type = string
}

variable "pingone_region_code" {
  type    = string
  default = "NA"
}

provider "pingone" {
  environment_id = var.pingone_admin_environment_id
  client_id      = var.pingone_admin_client_id
  client_secret  = var.pingone_admin_client_secret
  region_code    = var.pingone_region_code
}

variable "pingone_environment_license_id" {
  type = string
}

variable "pingone_environment_name" {
  type = string
}

variable "pingone_environment_description" {
  type = string
}

variable "pingone_environment_domain" {
  type = string
}

variable "pingone_environment_type" {
  description = "Environment type - SANDBOX or PRODUCTION"
  type        = string
  default     = "SANDBOX"
}

resource "pingone_environment" "environment" {
  name        = var.pingone_environment_name
  description = var.pingone_environment_description
  type        = var.pingone_environment_type
  license_id  = var.pingone_environment_license_id

  services = [
    { type = "DaVinci" },
    { type = "MFA" },
    { type = "Risk" },
    { type = "SSO" },
  { type = "Verify" }]
  solution = "CIAM_TRIAL"
}

resource "pingone_mfa_fido2_policy" "default_passkeys" {
  environment_id           = pingone_environment.environment.id
  name                     = "Passkeys"
  attestation_requirements = "NONE"
  authenticator_attachment = "BOTH"

  backup_eligibility = {
    allow                         = true
    enforce_during_authentication = true
  }
  device_display_name      = "fidoPolicy.deviceDisplayName01"
  discoverable_credentials = "REQUIRED"
  mds_authenticators_requirements = {
    enforce_during_authentication = false
    option                        = "NONE"
  }
  relying_party_id = var.pingone_environment_domain
  user_display_name_attributes = {
    attributes = [
      {
        name = "email"
      },
      {
        name = "name",
        sub_attributes = [
          {
            name = "given"
          },
          {
            name = "family"
          }
        ]
      },
      {
        name = "username"
      }
    ]
  }

  user_verification = {
    enforce_during_authentication = true
    option                        = "REQUIRED"
  }
}

resource "pingone_mfa_fido2_policy" "default_security_keys" {
  environment_id           = pingone_environment.environment.id
  name                     = "Security Keys"
  attestation_requirements = "NONE"
  authenticator_attachment = "CROSS_PLATFORM"
  backup_eligibility = {
    allow                         = false
    enforce_during_authentication = true
  }
  device_display_name      = "fidoPolicy.deviceDisplayName02"
  discoverable_credentials = "PREFERRED"
  mds_authenticators_requirements = {
    enforce_during_authentication = false
    option                        = "NONE"
  }
  relying_party_id = var.pingone_environment_domain
  user_display_name_attributes = {
    attributes = [
      {
        name = "email"
      },
      {
        name = "name",
        sub_attributes = [
          {
            name = "given"
          },
          {
            name = "family"
          }
        ]
      },
      {
        name = "username"
      }
    ]
  }
  user_verification = {
    enforce_during_authentication = true
    option                        = "PREFERRED"
  }
}

resource "pingone_mfa_fido2_policy" "new_fido2_policy" {
  environment_id           = pingone_environment.environment.id
  name                     = "New FIDO Policy"
  attestation_requirements = "NONE"
  authenticator_attachment = "BOTH"
  backup_eligibility = {
    allow                         = true
    enforce_during_authentication = true
  }
  default                  = true

  device_display_name      = "fidoPolicy.deviceDisplayName01"
  discoverable_credentials = "REQUIRED"
  mds_authenticators_requirements = {
    enforce_during_authentication = false
    option                        = "NONE"
  }
  relying_party_id = var.pingone_environment_domain
  user_display_name_attributes = {
    attributes = [
      {
        name = "email"
      },
      {
        name = "name",
        sub_attributes = [
          {
            name = "given"
          },
          {
            name = "family"
          }
        ]
      },
      {
        name = "username"
      },
      {
        name = "nickname"
      }
    ]
  }

  user_verification = {
    enforce_during_authentication = true
    option                        = "REQUIRED"
  }
}

``` 

5. Init Terraform and then Import existing environment into the terraform state

```
terraform init
terraform import pingone_environment.environment **envid**
terraform import pingone_mfa_fido2_policy.default_passkeys **envid**/**default_passkey_id**
terraform import pingone_mfa_fido2_policy.default_security_keys **envid**/**default_security_keys_id**
```

6. Plan to see the differences, and the new policy is added.

By setting the specific policy I want to be default and leaving the others as blank the default moves to the desired policy.

This also applies when moving the default policy back to an existing policy, just don't need to set `default` at all for the policies that are not default.

```
terraform plan    
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - pingidentity/pingone in /Users/peter/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
pingone_environment.environment: Refreshing state... [id=84..d]
pingone_mfa_fido2_policy.default_passkeys: Refreshing state... [id=88cd0fcc-02ce-4416-896c-fb12ef9100cc]
pingone_mfa_fido2_policy.default_security_keys: Refreshing state... [id=f64ff3be-5453-4fb9-abeb-907be003d562]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # pingone_mfa_fido2_policy.new_fido2_policy will be created
  + resource "pingone_mfa_fido2_policy" "new_fido2_policy" {
      + attestation_requirements        = "NONE"
      + authenticator_attachment        = "BOTH"
      + backup_eligibility              = {
          + allow                         = true
          + enforce_during_authentication = true
        }
      + default                         = true
      + device_display_name             = "fidoPolicy.deviceDisplayName01"
      + discoverable_credentials        = "REQUIRED"
      + environment_id                  = "84..d"
      + id                              = (known after apply)
      + mds_authenticators_requirements = {
          + enforce_during_authentication = false
          + option                        = "NONE"
        }
      + name                            = "New FIDO Policy"
      + relying_party_id                = "pingone.com"
      + user_display_name_attributes    = {
          + attributes = [
              + {
                  + name = "email"
                },
              + {
                  + name           = "name"
                  + sub_attributes = [
                      + {
                          + name = "given"
                        },
                      + {
                          + name = "family"
                        },
                    ]
                },
              + {
                  + name = "username"
                },
              + {
                  + name = "nickname"
                },
            ]
        }
      + user_presence_timeout           = {
          + duration  = 2
          + time_unit = "MINUTES"
        }
      + user_verification               = {
          + enforce_during_authentication = true
          + option                        = "REQUIRED"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

### Testing Results

The new policy is created and set to default.

<img width="566" height="482" alt="image" src="https://github.com/user-attachments/assets/e6348142-6d87-4b4c-8c46-b055f2abfcde" />

Equally if I move `default = true` to `default_passkeys` or `default_security_keys` and apply then the default moves to the desired policy.

The local terraform state doesn't match as if any of them have had `default = true` then that remains in the local state, but it doesn't impact how the provider behaves and that when the provider checks the current state whichever is desired to be the default in the configuration that is what is applied.

```
terraform apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - pingidentity/pingone in /Users/peter/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
pingone_environment.environment: Refreshing state... [id=84..d]
pingone_mfa_fido2_policy.default_security_keys: Refreshing state... [id=f64ff3be-5453-4fb9-abeb-907be003d562]
pingone_mfa_fido2_policy.default_passkeys: Refreshing state... [id=88cd0fcc-02ce-4416-896c-fb12ef9100cc]
pingone_mfa_fido2_policy.new_fido2_policy: Refreshing state... [id=7f7438b9-a93e-4063-9144-bf043eb7b10f]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # pingone_mfa_fido2_policy.new_fido2_policy will be updated in-place
  ~ resource "pingone_mfa_fido2_policy" "new_fido2_policy" {
      ~ default                         = false -> true
        id                              = "7f7438b9-a93e-4063-9144-bf043eb7b10f"
        name                            = "New FIDO Policy"
        # (11 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

