### PR TITLE
Support passcode_grace_period in pingone_application

### DIFF
--- a/.changelog/pr-1341.txt
+++ b/.changelog/pr-1341.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+`resource/pingone_application`: Added support for `oidc_options.mobile_app.passcode_grace_period`
+```
+
+```release-note:enhancement
+`data-source/pingone_application`: Added support for `oidc_options.mobile_app.passcode_grace_period`
+```

--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -144,6 +144,7 @@ Read-Only:
 - `huawei_package_name` (String) The package name associated with the application, for push notifications in native apps.
 - `integrity_detection` (Attributes) Mobile application integrity detection settings. (see [below for nested schema](#nestedatt--oidc_options--mobile_app--integrity_detection))
 - `package_name` (String) A string that specifies the package name associated with the application, for push notifications in native apps.
+- `passcode_grace_period` (Number) To cover time synchronization issues, you can use this property to customize the grace period during which the passcode can still be used even after the passcode has been refreshed. The value of the parameter should be the number of windows to use (min "1", max "10"). In this context, a window is equal to the passcode refresh period in either direction. For example, if you defined a passcode refresh duration of 30 seconds and a grace period of 2 windows, the passcode is valid for 150 seconds (from 60 seconds behind the time of issue until 60 seconds past the expiration time).
 - `passcode_refresh_seconds` (Number) The amount of time a passcode should be displayed before being replaced with a new passcode.
 - `universal_app_link` (String) A string that specifies a URI prefix that enables direct triggering of the mobile application when scanning a QR code.
 

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -169,6 +169,7 @@ resource "pingone_application" "my_awesome_native_app" {
       universal_app_link = "https://demo.bxretail.org"
 
       passcode_refresh_seconds = 30
+      passcode_grace_period    = 2
 
       integrity_detection = {
         enabled = true
@@ -411,6 +412,7 @@ Optional:
 - `huawei_package_name` (String) The package name associated with the application, for push notifications in native apps. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_app_id`.  This field is immutable and will trigger a replace plan if changed.
 - `integrity_detection` (Attributes) A single object that specifies mobile application integrity detection settings. (see [below for nested schema](#nestedatt--oidc_options--mobile_app--integrity_detection))
 - `package_name` (String) A string that specifies the package name associated with the application, for push notifications in native apps. The value of the `package_name` property is unique per environment, and once defined, is immutable.  This field is immutable and will trigger a replace plan if changed.
+- `passcode_grace_period` (Number) To cover time synchronization issues, you can use this property to customize the grace period during which the passcode can still be used even after the passcode has been refreshed. The value of the parameter should be the number of windows to use (min `1`, max `10`). In this context, a window is equal to the passcode refresh period in either direction. For example, if you defined a passcode refresh duration of 30 seconds and a grace period of 2 windows, the passcode is valid for 150 seconds (from 60 seconds behind the time of issue until 60 seconds past the expiration time).  Defaults to `5`.
 - `passcode_refresh_seconds` (Number) The amount of time a passcode should be displayed before being replaced with a new passcode - must be between `30` and `60` seconds.  Defaults to `30`.
 - `universal_app_link` (String) A string that specifies a URI prefix that enables direct triggering of the mobile application when scanning a QR code. The URI prefix can be set to a universal link with a valid value (which can be a URL address that starts with `HTTP://` or `HTTPS://`, such as `https://www.bxretail.org`), or an app schema, which is just a string and requires no special validation.
 

--- a/examples/resources/pingone_application/resource-native-mobile.tf
+++ b/examples/resources/pingone_application/resource-native-mobile.tf
@@ -27,6 +27,7 @@ resource "pingone_application" "my_awesome_native_app" {
       universal_app_link = "https://demo.bxretail.org"
 
       passcode_refresh_seconds = 30
+      passcode_grace_period    = 2
 
       integrity_detection = {
         enabled = true

--- a/internal/service/sso/data_source_application.go
+++ b/internal/service/sso/data_source_application.go
@@ -445,6 +445,10 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("The package name associated with the application, for push notifications in native apps.").Description,
 								Computed:    true,
 							},
+							"passcode_grace_period": schema.Int32Attribute{
+								Description: framework.SchemaAttributeDescriptionFromMarkdown("To cover time synchronization issues, you can use this property to customize the grace period during which the passcode can still be used even after the passcode has been refreshed. The value of the parameter should be the number of windows to use (min `1`, max `10`). In this context, a window is equal to the passcode refresh period in either direction. For example, if you defined a passcode refresh duration of 30 seconds and a grace period of 2 windows, the passcode is valid for 150 seconds (from 60 seconds behind the time of issue until 60 seconds past the expiration time).").Description,
+								Computed:    true,
+							},
 							"passcode_refresh_seconds": schema.Int32Attribute{
 								Description: framework.SchemaAttributeDescriptionFromMarkdown("The amount of time a passcode should be displayed before being replaced with a new passcode.").Description,
 								Computed:    true,

--- a/internal/service/sso/data_source_application_test.go
+++ b/internal/service/sso/data_source_application_test.go
@@ -546,6 +546,7 @@ resource "pingone_application" "%[2]s" {
       huawei_app_id       = "%[2]s"
       huawei_package_name = "com.%[2]s.huaweipackage"
 
+      passcode_grace_period    = 3
       passcode_refresh_seconds = 45
 
       universal_app_link = "https://applink.com"

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -134,6 +134,7 @@ type applicationOIDCMobileAppResourceModelV1 struct {
 	HuaweiPackageName      types.String `tfsdk:"huawei_package_name"`
 	IntegrityDetection     types.Object `tfsdk:"integrity_detection"`
 	PackageName            types.String `tfsdk:"package_name"`
+	PasscodeGracePeriod    types.Int32  `tfsdk:"passcode_grace_period"`
 	PasscodeRefreshSeconds types.Int32  `tfsdk:"passcode_refresh_seconds"`
 	UniversalAppLink       types.String `tfsdk:"universal_app_link"`
 }
@@ -300,6 +301,7 @@ var (
 		"huawei_package_name":      types.StringType,
 		"integrity_detection":      types.ObjectType{AttrTypes: applicationOidcMobileAppIntegrityDetectionTFObjectTypes},
 		"package_name":             types.StringType,
+		"passcode_grace_period":    types.Int32Type,
 		"passcode_refresh_seconds": types.Int32Type,
 		"universal_app_link":       types.StringType,
 	}
@@ -657,6 +659,13 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 	oidcOptionsMobileAppHuaweiPackageNameDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"The package name associated with the application, for push notifications in native apps. The value of this property is unique per environment, and once defined, is immutable.  Required with `huawei_app_id`.",
 	).RequiresReplace()
+
+	const oidcOptionsMobileAppPasscodeGracePeriodDefault = 5
+	const oidcOptionsMobileAppPasscodeGracePeriodMin = 1
+	const oidcOptionsMobileAppPasscodeGracePeriodMax = 10
+	oidcOptionsMobileAppPasscodeGracePeriodDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		fmt.Sprintf("To cover time synchronization issues, you can use this property to customize the grace period during which the passcode can still be used even after the passcode has been refreshed. The value of the parameter should be the number of windows to use (min `%d`, max `%d`). In this context, a window is equal to the passcode refresh period in either direction. For example, if you defined a passcode refresh duration of 30 seconds and a grace period of 2 windows, the passcode is valid for 150 seconds (from 60 seconds behind the time of issue until 60 seconds past the expiration time).", oidcOptionsMobileAppPasscodeGracePeriodMin, oidcOptionsMobileAppPasscodeGracePeriodMax),
+	).DefaultValue(oidcOptionsMobileAppPasscodeGracePeriodDefault)
 
 	const oidcOptionsMobileAppPasscodeRefreshSecondsDefault = 30
 	const oidcOptionsMobileAppPasscodeRefreshSecondsMin = 30
@@ -1387,6 +1396,19 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 											path.MatchRelative().AtParent().AtName("huawei_app_id"),
 											path.MatchRelative().AtParent().AtName("huawei_package_name"),
 										),
+									},
+								},
+
+								"passcode_grace_period": schema.Int32Attribute{
+									Description:         oidcOptionsMobileAppPasscodeGracePeriodDescription.Description,
+									MarkdownDescription: oidcOptionsMobileAppPasscodeGracePeriodDescription.MarkdownDescription,
+									Optional:            true,
+									Computed:            true,
+
+									Default: int32default.StaticInt32(oidcOptionsMobileAppPasscodeGracePeriodDefault),
+
+									Validators: []validator.Int32{
+										int32validator.Between(oidcOptionsMobileAppPasscodeGracePeriodMin, oidcOptionsMobileAppPasscodeGracePeriodMax),
 									},
 								},
 
