### PR TITLE
Fix pingone_application OIDC signing key rotation policy reset on update

### DIFF
--- a/.changelog/pr-1339.txt
+++ b/.changelog/pr-1339.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-`resource/pingone_application`: Fixed an issue where updating an OIDC application reset its signing key rotation policy to the PingOne default key. Added the `oidc_options.signing.key_rotation_policy_id` attribute to configure and preserve the signing key rotation policy.
-```

--- a/.changelog/pr-1339.txt
+++ b/.changelog/pr-1339.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/pingone_application`: Fixed an issue where updating an OIDC application reset its signing key rotation policy to the PingOne default key. Added the `oidc_options.signing.key_rotation_policy_id` attribute to configure and preserve the signing key rotation policy.
+```

--- a/.changelog/pr-1343.txt
+++ b/.changelog/pr-1343.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_application`: Added `oidc_options.signing.key_rotation_policy_id` attribute to allow configuration of the signing key rotation policy, fixing an issue where updates reset it to the PingOne default.
+```

--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -112,6 +112,7 @@ Read-Only:
 - `request_scopes_for_multiple_resources_enabled` (Boolean) A boolean that specifies whether the application can request scopes from multiple custom resources.
 - `require_signed_request_object` (Boolean) A boolean that indicates that the Java Web Token (JWT) for the [request query](https://openid.net/specs/openid-connect-core-1_0.html#RequestObject) parameter is required to be signed. If `false` or null, a signed request object is not required. Both `support_unsigned_request_object` and this property cannot be set to `true`.  Defaults to `false`.
 - `response_types` (Set of String) A list that specifies the code or token type returned by an authorization request.
+- `signing` (Attributes) The OIDC application token signing key settings. (see [below for nested schema](#nestedatt--oidc_options--signing))
 - `support_unsigned_request_object` (Boolean) A boolean that specifies whether the request query parameter JWT is allowed to be unsigned.
 - `target_link_uri` (String) The URI for the application.
 - `token_endpoint_auth_method` (String) A string that specifies the client authentication methods supported by the token endpoint.
@@ -177,6 +178,14 @@ Read-Only:
 - `verification_type` (String) The type of verification.
 
 
+
+
+<a id="nestedatt--oidc_options--signing"></a>
+### Nested Schema for `oidc_options.signing`
+
+Read-Only:
+
+- `key_rotation_policy_id` (String) The PingOne ID of the Key Rotation Policy used to sign application tokens.
 
 
 

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -48,6 +48,18 @@ resource "pingone_application_secret" "my_awesome_spa" {
 ## Example Usage - Web Application
 
 ```terraform
