### PR TITLE
CDI-1454: Support custom error screen settings attributes in pingone_davinci_flow resource

### DIFF
--- a/.changelog/pr-1366.txt
+++ b/.changelog/pr-1366.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/pingone_davinci_flow`: Added `settings.custom_timeout_error_screen_css`, `settings.custom_timeout_error_screen_html`, `settings.custom_timeout_error_screen_message`, and `settings.use_custom_timeout_error_screen` attributes.
+```

--- a/docs/resources/davinci_flow.md
+++ b/docs/resources/davinci_flow.md
@@ -1435,6 +1435,9 @@ Optional:
 - `custom_error_show_footer` (Boolean)
 - `custom_favicon_link` (String)
 - `custom_logo_urlselection` (Number)
+- `custom_timeout_error_screen_css` (String)
+- `custom_timeout_error_screen_html` (String)
+- `custom_timeout_error_screen_message` (String)
 - `custom_title` (String)
 - `default_error_screen_brand_logo` (Boolean)
 - `flow_http_timeout_in_seconds` (Number)
@@ -1452,6 +1455,7 @@ Optional:
 - `use_custom_css` (Boolean)
 - `use_custom_flow_player` (Boolean)
 - `use_custom_script` (Boolean)
+- `use_custom_timeout_error_screen` (Boolean)
 - `use_intermediate_loading_screen` (Boolean)
 - `validate_on_save` (Boolean)
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1
 	github.com/patrickcping/pingone-go-sdk-v2/risk v0.22.0
 	github.com/patrickcping/pingone-go-sdk-v2/verify v0.11.2
-	github.com/pingidentity/pingone-go-client v0.12.0
+	github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1
 	github.com/patrickcping/pingone-go-sdk-v2/risk v0.22.0
 	github.com/patrickcping/pingone-go-sdk-v2/verify v0.11.2
-	github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6
+	github.com/pingidentity/pingone-go-client v0.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -758,6 +758,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pingidentity/pingone-go-client v0.12.0 h1:t9L18Qul3UXqqvi0578R7bzys54cEEl+oSJDT6rMdyM=
 github.com/pingidentity/pingone-go-client v0.12.0/go.mod h1:ZFGQiCdcLdhDMnNZrefNY86Mb2wHH7GTWMDqv/PWKBk=
+github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6 h1:UrfrzHI6vDV8KGVNL4upXFUxiRY2apJWwPyYTVe8KZ4=
+github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6/go.mod h1:ZFGQiCdcLdhDMnNZrefNY86Mb2wHH7GTWMDqv/PWKBk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
 github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/pavius/impi v0.0.3/go.mod h1:x/hU0bfdWIhuOT1SKwiJg++yvkk6EuOtJk8WtDZq
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6 h1:UrfrzHI6vDV8KGVNL4upXFUxiRY2apJWwPyYTVe8KZ4=
-github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6/go.mod h1:ZFGQiCdcLdhDMnNZrefNY86Mb2wHH7GTWMDqv/PWKBk=
+github.com/pingidentity/pingone-go-client v0.13.0 h1:IRDAcFhnrXuiQDfpgxIwcJq5HXrdbMvVZtv9kJghuns=
+github.com/pingidentity/pingone-go-client v0.13.0/go.mod h1:ZFGQiCdcLdhDMnNZrefNY86Mb2wHH7GTWMDqv/PWKBk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
 github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,6 @@ github.com/pavius/impi v0.0.3/go.mod h1:x/hU0bfdWIhuOT1SKwiJg++yvkk6EuOtJk8WtDZq
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/pingidentity/pingone-go-client v0.12.0 h1:t9L18Qul3UXqqvi0578R7bzys54cEEl+oSJDT6rMdyM=
-github.com/pingidentity/pingone-go-client v0.12.0/go.mod h1:ZFGQiCdcLdhDMnNZrefNY86Mb2wHH7GTWMDqv/PWKBk=
 github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6 h1:UrfrzHI6vDV8KGVNL4upXFUxiRY2apJWwPyYTVe8KZ4=
 github.com/pingidentity/pingone-go-client v0.12.1-0.20260909220728-33af458c19a6/go.mod h1:ZFGQiCdcLdhDMnNZrefNY86Mb2wHH7GTWMDqv/PWKBk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/internal/acctest/testhcl/pingone_davinci_flow/full_minimal.tf