@@ -2912,6 +2934,10 @@ func (p *applicationOIDCMobileAppResourceModelV1) expand(ctx context.Context) (*
 
 	if !p.PackageName.IsNull() && !p.PackageName.IsUnknown() {
 		data.SetPackageName(p.PackageName.ValueString())
+	}
+
+	if !p.PasscodeGracePeriod.IsNull() && !p.PasscodeGracePeriod.IsUnknown() {
+		data.SetPasscodeGracePeriod(p.PasscodeGracePeriod.ValueInt32())
 	}
 
 	if !p.PasscodeRefreshSeconds.IsNull() && !p.PasscodeRefreshSeconds.IsUnknown() {

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -527,6 +527,7 @@ func TestAccApplication_OIDCFullNative(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.package_name", fmt.Sprintf("com.%s.package", resourceName)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_app_id", resourceName),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_package_name", fmt.Sprintf("com.%s.huaweipackage", resourceName)),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "45"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link", "https://applink.com"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "true"),
@@ -626,6 +627,7 @@ func TestAccApplication_OIDCMinimalNative(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.excluded_platforms.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "30"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "saml_options"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "external_link_options"),
@@ -704,6 +706,7 @@ func TestAccApplication_OIDCNativeUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.package_name", fmt.Sprintf("com.%s.package", resourceName)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_app_id", resourceName),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_package_name", fmt.Sprintf("com.%s.huaweipackage", resourceName)),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "45"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link", "https://applink.com"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "true"),
@@ -760,6 +763,7 @@ func TestAccApplication_OIDCNativeUpdate(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.excluded_platforms.#", "0"),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "5"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "30"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "saml_options"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "external_link_options"),
@@ -810,6 +814,7 @@ func TestAccApplication_OIDCNativeUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.package_name", fmt.Sprintf("com.%s.package", resourceName)),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_app_id", resourceName),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_package_name", fmt.Sprintf("com.%s.huaweipackage", resourceName)),
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "3"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "45"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link", "https://applink.com"),
 					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "true"),