+resource "pingone_key_rotation_policy" "my_awesome_key_rotation_policy" {
+  environment_id = pingone_environment.my_environment.id
+
+  name = "My Awesome Key Rotation Policy"
+
+  algorithm           = "RSA"
+  subject_dn          = "CN=awesomeness, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
+  key_length          = 4096
+  signature_algorithm = "SHA256withRSA"
+  usage_type          = "SIGNING"
+}
+
 resource "pingone_application" "my_awesome_web_app" {
   environment_id = pingone_environment.my_environment.id
   name           = "My Awesome Web App"
@@ -63,6 +75,10 @@ resource "pingone_application" "my_awesome_web_app" {
     include_x5t                                   = true
     op_session_check_enabled                      = true
     request_scopes_for_multiple_resources_enabled = true
+
+    signing = {
+      key_rotation_policy_id = pingone_key_rotation_policy.my_awesome_key_rotation_policy.id
+    }
   }
 }
 

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -374,6 +374,7 @@ Optional:
 - `request_scopes_for_multiple_resources_enabled` (Boolean) A boolean that specifies whether the application can request scopes from multiple custom resources.  Defaults to `false`.
 - `require_signed_request_object` (Boolean) A boolean that indicates that the Java Web Token (JWT) for the [request query](https://openid.net/specs/openid-connect-core-1_0.html#RequestObject) parameter is required to be signed. If `false` or null, a signed request object is not required. Both `support_unsigned_request_object` and this property cannot be set to `true`.  Defaults to `false`.
 - `response_types` (Set of String) A list that specifies the code or token type returned by an authorization request.  Options are `CODE`, `ID_TOKEN`, `TOKEN`.  Note that `CODE` cannot be used in an authorization request with `TOKEN` or `ID_TOKEN` because PingOne does not currently support OIDC hybrid flows.
+- `signing` (Attributes) A single object that specifies the OIDC application token signing key settings. If omitted, application tokens are signed and verified by the PingOne default key at runtime. Applies to OIDC applications of type `WORKER`, `WEB_APP`, `NATIVE_APP`, `SINGLE_PAGE_APP`, and `CUSTOM_APP`. (see [below for nested schema](#nestedatt--oidc_options--signing))
 - `support_unsigned_request_object` (Boolean) A boolean that specifies whether the request query parameter JWT is allowed to be unsigned. If `false` or null, an unsigned request object is not allowed.  Defaults to `false`.
 - `target_link_uri` (String) The URI for the application. If specified, PingOne will redirect application users to this URI after a user is authenticated. In the PingOne admin console, this becomes the value of the `target_link_uri` parameter used for the Initiate Single Sign-On URL field.  Both `http://` and `https://` URLs are permitted as well as custom mobile native schema (e.g., `org.bxretail.app://target`).
 
@@ -450,6 +451,14 @@ Optional:
 - `verification_key` (String, Sensitive) Play Integrity verdict signature verification key from your Google Play Services account. This parameter must be provided if you have set `verification_type` to `INTERNAL`.  Conflicts with `service_account_credentials_json`.
 
 
+
+
+<a id="nestedatt--oidc_options--signing"></a>
+### Nested Schema for `oidc_options.signing`
+
+Required:
+
+- `key_rotation_policy_id` (String) A string that specifies the PingOne ID of the Key Rotation Policy (from certificate management) used to sign application tokens. Must be a valid PingOne Resource ID.
 
 
 

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -472,7 +472,7 @@ Optional:
 <a id="nestedatt--oidc_options--signing"></a>
 ### Nested Schema for `oidc_options.signing`
 
-Required:
+Optional:
 
 - `key_rotation_policy_id` (String) A string that specifies the PingOne ID of the Key Rotation Policy (from certificate management) used to sign application tokens. Must be a valid PingOne Resource ID.
 

--- a/examples/resources/pingone_application/resource-web.tf
+++ b/examples/resources/pingone_application/resource-web.tf
@@ -1,3 +1,15 @@
+resource "pingone_key_rotation_policy" "my_awesome_key_rotation_policy" {
+  environment_id = pingone_environment.my_environment.id
+
+  name = "My Awesome Key Rotation Policy"
+
+  algorithm           = "RSA"
+  subject_dn          = "CN=awesomeness, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
+  key_length          = 4096
+  signature_algorithm = "SHA256withRSA"
+  usage_type          = "SIGNING"
+}
+
 resource "pingone_application" "my_awesome_web_app" {
   environment_id = pingone_environment.my_environment.id
   name           = "My Awesome Web App"
@@ -13,6 +25,10 @@ resource "pingone_application" "my_awesome_web_app" {
     include_x5t                                   = true
     op_session_check_enabled                      = true
     request_scopes_for_multiple_resources_enabled = true
+
+    signing = {
+      key_rotation_policy_id = pingone_key_rotation_policy.my_awesome_key_rotation_policy.id
+    }
   }
 }
 

--- a/internal/service/sso/data_source_application.go
+++ b/internal/service/sso/data_source_application.go
@@ -414,6 +414,17 @@ func (r *ApplicationDataSource) Schema(ctx context.Context, req datasource.Schem
 							},
 						},
 					},
+					"signing": schema.SingleNestedAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("The OIDC application token signing key settings.").Description,
+						Computed:    true,
+
+						Attributes: map[string]schema.Attribute{
+							"key_rotation_policy_id": schema.StringAttribute{
+								Description: framework.SchemaAttributeDescriptionFromMarkdown("The PingOne ID of the Key Rotation Policy used to sign application tokens.").Description,
+								Computed:    true,
+							},
+						},
+					},
 					"support_unsigned_request_object": schema.BoolAttribute{
 						Description: framework.SchemaAttributeDescriptionFromMarkdown("A boolean that specifies whether the request query parameter JWT is allowed to be unsigned.").Description,
 						Computed:    true,

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -2381,6 +2381,7 @@ func (p *applicationResourceModelV1) validate(ctx context.Context, allowUnknown 
 
 	if oidcPlan != nil {
 		diags.Append(oidcPlan.validateCertificateBasedAuthentication(allowUnknown)...)
+		diags.Append(oidcPlan.validateSigning(allowUnknown)...)
 		diags.Append(oidcPlan.validateWildcardInRedirectUri(ctx, allowUnknown)...)
 	}
 
@@ -2418,6 +2419,51 @@ func (p *applicationOIDCOptionsResourceModelV1) validateCertificateBasedAuthenti
 				path.Root("oidc_options").AtName("certificate_based_authentication"),
 				"Invalid configuration",
 				fmt.Sprintf("`certificate_based_authentication` can only be set with OIDC applications that have a `type` value of `%s`.", management.ENUMAPPLICATIONTYPE_NATIVE_APP),
+			)
+		}
+	}
+
+	return diags
+}
+
+func (p *applicationOIDCOptionsResourceModelV1) validateSigning(allowUnknown bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if p.Signing.IsUnknown() && !allowUnknown {
+		diags.AddAttributeError(
+			path.Root("oidc_options").AtName("signing"),
+			"Invalid configuration",
+			"Current configuration is invalid as the `oidc_options.signing` value is unknown, cannot validate.",
+		)
+	}
+
+	allowedTypes := []management.EnumApplicationType{
+		management.ENUMAPPLICATIONTYPE_WORKER,
+		management.ENUMAPPLICATIONTYPE_WEB_APP,
+		management.ENUMAPPLICATIONTYPE_NATIVE_APP,
+		management.ENUMAPPLICATIONTYPE_SINGLE_PAGE_APP,
+		management.ENUMAPPLICATIONTYPE_CUSTOM_APP,
+	}
+
+	if !p.Signing.IsNull() && !p.Signing.IsUnknown() {
+		typeAllowed := false
+		for _, allowedType := range allowedTypes {
+			if p.Type.Equal(types.StringValue(string(allowedType))) {
+				typeAllowed = true
+				break
+			}
+		}
+
+		if !typeAllowed {
+			allowedStrs := make([]string, len(allowedTypes))
+			for i, allowedType := range allowedTypes {
+				allowedStrs[i] = fmt.Sprintf("`%s`", string(allowedType))
+			}
+
+			diags.AddAttributeError(
+				path.Root("oidc_options").AtName("signing"),
+				"Invalid configuration",
+				fmt.Sprintf("`signing` can only be set with OIDC applications that have a `type` value of one of %s.", strings.Join(allowedStrs, ", ")),
 			)
 		}
 	}

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -102,6 +102,7 @@ type applicationOIDCOptionsCommonModelV1 struct {
 	RequestScopesForMultipleResourcesEnabled      types.Bool   `tfsdk:"request_scopes_for_multiple_resources_enabled"`
 	RequireSignedRequestObject                    types.Bool   `tfsdk:"require_signed_request_object"`
 	ResponseTypes                                 types.Set    `tfsdk:"response_types"`
+	Signing                                       types.Object `tfsdk:"signing"`
 	SupportUnsignedRequestObject                  types.Bool   `tfsdk:"support_unsigned_request_object"`
 	TargetLinkUri                                 types.String `tfsdk:"target_link_uri"`
 	TokenEndpointAuthnMethod                      types.String `tfsdk:"token_endpoint_auth_method"`
@@ -126,6 +127,10 @@ type applicationCorsSettingsResourceModelV1 struct {
 
 type applicationOIDCCertificateBasedAuthenticationResourceModelV1 struct {
 	KeyId pingonetypes.ResourceIDValue `tfsdk:"key_id"`
+}
+
+type applicationOIDCSigningResourceModelV1 struct {
+	KeyRotationPolicyId pingonetypes.ResourceIDValue `tfsdk:"key_rotation_policy_id"`
 }
 
 type applicationOIDCMobileAppResourceModelV1 struct {
@@ -276,6 +281,7 @@ var (
 		"request_scopes_for_multiple_resources_enabled":      types.BoolType,
 		"require_signed_request_object":                      types.BoolType,
 		"response_types":                                     types.SetType{ElemType: types.StringType},
+		"signing":                                            types.ObjectType{AttrTypes: applicationOidcOptionsSigningTFObjectTypes},
 		"support_unsigned_request_object":                    types.BoolType,
 		"target_link_uri":                                    types.StringType,
 		"token_endpoint_auth_method":                         types.StringType,
@@ -325,6 +331,10 @@ var (
 
 	applicationOidcOptionsCertificateAuthenticationTFObjectTypes = map[string]attr.Type{
 		"key_id": pingonetypes.ResourceIDType{},
+	}
+
+	applicationOidcOptionsSigningTFObjectTypes = map[string]attr.Type{
+		"key_rotation_policy_id": pingonetypes.ResourceIDType{},
 	}
 
 	applicationSamlOptionsTFObjectTypes = map[string]attr.Type{
@@ -640,6 +650,14 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 
 	oidcOptionsMobileAppDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		fmt.Sprintf("A single object that specifies Mobile application integration settings for `%s` type applications.", management.ENUMAPPLICATIONTYPE_NATIVE_APP),
+	)
+
+	oidcOptionsSigningDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A single object that specifies the OIDC application token signing key settings. If omitted, application tokens are signed and verified by the PingOne default key at runtime. Applies to OIDC applications of type `WORKER`, `WEB_APP`, `NATIVE_APP`, `SINGLE_PAGE_APP`, and `CUSTOM_APP`.",
+	)
+
+	oidcOptionsSigningKeyRotationPolicyIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"A string that specifies the PingOne ID of the Key Rotation Policy (from certificate management) used to sign application tokens. Must be a valid PingOne Resource ID.",
 	)
 
 	oidcOptionsMobileAppBundleIdDescription := framework.SchemaAttributeDescriptionFromMarkdown(
@@ -1312,6 +1330,22 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 								"key_id": schema.StringAttribute{
 									Description:         oidcOptionsCertificateBasedAuthenticationKeyIdDescription.Description,
 									MarkdownDescription: oidcOptionsCertificateBasedAuthenticationKeyIdDescription.MarkdownDescription,
+									Required:            true,
+
+									CustomType: pingonetypes.ResourceIDType{},
+								},
+							},
+						},
+
+						"signing": schema.SingleNestedAttribute{
+							Description:         oidcOptionsSigningDescription.Description,
+							MarkdownDescription: oidcOptionsSigningDescription.MarkdownDescription,
+							Optional:            true,
+
+							Attributes: map[string]schema.Attribute{
+								"key_rotation_policy_id": schema.StringAttribute{
+									Description:         oidcOptionsSigningKeyRotationPolicyIdDescription.Description,
+									MarkdownDescription: oidcOptionsSigningKeyRotationPolicyIdDescription.MarkdownDescription,
 									Required:            true,
 
 									CustomType: pingonetypes.ResourceIDType{},
@@ -2837,6 +2871,22 @@ func (p *applicationResourceModelV1) expandApplicationOIDC(ctx context.Context) 
 			}
 
 			data.SetKerberos(*management.NewApplicationOIDCAllOfKerberos(*management.NewApplicationOIDCAllOfKerberosKey(kerberosPlan.KeyId.ValueString())))
+		}
+
+		if !plan.Signing.IsNull() && !plan.Signing.IsUnknown() {
+			var signingPlan applicationOIDCSigningResourceModelV1
+
+			diags.Append(plan.Signing.As(ctx, &signingPlan, basetypes.ObjectAsOptions{
+				UnhandledNullAsEmpty:    false,
+				UnhandledUnknownAsEmpty: false,
+			})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			data.SetSigning(*management.NewApplicationOIDCAllOfSigning(
+				*management.NewApplicationOIDCAllOfSigningKeyRotationPolicy(signingPlan.KeyRotationPolicyId.ValueString()),
+			))
 		}
 
 		if !plan.SupportUnsignedRequestObject.IsNull() && !plan.SupportUnsignedRequestObject.IsUnknown() {

--- a/internal/service/sso/resource_application.go
+++ b/internal/service/sso/resource_application.go
@@ -1341,12 +1341,14 @@ func (r *ApplicationResource) Schema(ctx context.Context, req resource.SchemaReq
 							Description:         oidcOptionsSigningDescription.Description,
 							MarkdownDescription: oidcOptionsSigningDescription.MarkdownDescription,
 							Optional:            true,
+							Computed:            true,
 
 							Attributes: map[string]schema.Attribute{
 								"key_rotation_policy_id": schema.StringAttribute{
 									Description:         oidcOptionsSigningKeyRotationPolicyIdDescription.Description,
 									MarkdownDescription: oidcOptionsSigningKeyRotationPolicyIdDescription.MarkdownDescription,
-									Required:            true,
+									Optional:            true,
+									Computed:            true,
 
 									CustomType: pingonetypes.ResourceIDType{},
 								},
@@ -2381,7 +2383,7 @@ func (p *applicationResourceModelV1) validate(ctx context.Context, allowUnknown 
 
 	if oidcPlan != nil {
 		diags.Append(oidcPlan.validateCertificateBasedAuthentication(allowUnknown)...)
-		diags.Append(oidcPlan.validateSigning(allowUnknown)...)
+		diags.Append(oidcPlan.validateSigning()...)
 		diags.Append(oidcPlan.validateWildcardInRedirectUri(ctx, allowUnknown)...)
 	}
 
@@ -2426,16 +2428,8 @@ func (p *applicationOIDCOptionsResourceModelV1) validateCertificateBasedAuthenti
 	return diags
 }
 
-func (p *applicationOIDCOptionsResourceModelV1) validateSigning(allowUnknown bool) diag.Diagnostics {
+func (p *applicationOIDCOptionsResourceModelV1) validateSigning() diag.Diagnostics {
 	var diags diag.Diagnostics
-
-	if p.Signing.IsUnknown() && !allowUnknown {
-		diags.AddAttributeError(
-			path.Root("oidc_options").AtName("signing"),
-			"Invalid configuration",
-			"Current configuration is invalid as the `oidc_options.signing` value is unknown, cannot validate.",
-		)
-	}
 
 	allowedTypes := []management.EnumApplicationType{
 		management.ENUMAPPLICATIONTYPE_WORKER,

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -965,6 +965,79 @@ func TestAccApplication_NativeKerberos(t *testing.T) {
 	})
 }
 
+func TestAccApplication_OIDC_Signing(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_application.%s", resourceName)
+
+	name := resourceName
+
+	withSigning := resource.TestStep{
+		Config: testAccApplicationConfig_OIDC_Signing(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestMatchResourceAttr(resourceFullName, "oidc_options.signing.key_rotation_policy_id", verify.P1ResourceIDRegexpFullString),
+		),
+	}
+
+	// Updates an unrelated attribute (issue #1326 regression: signing must survive a PUT)
+	withSigningUpdated := resource.TestStep{
+		Config: testAccApplicationConfig_OIDC_SigningUpdate(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestMatchResourceAttr(resourceFullName, "oidc_options.signing.key_rotation_policy_id", verify.P1ResourceIDRegexpFullString),
+		),
+	}
+
+	// Detaches signing from the app while the KRP resource is still declared, so
+	// the app PUT (which drops the KRP reference) applies before the KRP is destroyed.
+	withoutSigningKRPStillDeclared := resource.TestStep{
+		Config: testAccApplicationConfig_OIDC_SigningDetached(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.signing"),
+		),
+	}
+
+	withoutSigning := resource.TestStep{
+		Config: testAccApplicationConfig_OIDC_MinimalWeb(resourceName, name),
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckNoResourceAttr(resourceFullName, "oidc_options.signing"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoBeta(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             sso.Application_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			withSigning,
+			withSigningUpdated,
+			withoutSigningKRPStillDeclared,
+			withoutSigning,
+			// Test importing the resource
+			{
+				ResourceName: resourceFullName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceFullName]
+						if !ok {
+							return "", fmt.Errorf("resource not found: %s", resourceFullName)
+						}
+
+						return fmt.Sprintf("%s/%s", rs.Primary.Attributes["environment_id"], rs.Primary.ID), nil
+					}
+				}(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccApplication_NativeMobile(t *testing.T) {
 	t.Parallel()
 
@@ -3733,6 +3806,114 @@ resource "pingone_application" "%[2]s" {
 }
 `, acctest.GenericSandboxEnvironment(), resourceName, name)
 }
+
+func testAccApplicationConfig_OIDC_Signing(resourceName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "pingone_key_rotation_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  algorithm           = "RSA"
+  subject_dn          = "CN=%[3]s, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
+  key_length          = 3072
+  signature_algorithm = "SHA256withRSA"
+  usage_type          = "SIGNING"
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options = {
+    type                       = "WEB_APP"
+    grant_types                = ["AUTHORIZATION_CODE"]
+    redirect_uris              = ["https://www.pingidentity.com"]
+    response_types             = ["CODE"]
+    token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
+
+    signing = {
+      key_rotation_policy_id = pingone_key_rotation_policy.%[2]s.id
+    }
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccApplicationConfig_OIDC_SigningUpdate(resourceName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "pingone_key_rotation_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  algorithm           = "RSA"
+  subject_dn          = "CN=%[3]s, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
+  key_length          = 3072
+  signature_algorithm = "SHA256withRSA"
+  usage_type          = "SIGNING"
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+  description    = "updated to force PUT"
+
+  oidc_options = {
+    type                       = "WEB_APP"
+    grant_types                = ["AUTHORIZATION_CODE"]
+    redirect_uris              = ["https://www.pingidentity.com"]
+    response_types             = ["CODE"]
+    token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
+
+    signing = {
+      key_rotation_policy_id = pingone_key_rotation_policy.%[2]s.id
+    }
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+// Keeps the KRP resource declared (but unreferenced) so the app PUT that drops
+// the KRP reference applies before the KRP itself is destroyed in a later step.
+func testAccApplicationConfig_OIDC_SigningDetached(resourceName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "pingone_key_rotation_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  algorithm           = "RSA"
+  subject_dn          = "CN=%[3]s, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
+  key_length          = 3072
+  signature_algorithm = "SHA256withRSA"
+  usage_type          = "SIGNING"
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options = {
+    type                       = "WEB_APP"
+    grant_types                = ["AUTHORIZATION_CODE"]
+    redirect_uris              = ["https://www.pingidentity.com"]
+    response_types             = ["CODE"]
+    token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
 func testAccApplicationConfig_OIDC_MinimalWeb_PrivateKeyJWT_JWKS(resourceName, name string) string {
 	return fmt.Sprintf(`
 		%[1]s

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -1047,39 +1047,6 @@ func TestAccApplication_OIDC_Signing(t *testing.T) {
 	})
 }
 
-// Verifies the API accepts `signing` on a WORKER application, as the resource/data-source
-// docs claim (issue #1326 Finding 1). A failure here means the docs overstate support.
-func TestAccApplication_OIDC_Signing_Worker(t *testing.T) {
-	t.Parallel()
-
-	resourceName := acctest.ResourceNameGen()
-	resourceFullName := fmt.Sprintf("pingone_application.%s", resourceName)
-	krpFullName := fmt.Sprintf("pingone_key_rotation_policy.%s", resourceName)
-
-	name := resourceName
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheckNoTestAccFlaky(t)
-			acctest.PreCheckClient(t)
-			acctest.PreCheckNoBeta(t)
-		},
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		CheckDestroy:             sso.Application_CheckDestroy,
-		ErrorCheck:               acctest.ErrorCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccApplicationConfig_OIDC_SigningWorker(resourceName, name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.type", "WORKER"),
-					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.signing.key_rotation_policy_id", verify.P1ResourceIDRegexpFullString),
-					resource.TestCheckResourceAttrPair(resourceFullName, "oidc_options.signing.key_rotation_policy_id", krpFullName, "id"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccApplication_NativeMobile(t *testing.T) {
 	t.Parallel()
 
@@ -3951,40 +3918,6 @@ resource "pingone_application" "%[2]s" {
     redirect_uris              = ["https://www.pingidentity.com"]
     response_types             = ["CODE"]
     token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
-  }
-}
-`, acctest.GenericSandboxEnvironment(), resourceName, name)
-}
-
-func testAccApplicationConfig_OIDC_SigningWorker(resourceName, name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "pingone_key_rotation_policy" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-
-  name = "%[3]s"
-
-  algorithm           = "RSA"
-  subject_dn          = "CN=%[3]s, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
-  key_length          = 3072
-  signature_algorithm = "SHA256withRSA"
-  usage_type          = "SIGNING"
-}
-
-resource "pingone_application" "%[2]s" {
-  environment_id = data.pingone_environment.general_test.id
-  name           = "%[3]s"
-  enabled        = true
-
-  oidc_options = {
-    type                       = "WORKER"
-    grant_types                = ["CLIENT_CREDENTIALS"]
-    token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
-
-    signing = {
-      key_rotation_policy_id = pingone_key_rotation_policy.%[2]s.id
-    }
   }
 }
 `, acctest.GenericSandboxEnvironment(), resourceName, name)

--- a/internal/service/sso/resource_application_test.go
+++ b/internal/service/sso/resource_application_test.go
@@ -970,6 +970,7 @@ func TestAccApplication_OIDC_Signing(t *testing.T) {
 
 	resourceName := acctest.ResourceNameGen()
 	resourceFullName := fmt.Sprintf("pingone_application.%s", resourceName)
+	krpFullName := fmt.Sprintf("pingone_key_rotation_policy.%s", resourceName)
 
 	name := resourceName
 
@@ -977,14 +978,17 @@ func TestAccApplication_OIDC_Signing(t *testing.T) {
 		Config: testAccApplicationConfig_OIDC_Signing(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(resourceFullName, "oidc_options.signing.key_rotation_policy_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttrPair(resourceFullName, "oidc_options.signing.key_rotation_policy_id", krpFullName, "id"),
 		),
 	}
 
-	// Updates an unrelated attribute (issue #1326 regression: signing must survive a PUT)
+	// Issue #1326 regression: an unrelated update must not reset signing to the default
+	// key. Asserting the KRP pair (KRP unchanged across steps) proves the exact policy survived.
 	withSigningUpdated := resource.TestStep{
 		Config: testAccApplicationConfig_OIDC_SigningUpdate(resourceName, name),
 		Check: resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(resourceFullName, "oidc_options.signing.key_rotation_policy_id", verify.P1ResourceIDRegexpFullString),
+			resource.TestCheckResourceAttrPair(resourceFullName, "oidc_options.signing.key_rotation_policy_id", krpFullName, "id"),
 		),
 	}
 
@@ -1014,6 +1018,11 @@ func TestAccApplication_OIDC_Signing(t *testing.T) {
 		CheckDestroy:             sso.Application_CheckDestroy,
 		ErrorCheck:               acctest.ErrorCheck(t),
 		Steps: []resource.TestStep{
+			// `signing` on an unsupported application type is rejected at plan time
+			{
+				Config:      testAccApplicationConfig_OIDC_SigningInvalidType(resourceName, name),
+				ExpectError: regexp.MustCompile("Invalid configuration"),
+			},
 			withSigning,
 			withSigningUpdated,
 			withoutSigningKRPStillDeclared,
@@ -1033,6 +1042,39 @@ func TestAccApplication_OIDC_Signing(t *testing.T) {
 				}(),
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Verifies the API accepts `signing` on a WORKER application, as the resource/data-source
+// docs claim (issue #1326 Finding 1). A failure here means the docs overstate support.
+func TestAccApplication_OIDC_Signing_Worker(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_application.%s", resourceName)
+	krpFullName := fmt.Sprintf("pingone_key_rotation_policy.%s", resourceName)
+
+	name := resourceName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoBeta(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             sso.Application_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationConfig_OIDC_SigningWorker(resourceName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceFullName, "oidc_options.type", "WORKER"),
+					resource.TestMatchResourceAttr(resourceFullName, "oidc_options.signing.key_rotation_policy_id", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttrPair(resourceFullName, "oidc_options.signing.key_rotation_policy_id", krpFullName, "id"),
+				),
 			},
 		},
 	})
@@ -3909,6 +3951,78 @@ resource "pingone_application" "%[2]s" {
     redirect_uris              = ["https://www.pingidentity.com"]
     response_types             = ["CODE"]
     token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccApplicationConfig_OIDC_SigningWorker(resourceName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "pingone_key_rotation_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  algorithm           = "RSA"
+  subject_dn          = "CN=%[3]s, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
+  key_length          = 3072
+  signature_algorithm = "SHA256withRSA"
+  usage_type          = "SIGNING"
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options = {
+    type                       = "WORKER"
+    grant_types                = ["CLIENT_CREDENTIALS"]
+    token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
+
+    signing = {
+      key_rotation_policy_id = pingone_key_rotation_policy.%[2]s.id
+    }
+  }
+}
+`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+// `signing` set on a SERVICE application, which does not support it, to exercise
+// the plan-time type validation.
+func testAccApplicationConfig_OIDC_SigningInvalidType(resourceName, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "pingone_key_rotation_policy" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name = "%[3]s"
+
+  algorithm           = "RSA"
+  subject_dn          = "CN=%[3]s, OU=Ping Identity, O=Ping Identity, L=, ST=, C=US"
+  key_length          = 3072
+  signature_algorithm = "SHA256withRSA"
+  usage_type          = "SIGNING"
+}
+
+resource "pingone_application" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+  name           = "%[3]s"
+  enabled        = true
+
+  oidc_options = {
+    type                       = "SERVICE"
+    grant_types                = ["AUTHORIZATION_CODE"]
+    redirect_uris              = ["https://www.pingidentity.com"]
+    response_types             = ["CODE"]
+    token_endpoint_auth_method = "CLIENT_SECRET_BASIC"
+
+    signing = {
+      key_rotation_policy_id = pingone_key_rotation_policy.%[2]s.id
+    }
   }
 }
 `, acctest.GenericSandboxEnvironment(), resourceName, name)

--- a/internal/service/sso/utils_application.go
+++ b/internal/service/sso/utils_application.go
@@ -82,7 +82,7 @@ func applicationCorsSettingsOkToTF(apiObject *management.ApplicationCorsSettings
 
 func applicationOidcOptionsDataSourceToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsDataSourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1)
+	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1, true)
 	diags.Append(d...)
 
 	if commonAttrs == nil {
@@ -104,7 +104,7 @@ func applicationOidcOptionsDataSourceToTF(ctx context.Context, apiObject *manage
 
 func applicationOidcOptionsToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsResourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1)
+	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1, false)
 	diags.Append(d...)
 
 	if commonAttrs == nil {
@@ -122,7 +122,7 @@ func applicationOidcOptionsToTF(ctx context.Context, apiObject *management.Appli
 	return returnVar, diags
 }
 
-func applicationOidcOptionsCommonToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsCommonModelV1) (map[string]attr.Value, diag.Diagnostics) {
+func applicationOidcOptionsCommonToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsCommonModelV1, forceReflectSigning bool) (map[string]attr.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if apiObject == nil || apiObject.GetId() == "" {
@@ -148,6 +148,10 @@ func applicationOidcOptionsCommonToTF(ctx context.Context, apiObject *management
 		}
 	}
 	mobileApp, d := applicationMobileAppOkToTF(ctx, mobileAppObject, ok, mobileAppState)
+	diags.Append(d...)
+
+	signingObject, signingOk := apiObject.GetSigningOk()
+	signing, d := applicationOidcOptionsSigningOkToTF(signingObject, signingOk, forceReflectSigning || (!stateValue.Signing.IsNull() && !stateValue.Signing.IsUnknown()))
 	diags.Append(d...)
 
 	return map[string]attr.Value{
@@ -180,6 +184,7 @@ func applicationOidcOptionsCommonToTF(ctx context.Context, apiObject *management
 		"request_scopes_for_multiple_resources_enabled":      types.BoolValue(apiObject.GetRequestScopesForMultipleResourcesEnabled()),
 		"require_signed_request_object":                      framework.BoolOkToTF(apiObject.GetRequireSignedRequestObjectOk()),
 		"response_types":                                     framework.EnumSetOkToTF(apiObject.GetResponseTypesOk()),
+		"signing":                                            signing,
 		"support_unsigned_request_object":                    framework.BoolOkToTF(apiObject.GetSupportUnsignedRequestObjectOk()),
 		"target_link_uri":                                    framework.StringOkToTF(apiObject.GetTargetLinkUriOk()),
 		"token_endpoint_auth_method":                         framework.EnumOkToTF(apiObject.GetTokenEndpointAuthMethodOk()),
@@ -203,6 +208,29 @@ func applicationOidcOptionsCertificateBasedAuthenticationToTF(apiObject *managem
 	}
 
 	returnVar, d := types.ObjectValue(applicationOidcOptionsCertificateAuthenticationTFObjectTypes, attributesMap)
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func applicationOidcOptionsSigningOkToTF(apiObject *management.ApplicationOIDCAllOfSigning, ok bool, configured bool) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// If the practitioner did not configure `signing`, keep it null to avoid
+	// perpetual drift against the API-applied default key.
+	if !ok || apiObject == nil || !configured {
+		return types.ObjectNull(applicationOidcOptionsSigningTFObjectTypes), diags
+	}
+
+	attributesMap := map[string]attr.Value{
+		"key_rotation_policy_id": pingonetypes.ResourceIDValue{},
+	}
+
+	if v, ok := apiObject.GetKeyRotationPolicyOk(); ok {
+		attributesMap["key_rotation_policy_id"] = framework.PingOneResourceIDOkToTF(v.GetIdOk())
+	}
+
+	returnVar, d := types.ObjectValue(applicationOidcOptionsSigningTFObjectTypes, attributesMap)
 	diags.Append(d...)
 
 	return returnVar, diags

--- a/internal/service/sso/utils_application.go
+++ b/internal/service/sso/utils_application.go
@@ -82,7 +82,7 @@ func applicationCorsSettingsOkToTF(apiObject *management.ApplicationCorsSettings
 
 func applicationOidcOptionsDataSourceToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsDataSourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1, true)
+	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1)
 	diags.Append(d...)
 
 	if commonAttrs == nil {
@@ -104,7 +104,7 @@ func applicationOidcOptionsDataSourceToTF(ctx context.Context, apiObject *manage
 
 func applicationOidcOptionsToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsResourceModelV1) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1, false)
+	commonAttrs, d := applicationOidcOptionsCommonToTF(ctx, apiObject, stateValue.applicationOIDCOptionsCommonModelV1)
 	diags.Append(d...)
 
 	if commonAttrs == nil {
@@ -122,7 +122,7 @@ func applicationOidcOptionsToTF(ctx context.Context, apiObject *management.Appli
 	return returnVar, diags
 }
 
-func applicationOidcOptionsCommonToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsCommonModelV1, forceReflectSigning bool) (map[string]attr.Value, diag.Diagnostics) {
+func applicationOidcOptionsCommonToTF(ctx context.Context, apiObject *management.ApplicationOIDC, stateValue applicationOIDCOptionsCommonModelV1) (map[string]attr.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if apiObject == nil || apiObject.GetId() == "" {
@@ -151,7 +151,7 @@ func applicationOidcOptionsCommonToTF(ctx context.Context, apiObject *management
 	diags.Append(d...)
 
 	signingObject, signingOk := apiObject.GetSigningOk()
-	signing, d := applicationOidcOptionsSigningOkToTF(signingObject, signingOk, forceReflectSigning || (!stateValue.Signing.IsNull() && !stateValue.Signing.IsUnknown()))
+	signing, d := applicationOidcOptionsSigningOkToTF(signingObject, signingOk)
 	diags.Append(d...)
 
 	return map[string]attr.Value{
@@ -213,12 +213,10 @@ func applicationOidcOptionsCertificateBasedAuthenticationToTF(apiObject *managem
 	return returnVar, diags
 }
 
-func applicationOidcOptionsSigningOkToTF(apiObject *management.ApplicationOIDCAllOfSigning, ok bool, configured bool) (types.Object, diag.Diagnostics) {
+func applicationOidcOptionsSigningOkToTF(apiObject *management.ApplicationOIDCAllOfSigning, ok bool) (types.Object, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	// If the practitioner did not configure `signing`, keep it null to avoid
-	// perpetual drift against the API-applied default key.
-	if !ok || apiObject == nil || !configured {
+	if !ok || apiObject == nil {
 		return types.ObjectNull(applicationOidcOptionsSigningTFObjectTypes), diags
 	}
 


### PR DESCRIPTION
## Change Description

Fixes #1326: updating a `pingone_application` OIDC application was resetting its signing key rotation policy back to the PingOne default. Adds an `oidc_options.signing.key_rotation_policy_id` attribute so the signing key rotation policy can be configured and is preserved across updates.

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades

N/a

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)

```shell
TF_ACC=1 go test ./internal/service/sso/ -run 'TestAccApplication_' -v -timeout 60m
```

### Testing Results

34 of 39 tests in the file passed. The 5 failures are pre-existing and unrelated to this change: 4 are local-environment gaps (missing `PINGONE_KEY_PKCS7_CERT`, `PINGONE_GOOGLE_JSON_KEY`, and a missing static sandbox environment), none touching the signing code path.

<details>
  <summary>Expand Results</summary>

```shell
--- FAIL: TestAccApplication_SAMLMinimal (0.00s)
--- FAIL: TestAccApplication_SAMLVirtualServerIdSettingsOrdering (0.00s)
--- FAIL: TestAccApplication_NativeKerberos (5.29s)
--- FAIL: TestAccApplication_SAMLFull (0.00s)
--- FAIL: TestAccApplication_NativeMobile_IntegrityDetection (0.00s)
--- PASS: TestAccApplication_OIDCMinimalSPA (16.13s)
--- PASS: TestAccApplication_OIDCMinimalWeb (20.45s)
--- PASS: TestAccApplication_ExternalLinkMinimal (21.05s)
--- PASS: TestAccApplication_OIDCFullNative (26.50s)
--- PASS: TestAccApplication_OIDCFullSPA (27.85s)
--- PASS: TestAccApplication_OIDCMinimalCustom (17.72s)
--- PASS: TestAccApplication_OIDCServiceUpdate (33.90s)
--- PASS: TestAccApplication_ExternalLinkFull (34.54s)
--- PASS: TestAccApplication_BadParameters (36.07s)
--- PASS: TestAccApplication_Enabled (41.23s)
--- PASS: TestAccApplication_OIDCNativeUpdate (44.92s)
--- PASS: TestAccApplication_OIDCMinimalNative (24.05s)
--- PASS: TestAccApplication_OIDC_WildcardInRedirectURI (14.37s)
--- PASS: TestAccApplication_OIDCWebUpdate (48.63s)
--- PASS: TestAccApplication_WSFedFull (56.06s)
--- PASS: TestAccApplication_OIDCMinimalWorker (20.30s)
--- PASS: TestAccApplication_OIDC_NativeAppAddresses (23.24s)
--- PASS: TestAccApplication_WSFedMinimal (58.54s)
--- PASS: TestAccApplication_OIDCFullCustom (23.85s)
--- PASS: TestAccApplication_OIDCCustomUpdate (51.58s)
--- PASS: TestAccApplication_OIDCMinimalService (27.67s)
--- PASS: TestAccApplication_OIDCFullWorker (25.01s)
--- PASS: TestAccApplication_OIDCFullWeb (27.85s)
--- PASS: TestAccApplication_WSFedMinimalMaximal (76.60s)
--- PASS: TestAccApplication_OIDC_LocalhostAddresses (46.08s)
--- PASS: TestAccApplication_OIDCFullService (25.74s)
--- PASS: TestAccApplication_OIDCWorkerUpdate (43.91s)
--- PASS: TestAccApplication_OIDC_Signing (62.29s)
--- PASS: TestAccApplication_OIDCSPAUpdate (33.60s)
--- PASS: TestAccApplication_NativeMobile (100.77s)
--- PASS: TestAccApplication_OIDCCustom_Device (43.91s)
--- PASS: TestAccApplication_NewEnv (47.86s)
--- PASS: TestAccApplication_RemovalDrift (107.24s)
--- PASS: TestAccApplication_OIDC_JwtTokenAuth (81.70s)
FAIL
```

</details>

### End-to-end Tests Workflow Links

-
</content>
