### PR TITLE
Fix panic when creating a pingone_davinci_flow with only a name

### DIFF
--- a/.changelog/pr-1340.txt
+++ b/.changelog/pr-1340.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_davinci_flow`: Fixed a panic when creating a flow only the name attribute configured.
+```

--- a/.changelog/pr-1340.txt
+++ b/.changelog/pr-1340.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/pingone_davinci_flow`: Fixed a panic when creating a flow only the name attribute configured.
+`resource/pingone_davinci_flow`: Fixed a panic when creating a flow with only the name attribute configured.
 ```

--- a/internal/service/davinci/resource_davinci_flow.go
+++ b/internal/service/davinci/resource_davinci_flow.go
@@ -175,6 +175,9 @@ func (m *davinciFlowResourceModel) getGraphDataElementsNodes() *types.Map {
 func (r *davinciFlowResource) isUpdateRequiredAfterCreate(plan, createResponse davinciFlowResourceModel) bool {
 	planNodes := plan.getGraphDataElementsNodes()
 	createResponseNodes := createResponse.getGraphDataElementsNodes()
+	if planNodes == nil || createResponseNodes == nil {
+		return false
+	}
 
 	// Check that the create returned all the nodes, but the content did not match the plan
 	return len(planNodes.Elements()) == len(createResponseNodes.Elements()) && !planNodes.Equal(createResponseNodes)


### PR DESCRIPTION
## Change Description
- Fix panic when configuring a `pingone_davinci_flow` resource with only a name
- CDI-1368

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [ ] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [x] Not applicable _(no evidences needed)_
Manually tested against failing resource config