+++ b/internal/acctest/testhcl/pingone_davinci_flow/full_minimal.tf
@@ -15,9 +15,13 @@ resource "pingone_davinci_flow" "%[2]s" {
   name = "%[2]s-simple"
   settings = {
     csp = "worker-src 'self' blob:; script-src 'self' https://cdn.jsdelivr.net https://code.jquery.com https://devsdk.singularkey.com http://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';"
+    custom_timeout_error_screen_css = "body { background-color: #f0f0f0; }"
+    custom_timeout_error_screen_html = "<div class=\"timeout-error\">The flow has timed out</div>"
+    custom_timeout_error_screen_message = "The session timed out. Please try again."
     flow_http_timeout_in_seconds = 300
     log_level = 1
     use_custom_css = true
+    use_custom_timeout_error_screen = true
   }
   color = "#FFC8C1"
   graph_data = {

--- a/internal/service/davinci/resource_davinci_flow_gen.go
+++ b/internal/service/davinci/resource_davinci_flow_gen.go
@@ -127,32 +127,36 @@ func (r *davinciFlowResource) Schema(ctx context.Context, req resource.SchemaReq
 	}
 	settingsJsLinksElementType := types.ObjectType{AttrTypes: settingsJsLinksAttrTypes}
 	settingsAttrTypes := map[string]attr.Type{
-		"csp":                                types.StringType,
-		"css":                                types.StringType,
-		"css_links":                          types.SetType{ElemType: types.StringType},
-		"custom_error_screen_brand_logo_url": types.StringType,
-		"custom_error_show_footer":           types.BoolType,
-		"custom_favicon_link":                types.StringType,
-		"custom_logo_urlselection":           types.Int32Type,
-		"custom_title":                       types.StringType,
-		"default_error_screen_brand_logo":    types.BoolType,
-		"flow_http_timeout_in_seconds":       types.Int32Type,
-		"flow_timeout_in_seconds":            types.Int32Type,
-		"intermediate_loading_screen_css":    types.StringType,
-		"intermediate_loading_screen_html":   types.StringType,
-		"js_custom_flow_player":              types.StringType,
-		"js_links":                           types.SetType{ElemType: settingsJsLinksElementType},
-		"log_level":                          types.Int32Type,
-		"preview_form_rendering_updates":     types.BoolType,
-		"require_authentication_to_initiate": types.BoolType,
-		"scrub_sensitive_info":               types.BoolType,
-		"sensitive_info_fields":              types.SetType{ElemType: types.StringType},
-		"use_csp":                            types.BoolType,
-		"use_custom_css":                     types.BoolType,
-		"use_custom_flow_player":             types.BoolType,
-		"use_custom_script":                  types.BoolType,
-		"use_intermediate_loading_screen":    types.BoolType,
-		"validate_on_save":                   types.BoolType,
+		"csp":                                 types.StringType,
+		"css":                                 types.StringType,
+		"css_links":                           types.SetType{ElemType: types.StringType},
+		"custom_error_screen_brand_logo_url":  types.StringType,
+		"custom_error_show_footer":            types.BoolType,
+		"custom_favicon_link":                 types.StringType,
+		"custom_logo_urlselection":            types.Int32Type,
+		"custom_timeout_error_screen_css":     types.StringType,
+		"custom_timeout_error_screen_html":    types.StringType,
+		"custom_timeout_error_screen_message": types.StringType,
+		"custom_title":                        types.StringType,
+		"default_error_screen_brand_logo":     types.BoolType,
+		"flow_http_timeout_in_seconds":        types.Int32Type,
+		"flow_timeout_in_seconds":             types.Int32Type,
+		"intermediate_loading_screen_css":     types.StringType,
+		"intermediate_loading_screen_html":    types.StringType,
+		"js_custom_flow_player":               types.StringType,
+		"js_links":                            types.SetType{ElemType: settingsJsLinksElementType},
+		"log_level":                           types.Int32Type,
+		"preview_form_rendering_updates":      types.BoolType,
+		"require_authentication_to_initiate":  types.BoolType,
+		"scrub_sensitive_info":                types.BoolType,
+		"sensitive_info_fields":               types.SetType{ElemType: types.StringType},
+		"use_csp":                             types.BoolType,
+		"use_custom_css":                      types.BoolType,
+		"use_custom_flow_player":              types.BoolType,
+		"use_custom_script":                   types.BoolType,
+		"use_custom_timeout_error_screen":     types.BoolType,
+		"use_intermediate_loading_screen":     types.BoolType,
+		"validate_on_save":                    types.BoolType,
 	}
 	resp.Schema = schema.Schema{
 		Description: "Resource to create and manage a DaVinci flow.",
@@ -591,6 +595,15 @@ func (r *davinciFlowResource) Schema(ctx context.Context, req resource.SchemaReq
 					"custom_logo_urlselection": schema.Int32Attribute{
 						Optional: true,
 					},
+					"custom_timeout_error_screen_css": schema.StringAttribute{
+						Optional: true,
+					},
+					"custom_timeout_error_screen_html": schema.StringAttribute{
+						Optional: true,
+					},
+					"custom_timeout_error_screen_message": schema.StringAttribute{
+						Optional: true,
+					},
 					"custom_title": schema.StringAttribute{
 						Optional: true,
 					},
@@ -679,6 +692,9 @@ func (r *davinciFlowResource) Schema(ctx context.Context, req resource.SchemaReq
 					"use_custom_script": schema.BoolAttribute{
 						Optional: true,
 					},
+					"use_custom_timeout_error_screen": schema.BoolAttribute{
+						Optional: true,
+					},
 					"use_intermediate_loading_screen": schema.BoolAttribute{
 						Optional: true,
 					},
@@ -689,32 +705,36 @@ func (r *davinciFlowResource) Schema(ctx context.Context, req resource.SchemaReq
 				Optional: true,
 				Computed: true,
 				Default: objectdefault.StaticValue(types.ObjectValueMust(settingsAttrTypes, map[string]attr.Value{
-					"csp":                                types.StringNull(),
-					"css":                                types.StringNull(),
-					"css_links":                          types.SetNull(types.StringType),
-					"custom_error_screen_brand_logo_url": types.StringNull(),
-					"custom_error_show_footer":           types.BoolNull(),
-					"custom_favicon_link":                types.StringNull(),
-					"custom_logo_urlselection":           types.Int32Null(),
-					"custom_title":                       types.StringNull(),
-					"default_error_screen_brand_logo":    types.BoolNull(),
-					"flow_http_timeout_in_seconds":       types.Int32Null(),
-					"flow_timeout_in_seconds":            types.Int32Null(),
-					"intermediate_loading_screen_css":    types.StringNull(),
-					"intermediate_loading_screen_html":   types.StringNull(),
-					"js_custom_flow_player":              types.StringNull(),
-					"js_links":                           types.SetNull(settingsJsLinksElementType),
-					"log_level":                          types.Int32Value(4),
-					"preview_form_rendering_updates":     types.BoolNull(),
-					"require_authentication_to_initiate": types.BoolNull(),
-					"scrub_sensitive_info":               types.BoolNull(),
-					"sensitive_info_fields":              types.SetNull(types.StringType),
-					"use_csp":                            types.BoolNull(),
-					"use_custom_css":                     types.BoolNull(),
-					"use_custom_flow_player":             types.BoolNull(),
-					"use_custom_script":                  types.BoolNull(),
-					"use_intermediate_loading_screen":    types.BoolNull(),
-					"validate_on_save":                   types.BoolNull(),
+					"csp":                                 types.StringNull(),
+					"css":                                 types.StringNull(),
+					"css_links":                           types.SetNull(types.StringType),
+					"custom_error_screen_brand_logo_url":  types.StringNull(),
+					"custom_error_show_footer":            types.BoolNull(),
+					"custom_favicon_link":                 types.StringNull(),
+					"custom_logo_urlselection":            types.Int32Null(),
+					"custom_timeout_error_screen_css":     types.StringNull(),
+					"custom_timeout_error_screen_html":    types.StringNull(),
+					"custom_timeout_error_screen_message": types.StringNull(),
+					"custom_title":                        types.StringNull(),
+					"default_error_screen_brand_logo":     types.BoolNull(),
+					"flow_http_timeout_in_seconds":        types.Int32Null(),
+					"flow_timeout_in_seconds":             types.Int32Null(),
+					"intermediate_loading_screen_css":     types.StringNull(),
+					"intermediate_loading_screen_html":    types.StringNull(),
+					"js_custom_flow_player":               types.StringNull(),
+					"js_links":                            types.SetNull(settingsJsLinksElementType),
+					"log_level":                           types.Int32Value(4),
+					"preview_form_rendering_updates":      types.BoolNull(),
+					"require_authentication_to_initiate":  types.BoolNull(),
+					"scrub_sensitive_info":                types.BoolNull(),
+					"sensitive_info_fields":               types.SetNull(types.StringType),
+					"use_csp":                             types.BoolNull(),
+					"use_custom_css":                      types.BoolNull(),
+					"use_custom_flow_player":              types.BoolNull(),
+					"use_custom_script":                   types.BoolNull(),
+					"use_custom_timeout_error_screen":     types.BoolNull(),
+					"use_intermediate_loading_screen":     types.BoolNull(),
+					"validate_on_save":                    types.BoolNull(),
 				})),
 			},
 			"trigger": schema.SingleNestedAttribute{
@@ -1044,6 +1064,9 @@ func (model *davinciFlowResourceModel) buildClientStructPost() (*pingone.DaVinci
 		}
 		settingsValue.CustomFaviconLink = settingsAttrs["custom_favicon_link"].(types.String).ValueStringPointer()
 		settingsValue.CustomLogoURLSelection = settingsAttrs["custom_logo_urlselection"].(types.Int32).ValueInt32Pointer()
+		settingsValue.CustomTimeoutErrorScreenCSS = settingsAttrs["custom_timeout_error_screen_css"].(types.String).ValueStringPointer()
+		settingsValue.CustomTimeoutErrorScreenHTML = settingsAttrs["custom_timeout_error_screen_html"].(types.String).ValueStringPointer()
+		settingsValue.CustomTimeoutErrorScreenMessage = settingsAttrs["custom_timeout_error_screen_message"].(types.String).ValueStringPointer()
 		settingsValue.CustomTitle = settingsAttrs["custom_title"].(types.String).ValueStringPointer()
 		if !settingsAttrs["default_error_screen_brand_logo"].IsNull() && !settingsAttrs["default_error_screen_brand_logo"].IsUnknown() {
 			settingsValue.DefaultErrorScreenBrandLogo = &pingone.DaVinciFlowSettingsRequestDefaultErrorScreenBrandLogo{
@@ -1123,6 +1146,9 @@ func (model *davinciFlowResourceModel) buildClientStructPost() (*pingone.DaVinci
 			settingsValue.UseCustomScript = &pingone.DaVinciFlowSettingsRequestUseCustomScript{
 				Bool: settingsAttrs["use_custom_script"].(types.Bool).ValueBoolPointer(),
 			}
+		}
+		if !settingsAttrs["use_custom_timeout_error_screen"].IsNull() && !settingsAttrs["use_custom_timeout_error_screen"].IsUnknown() {
+			settingsValue.UseCustomTimeoutErrorScreen = settingsAttrs["use_custom_timeout_error_screen"].(types.Bool).ValueBoolPointer()
 		}
 		if !settingsAttrs["use_intermediate_loading_screen"].IsNull() && !settingsAttrs["use_intermediate_loading_screen"].IsUnknown() {
 			settingsValue.UseIntermediateLoadingScreen = &pingone.DaVinciFlowSettingsRequestUseIntermediateLoadingScreen{
@@ -1451,6 +1477,9 @@ func (model *davinciFlowResourceModel) buildClientStructPut() (*pingone.DaVinciF
 		}
 		settingsValue.CustomFaviconLink = settingsAttrs["custom_favicon_link"].(types.String).ValueStringPointer()
 		settingsValue.CustomLogoURLSelection = settingsAttrs["custom_logo_urlselection"].(types.Int32).ValueInt32Pointer()
+		settingsValue.CustomTimeoutErrorScreenCSS = settingsAttrs["custom_timeout_error_screen_css"].(types.String).ValueStringPointer()
+		settingsValue.CustomTimeoutErrorScreenHTML = settingsAttrs["custom_timeout_error_screen_html"].(types.String).ValueStringPointer()
+		settingsValue.CustomTimeoutErrorScreenMessage = settingsAttrs["custom_timeout_error_screen_message"].(types.String).ValueStringPointer()
 		settingsValue.CustomTitle = settingsAttrs["custom_title"].(types.String).ValueStringPointer()
 		if !settingsAttrs["default_error_screen_brand_logo"].IsNull() && !settingsAttrs["default_error_screen_brand_logo"].IsUnknown() {
 			settingsValue.DefaultErrorScreenBrandLogo = &pingone.DaVinciFlowSettingsRequestDefaultErrorScreenBrandLogo{
@@ -1530,6 +1559,9 @@ func (model *davinciFlowResourceModel) buildClientStructPut() (*pingone.DaVinciF
 			settingsValue.UseCustomScript = &pingone.DaVinciFlowSettingsRequestUseCustomScript{
 				Bool: settingsAttrs["use_custom_script"].(types.Bool).ValueBoolPointer(),
 			}
+		}
+		if !settingsAttrs["use_custom_timeout_error_screen"].IsNull() && !settingsAttrs["use_custom_timeout_error_screen"].IsUnknown() {
+			settingsValue.UseCustomTimeoutErrorScreen = settingsAttrs["use_custom_timeout_error_screen"].(types.Bool).ValueBoolPointer()
 		}
 		if !settingsAttrs["use_intermediate_loading_screen"].IsNull() && !settingsAttrs["use_intermediate_loading_screen"].IsUnknown() {
 			settingsValue.UseIntermediateLoadingScreen = &pingone.DaVinciFlowSettingsRequestUseIntermediateLoadingScreen{
@@ -1968,32 +2000,36 @@ func (state *davinciFlowResourceModel) readClientResponse(response *pingone.DaVi
 	}
 	settingsJsLinksElementType := types.ObjectType{AttrTypes: settingsJsLinksAttrTypes}
 	settingsAttrTypes := map[string]attr.Type{
-		"csp":                                types.StringType,
-		"css":                                types.StringType,
-		"css_links":                          types.SetType{ElemType: types.StringType},
-		"custom_error_screen_brand_logo_url": types.StringType,
-		"custom_error_show_footer":           types.BoolType,
-		"custom_favicon_link":                types.StringType,
-		"custom_logo_urlselection":           types.Int32Type,
-		"custom_title":                       types.StringType,
-		"default_error_screen_brand_logo":    types.BoolType,
-		"flow_http_timeout_in_seconds":       types.Int32Type,
-		"flow_timeout_in_seconds":            types.Int32Type,
-		"intermediate_loading_screen_css":    types.StringType,
-		"intermediate_loading_screen_html":   types.StringType,
-		"js_custom_flow_player":              types.StringType,
-		"js_links":                           types.SetType{ElemType: settingsJsLinksElementType},
-		"log_level":                          types.Int32Type,
-		"preview_form_rendering_updates":     types.BoolType,
-		"require_authentication_to_initiate": types.BoolType,
-		"scrub_sensitive_info":               types.BoolType,
-		"sensitive_info_fields":              types.SetType{ElemType: types.StringType},
-		"use_csp":                            types.BoolType,
-		"use_custom_css":                     types.BoolType,
-		"use_custom_flow_player":             types.BoolType,
-		"use_custom_script":                  types.BoolType,
-		"use_intermediate_loading_screen":    types.BoolType,
-		"validate_on_save":                   types.BoolType,
+		"csp":                                 types.StringType,
+		"css":                                 types.StringType,
+		"css_links":                           types.SetType{ElemType: types.StringType},
+		"custom_error_screen_brand_logo_url":  types.StringType,
+		"custom_error_show_footer":            types.BoolType,
+		"custom_favicon_link":                 types.StringType,
+		"custom_logo_urlselection":            types.Int32Type,
+		"custom_timeout_error_screen_css":     types.StringType,
+		"custom_timeout_error_screen_html":    types.StringType,
+		"custom_timeout_error_screen_message": types.StringType,
+		"custom_title":                        types.StringType,
+		"default_error_screen_brand_logo":     types.BoolType,
+		"flow_http_timeout_in_seconds":        types.Int32Type,
+		"flow_timeout_in_seconds":             types.Int32Type,
+		"intermediate_loading_screen_css":     types.StringType,
+		"intermediate_loading_screen_html":    types.StringType,
+		"js_custom_flow_player":               types.StringType,
+		"js_links":                            types.SetType{ElemType: settingsJsLinksElementType},
+		"log_level":                           types.Int32Type,
+		"preview_form_rendering_updates":      types.BoolType,
+		"require_authentication_to_initiate":  types.BoolType,
+		"scrub_sensitive_info":                types.BoolType,
+		"sensitive_info_fields":               types.SetType{ElemType: types.StringType},
+		"use_csp":                             types.BoolType,
+		"use_custom_css":                      types.BoolType,
+		"use_custom_flow_player":              types.BoolType,
+		"use_custom_script":                   types.BoolType,
+		"use_custom_timeout_error_screen":     types.BoolType,
+		"use_intermediate_loading_screen":     types.BoolType,
+		"validate_on_save":                    types.BoolType,
 	}
 	var settingsValue types.Object
 	if response.Settings == nil {
@@ -2164,32 +2200,36 @@ func (state *davinciFlowResourceModel) readClientResponse(response *pingone.DaVi
 			settingsValidateOnSaveValue = types.BoolPointerValue(response.Settings.ValidateOnSave.Bool)
 		}
 		settingsValue, diags = types.ObjectValue(settingsAttrTypes, map[string]attr.Value{
-			"csp":                                types.StringPointerValue(response.Settings.Csp),
-			"css":                                types.StringPointerValue(response.Settings.Css),
-			"css_links":                          settingsCssLinksValue,
-			"custom_error_screen_brand_logo_url": types.StringPointerValue(response.Settings.CustomErrorScreenBrandLogoUrl),
-			"custom_error_show_footer":           settingsCustomErrorShowFooterValue,
-			"custom_favicon_link":                types.StringPointerValue(response.Settings.CustomFaviconLink),
-			"custom_logo_urlselection":           types.Int32PointerValue(response.Settings.CustomLogoURLSelection),
-			"custom_title":                       types.StringPointerValue(response.Settings.CustomTitle),
-			"default_error_screen_brand_logo":    settingsDefaultErrorScreenBrandLogoValue,
-			"flow_http_timeout_in_seconds":       types.Int32PointerValue(response.Settings.FlowHttpTimeoutInSeconds),
-			"flow_timeout_in_seconds":            flowTimeoutInSecondsValue,
-			"intermediate_loading_screen_css":    intermediateLoadingScreenCSSValue,
-			"intermediate_loading_screen_html":   intermediateLoadingScreenHTMLValue,
-			"js_custom_flow_player":              types.StringPointerValue(response.Settings.JsCustomFlowPlayer),
-			"js_links":                           settingsJsLinksValue,
-			"log_level":                          types.Int32PointerValue(response.Settings.LogLevel),
-			"preview_form_rendering_updates":     settingsPreviewFormRenderingUpdatesValue,
-			"require_authentication_to_initiate": settingsRequireAuthenticationToInitiateValue,
-			"scrub_sensitive_info":               settingsScrubSensitiveInfoValue,
-			"sensitive_info_fields":              settingsSensitiveInfoFieldsValue,
-			"use_csp":                            settingsUseCSPValue,
-			"use_custom_css":                     settingsUseCustomCSSValue,
-			"use_custom_flow_player":             settingsUseCustomFlowPlayerValue,
-			"use_custom_script":                  settingsUseCustomScriptValue,
-			"use_intermediate_loading_screen":    settingsUseIntermediateLoadingScreenValue,
-			"validate_on_save":                   settingsValidateOnSaveValue,
+			"csp":                                 types.StringPointerValue(response.Settings.Csp),
+			"css":                                 types.StringPointerValue(response.Settings.Css),
+			"css_links":                           settingsCssLinksValue,
+			"custom_error_screen_brand_logo_url":  types.StringPointerValue(response.Settings.CustomErrorScreenBrandLogoUrl),
+			"custom_error_show_footer":            settingsCustomErrorShowFooterValue,
+			"custom_favicon_link":                 types.StringPointerValue(response.Settings.CustomFaviconLink),
+			"custom_logo_urlselection":            types.Int32PointerValue(response.Settings.CustomLogoURLSelection),
+			"custom_timeout_error_screen_css":     types.StringPointerValue(response.Settings.CustomTimeoutErrorScreenCSS),
+			"custom_timeout_error_screen_html":    types.StringPointerValue(response.Settings.CustomTimeoutErrorScreenHTML),
+			"custom_timeout_error_screen_message": types.StringPointerValue(response.Settings.CustomTimeoutErrorScreenMessage),
+			"custom_title":                        types.StringPointerValue(response.Settings.CustomTitle),
+			"default_error_screen_brand_logo":     settingsDefaultErrorScreenBrandLogoValue,
+			"flow_http_timeout_in_seconds":        types.Int32PointerValue(response.Settings.FlowHttpTimeoutInSeconds),
+			"flow_timeout_in_seconds":             flowTimeoutInSecondsValue,
+			"intermediate_loading_screen_css":     intermediateLoadingScreenCSSValue,
+			"intermediate_loading_screen_html":    intermediateLoadingScreenHTMLValue,
+			"js_custom_flow_player":               types.StringPointerValue(response.Settings.JsCustomFlowPlayer),
+			"js_links":                            settingsJsLinksValue,
+			"log_level":                           types.Int32PointerValue(response.Settings.LogLevel),
+			"preview_form_rendering_updates":      settingsPreviewFormRenderingUpdatesValue,
+			"require_authentication_to_initiate":  settingsRequireAuthenticationToInitiateValue,
+			"scrub_sensitive_info":                settingsScrubSensitiveInfoValue,
+			"sensitive_info_fields":               settingsSensitiveInfoFieldsValue,
+			"use_csp":                             settingsUseCSPValue,
+			"use_custom_css":                      settingsUseCustomCSSValue,
+			"use_custom_flow_player":              settingsUseCustomFlowPlayerValue,
+			"use_custom_script":                   settingsUseCustomScriptValue,
+			"use_custom_timeout_error_screen":     types.BoolPointerValue(response.Settings.UseCustomTimeoutErrorScreen),
+			"use_intermediate_loading_screen":     settingsUseIntermediateLoadingScreenValue,
+			"validate_on_save":                    settingsValidateOnSaveValue,
 		})
 		respDiags.Append(diags...)
 	}

--- a/internal/service/davinci/resource_davinci_flow_gen_test.go
+++ b/internal/service/davinci/resource_davinci_flow_gen_test.go
@@ -1053,6 +1053,10 @@ func davinciFlow_CheckComputedValuesFullMinimal(resourceName string) resource.Te
 		resource.TestCheckNoResourceAttr(fmt.Sprintf("pingone_davinci_flow.%s", resourceName), "input_schema"),
 		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_davinci_flow.%s", resourceName), "graph_data.elements.nodes.2pzouq7el7.data.connector_id", "errorConnector"),
 		resource.TestCheckNoResourceAttr(fmt.Sprintf("pingone_davinci_flow.%s", resourceName), "published_version"),
+		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_davinci_flow.%s", resourceName), "settings.custom_timeout_error_screen_css", "body { background-color: #f0f0f0; }"),
+		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_davinci_flow.%s", resourceName), "settings.custom_timeout_error_screen_html", "<div class=\"timeout-error\">The flow has timed out</div>"),
+		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_davinci_flow.%s", resourceName), "settings.custom_timeout_error_screen_message", "The session timed out. Please try again."),
+		resource.TestCheckResourceAttr(fmt.Sprintf("pingone_davinci_flow.%s", resourceName), "settings.use_custom_timeout_error_screen", "true"),
 	)
 }
 


### PR DESCRIPTION
## Change Description
- Add support for new attributes added in the Go client in https://github.com/pingidentity/pingone-go-client/pull/101 
- Add test coverage for the new attributes
- Bump client to v0.13.0

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [x] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
make testaccprefix SERVICE=davinci PREFIX=TestAccDavinciFlow_BasicClean
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->

<details>
  <summary>Expand Results</summary>

```shell
=== RUN   TestAccDavinciFlow_BasicClean
=== PAUSE TestAccDavinciFlow_BasicClean           === CONT  TestAccDavinciFlow_BasicClean
--- PASS: TestAccDavinciFlow_BasicClean (57.02s)  PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/davinci       57.733s
```

</details>