@@ -980,6 +985,7 @@ func TestAccApplication_NativeMobile(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.package_name", fmt.Sprintf("com.%s.package", resourceName)),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_app_id", resourceName),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_package_name", fmt.Sprintf("com.%s.huaweipackage", resourceName)),
+			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "3"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "45"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link", "https://applink.com"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "true"),
@@ -1000,6 +1006,7 @@ func TestAccApplication_NativeMobile(t *testing.T) {
 			resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.mobile_app.package_name"),
 			resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_app_id"),
 			resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.mobile_app.huawei_package_name"),
+			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "5"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "30"),
 			resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "false"),
@@ -1016,6 +1023,7 @@ func TestAccApplication_NativeMobile(t *testing.T) {
 			resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.mobile_app.universal_app_link"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.enabled", "false"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.integrity_detection.excluded_platforms.#", "0"),
+			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_grace_period", "5"),
 			resource.TestCheckResourceAttr(resourceFullName, "oidc_options.mobile_app.passcode_refresh_seconds", "30"),
 		),
 	}
@@ -3869,6 +3877,7 @@ resource "pingone_application" "%[2]s" {
       huawei_app_id       = "%[2]s"
       huawei_package_name = "com.%[2]s.huaweipackage"
 
+      passcode_grace_period    = 3
       passcode_refresh_seconds = 45
 
       universal_app_link = "https://applink.com"
@@ -4077,6 +4086,7 @@ resource "pingone_application" "%[2]s" {
       huawei_app_id       = "%[2]s"
       huawei_package_name = "com.%[2]s.huaweipackage"
 
+      passcode_grace_period    = 3
       passcode_refresh_seconds = 45
 
       universal_app_link = "https://applink.com"
@@ -4143,6 +4153,7 @@ resource "pingone_application" "%[2]s" {
       huawei_app_id       = "%[2]s"
       huawei_package_name = "com.%[2]s.huaweipackage"
 
+      passcode_grace_period    = 3
       passcode_refresh_seconds = 45
 
       universal_app_link = "https://applink.com"
@@ -4189,6 +4200,7 @@ resource "pingone_application" "%[2]s" {
       huawei_app_id       = "%[2]s"
       huawei_package_name = "com.%[2]s.huaweipackage"
 
+      passcode_grace_period    = 3
       passcode_refresh_seconds = 45
 
       universal_app_link = "https://applink.com"
@@ -4231,6 +4243,7 @@ resource "pingone_application" "%[2]s" {
       huawei_app_id       = "%[2]s"
       huawei_package_name = "com.%[2]s.huaweipackage"
 
+      passcode_grace_period    = 3
       passcode_refresh_seconds = 45
 
       universal_app_link = "https://applink.com"
@@ -4270,6 +4283,7 @@ resource "pingone_application" "%[2]s" {
       huawei_app_id       = "%[2]s"
       huawei_package_name = "com.%[2]s.huaweipackage"
 
+      passcode_grace_period    = 3
       passcode_refresh_seconds = 45
 
       universal_app_link = "https://applink.com"

--- a/internal/service/sso/utils_application.go
+++ b/internal/service/sso/utils_application.go
@@ -236,6 +236,7 @@ func applicationMobileAppOkToTF(ctx context.Context, apiObject *management.Appli
 		"huawei_package_name":      framework.StringOkToTF(apiObject.GetHuaweiPackageNameOk()),
 		"integrity_detection":      integrityDetection,
 		"package_name":             framework.StringOkToTF(apiObject.GetPackageNameOk()),
+		"passcode_grace_period":    framework.Int32OkToTF(apiObject.GetPasscodeGracePeriodOk()),
 		"passcode_refresh_seconds": types.Int32Null(),
 		"universal_app_link":       framework.StringOkToTF(apiObject.GetUriPrefixOk()),
 	}


### PR DESCRIPTION
## Change Description
- Support the `passcode_grace_period` field in `pingone_application`, resource and data source
- CDI-1367

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 go test -v -timeout 3000s -run ^TestAccApplication_ github.com/pingidentity/terraform-provider-pingone/internal/service/sso
```

### Testing Results
Some failures due to env vars or environments missing from my local setup
<!-- Use the following shell block to paste the results from the testing command(s) used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccApplication_RemovalDrift
=== PAUSE TestAccApplication_RemovalDrift
=== RUN   TestAccApplication_NewEnv
=== PAUSE TestAccApplication_NewEnv
=== RUN   TestAccApplication_OIDCFullWeb
=== PAUSE TestAccApplication_OIDCFullWeb
=== RUN   TestAccApplication_OIDCMinimalWeb
=== PAUSE TestAccApplication_OIDCMinimalWeb
=== RUN   TestAccApplication_OIDCWebUpdate
=== PAUSE TestAccApplication_OIDCWebUpdate
=== RUN   TestAccApplication_OIDCFullNative
=== PAUSE TestAccApplication_OIDCFullNative
=== RUN   TestAccApplication_OIDCMinimalNative
=== PAUSE TestAccApplication_OIDCMinimalNative
=== RUN   TestAccApplication_OIDCNativeUpdate
=== PAUSE TestAccApplication_OIDCNativeUpdate
=== RUN   TestAccApplication_NativeKerberos
=== PAUSE TestAccApplication_NativeKerberos
=== RUN   TestAccApplication_NativeMobile
=== PAUSE TestAccApplication_NativeMobile
=== RUN   TestAccApplication_NativeMobile_IntegrityDetection
=== PAUSE TestAccApplication_NativeMobile_IntegrityDetection
=== RUN   TestAccApplication_OIDCFullCustom
=== PAUSE TestAccApplication_OIDCFullCustom
=== RUN   TestAccApplication_OIDCMinimalCustom
=== PAUSE TestAccApplication_OIDCMinimalCustom
=== RUN   TestAccApplication_OIDCCustomUpdate
=== PAUSE TestAccApplication_OIDCCustomUpdate
=== RUN   TestAccApplication_OIDCCustom_Device
=== PAUSE TestAccApplication_OIDCCustom_Device
=== RUN   TestAccApplication_OIDCFullService
=== PAUSE TestAccApplication_OIDCFullService
=== RUN   TestAccApplication_OIDCMinimalService
=== PAUSE TestAccApplication_OIDCMinimalService
=== RUN   TestAccApplication_OIDCServiceUpdate
=== PAUSE TestAccApplication_OIDCServiceUpdate
=== RUN   TestAccApplication_OIDCFullSPA
=== PAUSE TestAccApplication_OIDCFullSPA
=== RUN   TestAccApplication_OIDCMinimalSPA
=== PAUSE TestAccApplication_OIDCMinimalSPA
=== RUN   TestAccApplication_OIDCSPAUpdate
=== PAUSE TestAccApplication_OIDCSPAUpdate
=== RUN   TestAccApplication_OIDCFullWorker
=== PAUSE TestAccApplication_OIDCFullWorker
=== RUN   TestAccApplication_OIDCMinimalWorker
=== PAUSE TestAccApplication_OIDCMinimalWorker
=== RUN   TestAccApplication_OIDCWorkerUpdate
=== PAUSE TestAccApplication_OIDCWorkerUpdate
=== RUN   TestAccApplication_OIDC_WildcardInRedirectURI
=== PAUSE TestAccApplication_OIDC_WildcardInRedirectURI
=== RUN   TestAccApplication_OIDC_LocalhostAddresses
=== PAUSE TestAccApplication_OIDC_LocalhostAddresses
=== RUN   TestAccApplication_OIDC_NativeAppAddresses
=== PAUSE TestAccApplication_OIDC_NativeAppAddresses
=== RUN   TestAccApplication_OIDC_JwtTokenAuth
=== PAUSE TestAccApplication_OIDC_JwtTokenAuth
=== RUN   TestAccApplication_SAMLFull
=== PAUSE TestAccApplication_SAMLFull
=== RUN   TestAccApplication_SAMLMinimal
=== PAUSE TestAccApplication_SAMLMinimal
=== RUN   TestAccApplication_SAMLVirtualServerIdSettingsOrdering
=== PAUSE TestAccApplication_SAMLVirtualServerIdSettingsOrdering
=== RUN   TestAccApplication_ExternalLinkFull
=== PAUSE TestAccApplication_ExternalLinkFull
=== RUN   TestAccApplication_ExternalLinkMinimal
=== PAUSE TestAccApplication_ExternalLinkMinimal
=== RUN   TestAccApplication_WSFedFull
=== PAUSE TestAccApplication_WSFedFull
=== RUN   TestAccApplication_WSFedMinimal
=== PAUSE TestAccApplication_WSFedMinimal
=== RUN   TestAccApplication_WSFedMinimalMaximal
=== PAUSE TestAccApplication_WSFedMinimalMaximal
=== RUN   TestAccApplication_Enabled
=== PAUSE TestAccApplication_Enabled
=== RUN   TestAccApplication_BadParameters
=== PAUSE TestAccApplication_BadParameters
=== CONT  TestAccApplication_RemovalDrift
=== CONT  TestAccApplication_OIDCMinimalSPA
=== CONT  TestAccApplication_SAMLMinimal
=== CONT  TestAccApplication_OIDC_WildcardInRedirectURI
=== CONT  TestAccApplication_OIDCMinimalWorker
=== CONT  TestAccApplication_SAMLFull
=== CONT  TestAccApplication_WSFedFull
=== CONT  TestAccApplication_Enabled
=== CONT  TestAccApplication_OIDCFullSPA
=== CONT  TestAccApplication_OIDC_NativeAppAddresses
=== CONT  TestAccApplication_ExternalLinkMinimal
=== CONT  TestAccApplication_OIDCWorkerUpdate
=== CONT  TestAccApplication_NativeMobile_IntegrityDetection
=== CONT  TestAccApplication_OIDCFullWorker
=== NAME  TestAccApplication_SAMLFull
    acctest.go:272: PINGONE_KEY_PEM_CERT is missing and must be set
--- FAIL: TestAccApplication_SAMLFull (0.00s)
=== CONT  TestAccApplication_OIDCServiceUpdate
=== CONT  TestAccApplication_ExternalLinkFull
=== CONT  TestAccApplication_OIDC_JwtTokenAuth
=== NAME  TestAccApplication_SAMLMinimal
    acctest.go:272: PINGONE_KEY_PEM_CERT is missing and must be set
--- FAIL: TestAccApplication_SAMLMinimal (0.00s)
=== CONT  TestAccApplication_OIDCMinimalService
=== NAME  TestAccApplication_NativeMobile_IntegrityDetection
    acctest.go:278: PINGONE_GOOGLE_JSON_KEY is missing and must be set
--- FAIL: TestAccApplication_NativeMobile_IntegrityDetection (0.00s)
=== CONT  TestAccApplication_OIDCFullService
--- PASS: TestAccApplication_OIDC_NativeAppAddresses (14.97s)
=== CONT  TestAccApplication_OIDCCustom_Device
--- PASS: TestAccApplication_OIDCMinimalSPA (15.55s)
=== CONT  TestAccApplication_OIDCCustomUpdate
--- PASS: TestAccApplication_OIDCMinimalWorker (16.24s)
=== CONT  TestAccApplication_OIDCMinimalCustom
--- PASS: TestAccApplication_OIDC_WildcardInRedirectURI (17.14s)
=== CONT  TestAccApplication_OIDCFullCustom
--- PASS: TestAccApplication_ExternalLinkMinimal (17.24s)
=== CONT  TestAccApplication_NativeMobile
--- PASS: TestAccApplication_OIDCFullWorker (18.26s)
=== CONT  TestAccApplication_NativeKerberos
--- PASS: TestAccApplication_OIDCMinimalService (19.16s)
=== CONT  TestAccApplication_OIDCNativeUpdate
--- PASS: TestAccApplication_OIDCFullService (19.45s)
=== CONT  TestAccApplication_OIDCMinimalNative
--- PASS: TestAccApplication_OIDCFullSPA (23.95s)
=== CONT  TestAccApplication_OIDCFullNative
=== NAME  TestAccApplication_NativeKerberos
    resource_application_test.go:867: Step 1/22, expected an error with pattern, no match on: Error running pre-apply plan: exit status 1

        Error: Cannot find environment from name

          with data.pingone_environment.workforce_test,
          on terraform_plugin_test.tf line 13, in data "pingone_environment" "workforce_test":
          13: 		data "pingone_environment" "workforce_test" {

        The environment "tf-testacc-static-workforce-test" cannot be found
--- FAIL: TestAccApplication_NativeKerberos (7.25s)
=== CONT  TestAccApplication_OIDCWebUpdate
--- PASS: TestAccApplication_ExternalLinkFull (28.38s)
=== CONT  TestAccApplication_OIDCMinimalWeb
--- PASS: TestAccApplication_OIDCMinimalCustom (13.75s)
=== CONT  TestAccApplication_OIDCFullWeb
--- PASS: TestAccApplication_OIDCServiceUpdate (35.09s)
=== CONT  TestAccApplication_NewEnv
--- PASS: TestAccApplication_OIDCWorkerUpdate (37.45s)
=== CONT  TestAccApplication_WSFedMinimalMaximal
--- PASS: TestAccApplication_OIDCMinimalNative (19.37s)
=== CONT  TestAccApplication_OIDCSPAUpdate
=== CONT  TestAccApplication_WSFedMinimal
--- PASS: TestAccApplication_Enabled (39.41s)
--- PASS: TestAccApplication_OIDCFullCustom (22.64s)
=== CONT  TestAccApplication_OIDC_LocalhostAddresses
--- PASS: TestAccApplication_OIDCFullNative (17.55s)
=== CONT  TestAccApplication_BadParameters
--- PASS: TestAccApplication_OIDCMinimalWeb (14.75s)
=== CONT  TestAccApplication_SAMLVirtualServerIdSettingsOrdering
    acctest.go:272: PINGONE_KEY_PEM_CERT is missing and must be set
--- FAIL: TestAccApplication_SAMLVirtualServerIdSettingsOrdering (0.00s)
--- PASS: TestAccApplication_OIDCFullWeb (19.66s)
--- PASS: TestAccApplication_OIDCCustomUpdate (38.27s)
--- PASS: TestAccApplication_WSFedFull (58.73s)
--- PASS: TestAccApplication_OIDCNativeUpdate (39.81s)
--- PASS: TestAccApplication_BadParameters (18.23s)
--- PASS: TestAccApplication_OIDCWebUpdate (35.73s)
--- PASS: TestAccApplication_OIDCSPAUpdate (25.36s)
--- PASS: TestAccApplication_OIDC_LocalhostAddresses (25.04s)
--- PASS: TestAccApplication_OIDCCustom_Device (54.52s)
--- PASS: TestAccApplication_NativeMobile (62.79s)
--- PASS: TestAccApplication_WSFedMinimalMaximal (43.42s)
--- PASS: TestAccApplication_NewEnv (46.11s)
--- PASS: TestAccApplication_OIDC_JwtTokenAuth (83.40s)
--- PASS: TestAccApplication_WSFedMinimal (48.26s)
--- PASS: TestAccApplication_RemovalDrift (97.16s)
FAIL
FAIL	github.com/pingidentity/terraform-provider-pingone/internal/service/sso	97.851s
```

</details>
