### PR TITLE
CDI-872: Support new branding theme fields to align with API

### DIFF
--- a/.changelog/pr-1367.txt
+++ b/.changelog/pr-1367.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+`resource/pingone_branding_theme`: Added configuration attributes to align with the API: `application_background_color`, `body_text_size`, `body_text_weight`, `button_border_color`, `button_border_width`, `button_corner_radius`, `button_hover_state_border_color`, `button_hover_state_fill_color`, `button_hover_state_text_color`, `button_text_size`, `button_text_weight`, `card_border_color`, `card_border_width`, `card_corner_radius`, `card_horizontal_alignment`, `card_shadow`, `card_vertical_alignment`, `focus_rectangle_color`, `footer_localized`, `global_font`, `header`, `header_background_color`, `header_localized`, `input_border_width`, `input_box_border_color`, `input_corner_radius`, `input_label_position`, `input_label_text_color`, `input_label_text_size`, `input_label_text_weight`, `input_value_text_color`, `input_value_text_size`, `input_value_text_weight`, `link_text_hover_color`, `link_text_size`, `link_text_weight`, `logo_height`, `sub_title_text_color`, `sub_title_text_size`, `sub_title_text_weight`, `title_text_color`, `title_text_size`, `title_text_weight`
+```
+
+```release-note:note
+bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.70.0 => v0.71.0
+```

--- a/docs/resources/branding_theme.md
+++ b/docs/resources/branding_theme.md
@@ -50,6 +50,25 @@ resource "pingone_branding_theme" "my_awesome_theme" {
   body_text_color    = "#263956"
   link_text_color    = "#263956"
   button_color       = "#263956"
+
+  header = "<h1>Welcome to PingOne</h1>"
+
+  footer_text = "<p>Copyright © 2025 My Company</p>"
+
+  title_text_color     = "#686F77"
+  sub_title_text_color = "#686F77"
+  global_font          = "\"Helvetica Neue\", Helvetica, sans-serif"
+  logo_height          = "56px"
+
+  footer_localized = {
+    enabled          = true
+    default_language = "en"
+    content_type     = "HTML"
+    content = {
+      en = { input_text = "<p>Copyright © 2025 My Company</p>" }
+      fr = { input_text = "<p>Copyright © 2025 Ma Société</p>" }
+    }
+  }
 }
 ```
 
@@ -70,10 +89,54 @@ resource "pingone_branding_theme" "my_awesome_theme" {
 
 ### Optional
 
+- `application_background_color` (String) The application background color for the theme. It must be a valid hexadecimal color code.  Note that this property is not used by DaVinci forms.
 - `background_color` (String) The background color for the theme. It must be a valid hexadecimal color code.  Conflicts with `background_image`.
 - `background_image` (Attributes) A single object that specifies the HREF and ID for the background image.  Conflicts with `background_color`. (see [below for nested schema](#nestedatt--background_image))
+- `body_text_size` (String) The body text size for the theme.
+- `body_text_weight` (String) The body text weight for the theme (range from 100-900).
+- `button_border_color` (String) The button border color for the theme. It must be a valid hexadecimal color code.
+- `button_border_radius` (String) The button border radius for the theme (range from 0-25px).
+- `button_border_width` (String) The button border width for the theme (range from 0-4px).
+- `button_corner_radius` (String) The button corner radius for the theme (range from 0-25px).
+- `button_hover_state_border_color` (String) The button hover state border color for the theme. It must be a valid hexadecimal color code.
+- `button_hover_state_fill_color` (String) The button hover state fill color for the theme. It must be a valid hexadecimal color code.
+- `button_hover_state_text_color` (String) The button hover state text color for the theme. It must be a valid hexadecimal color code.
+- `button_text_size` (String) The button text size for the theme.
+- `button_text_weight` (String) The button text weight for the theme (range from 100-900).
+- `card_border_color` (String) The card border color for the theme. It must be a valid hexadecimal color code.
+- `card_border_width` (String) The card border width for the theme (range from 0-4px).
+- `card_corner_radius` (String) The card corner radius for the theme (range from 0-25px).
+- `card_horizontal_alignment` (String) The card horizontal alignment for the theme.
+- `card_shadow` (String) The card shadow for the theme.
+- `card_vertical_alignment` (String) The card vertical alignment for the theme.
+- `focus_rectangle_color` (String) The focus rectangle color for the theme. It must be a valid hexadecimal color code.
+- `footer_localized` (Attributes) The localization object to specify language translations for the form footer. (see [below for nested schema](#nestedatt--footer_localized))
 - `footer_text` (String) The text to be displayed in the footer of the branding theme.
+- `global_font` (String) The global font for the theme.  The default value is "Helvetica Neue, Helvetica, sans-serif".
+- `header` (String) The header for the theme.  For example, "<h1>Welcome to PingOne</h1>".
+- `header_background_color` (String) The header background color for the theme. It must be a valid hexadecimal color code.  Note that this property is not used by DaVinci forms.
+- `header_localized` (Attributes) The localization object to specify language translations for the form header. (see [below for nested schema](#nestedatt--header_localized))
+- `input_border_width` (String) The input border width for the theme (range from 0-4px).
+- `input_box_border_color` (String) The input box border color for the theme. It must be a valid hexadecimal color code.
+- `input_corner_radius` (String) The input corner radius for the theme (range from 0-25px).
+- `input_label_position` (String) The input label position for the theme.
+- `input_label_text_color` (String) The input label text color for the theme. It must be a valid hexadecimal color code.
+- `input_label_text_size` (String) The input label text size for the theme.
+- `input_label_text_weight` (String) The input label text weight for the theme (range from 100-900).
+- `input_value_text_color` (String) The input value text color for the theme. It must be a valid hexadecimal color code.
+- `input_value_text_size` (String) The input value text size for the theme.
+- `input_value_text_weight` (String) The input value text weight for the theme (range from 100-900).
+- `link_text_hover_color` (String) The link text hover color for the theme. It must be a valid hexadecimal color code.
+- `link_text_size` (String) The link text size for the theme.
+- `link_text_weight` (String) The link text weight for the theme (range from 100-900).
 - `logo` (Attributes) A single object that specifies the HREF and ID for the company logo, for this branding template.  If not set, the environment's default logo (set with the `pingone_branding_settings` resource) will be applied. (see [below for nested schema](#nestedatt--logo))
+- `logo_height` (String) The logo height assigned to the image (range from 0-100px).
+- `sub_title_text_color` (String) The subtitle text color for the theme. It must be a valid hexadecimal color code.
+- `sub_title_text_size` (String) The subtitle text size for the theme.
+- `sub_title_text_weight` (String) The subtitle text weight for the theme (range from 100-900).
+- `title_text_color` (String) The title text color for the theme. It must be a valid hexadecimal color code.
+- `title_text_size` (String) The title text size for the theme.
+- `title_text_weight` (String) The title text weight for the theme (range from 100-900).
 - `use_default_background` (Boolean) A boolean to specify that the background should be set to the theme template's default.  Defaults to `false`.
 
 ### Read-Only
@@ -88,6 +151,50 @@ Required:
 
 - `href` (String) The URL or fully qualified path to the background image file used for branding.  This can be retrieved from the `uploaded_image.href` parameter of the `pingone_image` resource.
 - `id` (String) The ID of the background image.  This can be retrieved from the `id` parameter of the `pingone_image` resource.  Must be a valid PingOne resource ID.
+
+
+<a id="nestedatt--footer_localized"></a>
+### Nested Schema for `footer_localized`
+
+Required:
+
+- `content` (Attributes Map) A map of language codes to the localized text for the language options.  The map key is the language code (for example, "en"). (see [below for nested schema](#nestedatt--footer_localized--content))
+- `content_type` (String) The content type for the localized text.  Options are `HTML`, `RichText`.
+- `default_language` (String) The localization language code for the footer's default language (for example, "en").
+
+Optional:
+
+- `enabled` (Boolean) Specifies whether localization is enabled for the footer.
+
+<a id="nestedatt--footer_localized--content"></a>
+### Nested Schema for `footer_localized.content`
+
+Required:
+
+- `input_text` (String) The footer text in the specified language.
+
+
+
+<a id="nestedatt--header_localized"></a>
+### Nested Schema for `header_localized`
+
+Required:
+
+- `content` (Attributes Map) A map of language codes to the localized text for the language options.  The map key is the language code (for example, "en"). (see [below for nested schema](#nestedatt--header_localized--content))
+- `content_type` (String) The content type for the localized text.  Options are `HTML`, `RichText`.
+- `default_language` (String) The localization language code for the header's default language (for example, "en").
+
+Optional:
+
+- `enabled` (Boolean) Specifies whether localization is enabled for the header.
+
+<a id="nestedatt--header_localized--content"></a>
+### Nested Schema for `header_localized.content`
+
+Required:
+
+- `input_text` (String) The header text in the specified language.
+
 
 
 <a id="nestedatt--logo"></a>

--- a/docs/resources/branding_theme.md
+++ b/docs/resources/branding_theme.md
@@ -95,7 +95,6 @@ resource "pingone_branding_theme" "my_awesome_theme" {
 - `body_text_size` (String) The body text size for the theme.
 - `body_text_weight` (String) The body text weight for the theme (range from 100-900).
 - `button_border_color` (String) The button border color for the theme. It must be a valid hexadecimal color code.
-- `button_border_radius` (String) The button border radius for the theme (range from 0-25px).
 - `button_border_width` (String) The button border width for the theme (range from 0-4px).
 - `button_corner_radius` (String) The button corner radius for the theme (range from 0-25px).
 - `button_hover_state_border_color` (String) The button hover state border color for the theme. It must be a valid hexadecimal color code.

--- a/examples/resources/pingone_branding_theme/resource.tf
+++ b/examples/resources/pingone_branding_theme/resource.tf
@@ -36,4 +36,23 @@ resource "pingone_branding_theme" "my_awesome_theme" {
   body_text_color    = "#263956"
   link_text_color    = "#263956"
   button_color       = "#263956"
+
+  header = "<h1>Welcome to PingOne</h1>"
+
+  footer_text = "<p>Copyright © 2025 My Company</p>"
+
+  title_text_color     = "#686F77"
+  sub_title_text_color = "#686F77"
+  global_font          = "\"Helvetica Neue\", Helvetica, sans-serif"
+  logo_height          = "56px"
+
+  footer_localized = {
+    enabled          = true
+    default_language = "en"
+    content_type     = "HTML"
+    content = {
+      en = { input_text = "<p>Copyright © 2025 My Company</p>" }
+      fr = { input_text = "<p>Copyright © 2025 Ma Société</p>" }
+    }
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -29,12 +29,15 @@ require (
 	github.com/patrickcping/pingone-go-sdk-v2 v0.14.14
 	github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3
 	github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1
-	github.com/patrickcping/pingone-go-sdk-v2/management v0.70.0
+	github.com/patrickcping/pingone-go-sdk-v2/management v0.71.0
 	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1
 	github.com/patrickcping/pingone-go-sdk-v2/risk v0.22.0
 	github.com/patrickcping/pingone-go-sdk-v2/verify v0.11.2
 	github.com/pingidentity/pingone-go-client v0.12.0
 )
+
+// TEMPORARY: point at the local regenerated SDK for CDI-872 testing. Do not commit.
+replace github.com/patrickcping/pingone-go-sdk-v2/management => ../pingone-go-sdk-v2/management
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,15 +29,12 @@ require (
 	github.com/patrickcping/pingone-go-sdk-v2 v0.14.14
 	github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3
 	github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1
-	github.com/patrickcping/pingone-go-sdk-v2/management v0.71.0
+	github.com/patrickcping/pingone-go-sdk-v2/management v0.70.1-0.20260911202801-aa9d668ea785
 	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1
 	github.com/patrickcping/pingone-go-sdk-v2/risk v0.22.0
 	github.com/patrickcping/pingone-go-sdk-v2/verify v0.11.2
 	github.com/pingidentity/pingone-go-client v0.12.0
 )
-
-// TEMPORARY: point at the local regenerated SDK for CDI-872 testing. Do not commit.
-replace github.com/patrickcping/pingone-go-sdk-v2/management => ../pingone-go-sdk-v2/management
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -743,6 +743,8 @@ github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3 h1:rB2g0Ry+AlvCxN0gxX
 github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3/go.mod h1:Tb8FQPxveYj4QOc4VJa42QccMv2hSLNpTKDUSdWXtVk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1 h1:7g4f1UWz85C4Onwg5hfqZPvyWrbqXJ5HlYNeVDRD8Sk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1/go.mod h1:SaqdGPTxYXaeVgOCJXDDCK40Avr+zGujG0YJGQTwyJg=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.70.1-0.20260911202801-aa9d668ea785 h1:8p8CED2tqMIQaubFwyTfPeEwo2KNRxwBUub0RVsVroE=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.70.1-0.20260911202801-aa9d668ea785/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1 h1:qLwEQfXJwKsStn935tEUyt9L6r7rJRuukmOfVwRX4H0=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1/go.mod h1:U5xu9EHj1Wvgl2an+qoq8QgScAPYB02bF0CKQmpo08Y=
 github.com/patrickcping/pingone-go-sdk-v2/risk v0.22.0 h1:RIE5NsI94W0sOX9L7xvaV2rMRDftJ283tIU+rvUnqRU=

--- a/go.sum
+++ b/go.sum
@@ -743,8 +743,6 @@ github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3 h1:rB2g0Ry+AlvCxN0gxX
 github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3/go.mod h1:Tb8FQPxveYj4QOc4VJa42QccMv2hSLNpTKDUSdWXtVk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1 h1:7g4f1UWz85C4Onwg5hfqZPvyWrbqXJ5HlYNeVDRD8Sk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1/go.mod h1:SaqdGPTxYXaeVgOCJXDDCK40Avr+zGujG0YJGQTwyJg=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.70.0 h1:O+tBQC6AreSSoFAproARMxaxcPL3hDJKJmb7GkVm7Sg=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.70.0/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1 h1:qLwEQfXJwKsStn935tEUyt9L6r7rJRuukmOfVwRX4H0=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1/go.mod h1:U5xu9EHj1Wvgl2an+qoq8QgScAPYB02bF0CKQmpo08Y=
 github.com/patrickcping/pingone-go-sdk-v2/risk v0.22.0 h1:RIE5NsI94W0sOX9L7xvaV2rMRDftJ283tIU+rvUnqRU=

--- a/internal/service/base/resource_branding_theme.go
+++ b/internal/service/base/resource_branding_theme.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -32,23 +33,89 @@ import (
 // Types
 type BrandingThemeResource serviceClientType
 
+var brandingThemeLocalizedTextTFObjectTypes = map[string]attr.Type{
+	"content":          types.MapType{ElemType: types.ObjectType{AttrTypes: brandingThemeLocalizedTextContentTFObjectTypes}},
+	"content_type":     types.StringType,
+	"default_language": types.StringType,
+	"enabled":          types.BoolType,
+}
+
+var brandingThemeLocalizedTextContentTFObjectTypes = map[string]attr.Type{
+	"input_text": types.StringType,
+}
+
 type brandingThemeResourceModelV1 struct {
-	Id                   pingonetypes.ResourceIDValue `tfsdk:"id"`
-	EnvironmentId        pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
-	Name                 types.String                 `tfsdk:"name"`
-	Template             types.String                 `tfsdk:"template"`
-	Default              types.Bool                   `tfsdk:"default"`
-	Logo                 types.Object                 `tfsdk:"logo"`
-	BackgroundImage      types.Object                 `tfsdk:"background_image"`
-	BackgroundColor      types.String                 `tfsdk:"background_color"`
-	UseDefaultBackground types.Bool                   `tfsdk:"use_default_background"`
-	BodyTextColor        types.String                 `tfsdk:"body_text_color"`
-	ButtonColor          types.String                 `tfsdk:"button_color"`
-	ButtonTextColor      types.String                 `tfsdk:"button_text_color"`
-	CardColor            types.String                 `tfsdk:"card_color"`
-	FooterText           types.String                 `tfsdk:"footer_text"`
-	HeadingTextColor     types.String                 `tfsdk:"heading_text_color"`
-	LinkTextColor        types.String                 `tfsdk:"link_text_color"`
+	Id                          pingonetypes.ResourceIDValue `tfsdk:"id"`
+	EnvironmentId               pingonetypes.ResourceIDValue `tfsdk:"environment_id"`
+	Name                        types.String                 `tfsdk:"name"`
+	Template                    types.String                 `tfsdk:"template"`
+	Default                     types.Bool                   `tfsdk:"default"`
+	Logo                        types.Object                 `tfsdk:"logo"`
+	BackgroundImage             types.Object                 `tfsdk:"background_image"`
+	BackgroundColor             types.String                 `tfsdk:"background_color"`
+	UseDefaultBackground        types.Bool                   `tfsdk:"use_default_background"`
+	BodyTextColor               types.String                 `tfsdk:"body_text_color"`
+	ButtonColor                 types.String                 `tfsdk:"button_color"`
+	ButtonTextColor             types.String                 `tfsdk:"button_text_color"`
+	CardColor                   types.String                 `tfsdk:"card_color"`
+	FooterText                  types.String                 `tfsdk:"footer_text"`
+	HeadingTextColor            types.String                 `tfsdk:"heading_text_color"`
+	LinkTextColor               types.String                 `tfsdk:"link_text_color"`
+	ApplicationBackgroundColor  types.String                 `tfsdk:"application_background_color"`
+	BodyTextSize                types.String                 `tfsdk:"body_text_size"`
+	BodyTextWeight              types.String                 `tfsdk:"body_text_weight"`
+	ButtonBorderColor           types.String                 `tfsdk:"button_border_color"`
+	ButtonCornerRadius          types.String                 `tfsdk:"button_corner_radius"`
+	ButtonBorderRadius          types.String                 `tfsdk:"button_border_radius"`
+	ButtonBorderWidth           types.String                 `tfsdk:"button_border_width"`
+	ButtonHoverStateBorderColor types.String                 `tfsdk:"button_hover_state_border_color"`
+	ButtonHoverStateFillColor   types.String                 `tfsdk:"button_hover_state_fill_color"`
+	ButtonHoverStateTextColor   types.String                 `tfsdk:"button_hover_state_text_color"`
+	ButtonTextSize              types.String                 `tfsdk:"button_text_size"`
+	ButtonTextWeight            types.String                 `tfsdk:"button_text_weight"`
+	CardBorderColor             types.String                 `tfsdk:"card_border_color"`
+	CardBorderWidth             types.String                 `tfsdk:"card_border_width"`
+	CardCornerRadius            types.String                 `tfsdk:"card_corner_radius"`
+	CardHorizontalAlignment     types.String                 `tfsdk:"card_horizontal_alignment"`
+	CardShadow                  types.String                 `tfsdk:"card_shadow"`
+	CardVerticalAlignment       types.String                 `tfsdk:"card_vertical_alignment"`
+	FocusRectangleColor         types.String                 `tfsdk:"focus_rectangle_color"`
+	FooterLocalized             types.Object                 `tfsdk:"footer_localized"`
+	GlobalFont                  types.String                 `tfsdk:"global_font"`
+	Header                      types.String                 `tfsdk:"header"`
+	HeaderLocalized             types.Object                 `tfsdk:"header_localized"`
+	HeaderBackgroundColor       types.String                 `tfsdk:"header_background_color"`
+	InputBorderWidth            types.String                 `tfsdk:"input_border_width"`
+	InputBoxBorderColor         types.String                 `tfsdk:"input_box_border_color"`
+	InputCornerRadius           types.String                 `tfsdk:"input_corner_radius"`
+	InputLabelPosition          types.String                 `tfsdk:"input_label_position"`
+	InputLabelTextColor         types.String                 `tfsdk:"input_label_text_color"`
+	InputLabelTextSize          types.String                 `tfsdk:"input_label_text_size"`
+	InputLabelTextWeight        types.String                 `tfsdk:"input_label_text_weight"`
+	InputValueTextColor         types.String                 `tfsdk:"input_value_text_color"`
+	InputValueTextSize          types.String                 `tfsdk:"input_value_text_size"`
+	InputValueTextWeight        types.String                 `tfsdk:"input_value_text_weight"`
+	LinkTextHoverColor          types.String                 `tfsdk:"link_text_hover_color"`
+	LinkTextSize                types.String                 `tfsdk:"link_text_size"`
+	LinkTextWeight              types.String                 `tfsdk:"link_text_weight"`
+	LogoHeight                  types.String                 `tfsdk:"logo_height"`
+	SubTitleTextColor           types.String                 `tfsdk:"sub_title_text_color"`
+	SubTitleTextSize            types.String                 `tfsdk:"sub_title_text_size"`
+	SubTitleTextWeight          types.String                 `tfsdk:"sub_title_text_weight"`
+	TitleTextColor              types.String                 `tfsdk:"title_text_color"`
+	TitleTextSize               types.String                 `tfsdk:"title_text_size"`
+	TitleTextWeight             types.String                 `tfsdk:"title_text_weight"`
+}
+
+type brandingThemeLocalizedTextResourceModel struct {
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	DefaultLanguage types.String `tfsdk:"default_language"`
+	ContentType     types.String `tfsdk:"content_type"`
+	Content         types.Map    `tfsdk:"content"`
+}
+
+type brandingThemeLocalizedTextContentResourceModel struct {
+	InputText types.String `tfsdk:"input_text"`
 }
 
 // Framework interfaces
@@ -109,6 +176,10 @@ func (r *BrandingThemeResource) Schema(ctx context.Context, req resource.SchemaR
 	backgroundImageHrefDescription := framework.SchemaAttributeDescriptionFromMarkdown(
 		"The URL or fully qualified path to the background image file used for branding.  This can be retrieved from the `uploaded_image.href` parameter of the `pingone_image` resource.",
 	)
+
+	localizedContentTypeDescription := framework.SchemaAttributeDescriptionFromMarkdown(
+		"The content type for the localized text.",
+	).AllowedValuesEnum(management.AllowedEnumBrandingThemeLocalizedContentTypeEnumValues)
 
 	resp.Schema = schema.Schema{
 
@@ -272,6 +343,344 @@ func (r *BrandingThemeResource) Schema(ctx context.Context, req resource.SchemaR
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
 				},
+			},
+
+			"application_background_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The application background color for the theme. It must be a valid hexadecimal color code.  Note that this property is not used by DaVinci forms.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"header": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The header for the theme.  For example, `<h1>Welcome to PingOne</h1>`.").Description,
+				Optional:    true,
+			},
+
+			"header_background_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The header background color for the theme. It must be a valid hexadecimal color code.  Note that this property is not used by DaVinci forms.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"header_localized": schema.SingleNestedAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The localization object to specify language translations for the form header.").Description,
+				Optional:    true,
+
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("Specifies whether localization is enabled for the header.").Description,
+						Optional:    true,
+						Computed:    true,
+
+						Default: booldefault.StaticBool(false),
+					},
+
+					"default_language": schema.StringAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("The localization language code for the header's default language (for example, `en`).").Description,
+						Required:    true,
+					},
+
+					"content_type": schema.StringAttribute{
+						Description:         localizedContentTypeDescription.Description,
+						MarkdownDescription: localizedContentTypeDescription.MarkdownDescription,
+						Required:            true,
+						Validators: []validator.String{
+							stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumBrandingThemeLocalizedContentTypeEnumValues)...),
+						},
+					},
+
+					"content": schema.MapNestedAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("A map of language codes to the localized text for the language options.  The map key is the language code (for example, `en`).").Description,
+						Required:    true,
+
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"input_text": schema.StringAttribute{
+									Description: framework.SchemaAttributeDescriptionFromMarkdown("The header text in the specified language.").Description,
+									Required:    true,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"footer_localized": schema.SingleNestedAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The localization object to specify language translations for the form footer.").Description,
+				Optional:    true,
+
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("Specifies whether localization is enabled for the footer.").Description,
+						Optional:    true,
+						Computed:    true,
+
+						Default: booldefault.StaticBool(false),
+					},
+
+					"default_language": schema.StringAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("The localization language code for the footer's default language (for example, `en`).").Description,
+						Required:    true,
+					},
+
+					"content_type": schema.StringAttribute{
+						Description:         localizedContentTypeDescription.Description,
+						MarkdownDescription: localizedContentTypeDescription.MarkdownDescription,
+						Required:            true,
+						Validators: []validator.String{
+							stringvalidator.OneOf(utils.EnumSliceToStringSlice(management.AllowedEnumBrandingThemeLocalizedContentTypeEnumValues)...),
+						},
+					},
+
+					"content": schema.MapNestedAttribute{
+						Description: framework.SchemaAttributeDescriptionFromMarkdown("A map of language codes to the localized text for the language options.  The map key is the language code (for example, `en`).").Description,
+						Required:    true,
+
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"input_text": schema.StringAttribute{
+									Description: framework.SchemaAttributeDescriptionFromMarkdown("The footer text in the specified language.").Description,
+									Required:    true,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"body_text_size": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The body text size for the theme.").Description,
+				Optional:    true,
+			},
+
+			"body_text_weight": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The body text weight for the theme (range from 100-900).").Description,
+				Optional:    true,
+			},
+
+			"button_border_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button border color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"button_corner_radius": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button corner radius for the theme (range from 0-25px).").Description,
+				Optional:    true,
+			},
+
+			"button_border_radius": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button border radius for the theme (range from 0-25px).").Description,
+				Optional:    true,
+			},
+
+			"button_border_width": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button border width for the theme (range from 0-4px).").Description,
+				Optional:    true,
+			},
+
+			"button_hover_state_border_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button hover state border color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"button_hover_state_fill_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button hover state fill color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"button_hover_state_text_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button hover state text color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"button_text_size": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button text size for the theme.").Description,
+				Optional:    true,
+			},
+
+			"button_text_weight": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button text weight for the theme (range from 100-900).").Description,
+				Optional:    true,
+			},
+
+			"card_border_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The card border color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"card_border_width": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The card border width for the theme (range from 0-4px).").Description,
+				Optional:    true,
+			},
+
+			"card_corner_radius": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The card corner radius for the theme (range from 0-25px).").Description,
+				Optional:    true,
+			},
+
+			"card_horizontal_alignment": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The card horizontal alignment for the theme.").Description,
+				Optional:    true,
+			},
+
+			"card_shadow": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The card shadow for the theme.").Description,
+				Optional:    true,
+			},
+
+			"card_vertical_alignment": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The card vertical alignment for the theme.").Description,
+				Optional:    true,
+			},
+
+			"focus_rectangle_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The focus rectangle color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"global_font": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The global font for the theme.  The default value is `Helvetica Neue, Helvetica, sans-serif`.").Description,
+				Optional:    true,
+			},
+
+			"input_border_width": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input border width for the theme (range from 0-4px).").Description,
+				Optional:    true,
+			},
+
+			"input_box_border_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input box border color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"input_corner_radius": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input corner radius for the theme (range from 0-25px).").Description,
+				Optional:    true,
+			},
+
+			"input_label_position": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input label position for the theme.").Description,
+				Optional:    true,
+			},
+
+			"input_label_text_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input label text color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"input_label_text_size": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input label text size for the theme.").Description,
+				Optional:    true,
+			},
+
+			"input_label_text_weight": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input label text weight for the theme (range from 100-900).").Description,
+				Optional:    true,
+			},
+
+			"input_value_text_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input value text color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"input_value_text_size": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input value text size for the theme.").Description,
+				Optional:    true,
+			},
+
+			"input_value_text_weight": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The input value text weight for the theme (range from 100-900).").Description,
+				Optional:    true,
+			},
+
+			"link_text_hover_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The link text hover color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"link_text_size": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The link text size for the theme.").Description,
+				Optional:    true,
+			},
+
+			"link_text_weight": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The link text weight for the theme (range from 100-900).").Description,
+				Optional:    true,
+			},
+
+			"logo_height": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The logo height assigned to the image (range from 0-100px).").Description,
+				Optional:    true,
+			},
+
+			"sub_title_text_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The subtitle text color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"sub_title_text_size": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The subtitle text size for the theme.").Description,
+				Optional:    true,
+			},
+
+			"sub_title_text_weight": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The subtitle text weight for the theme (range from 100-900).").Description,
+				Optional:    true,
+			},
+
+			"title_text_color": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The title text color for the theme. It must be a valid hexadecimal color code.").Description,
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(verify.HexColorCode, "Value must be a valid hex color code."),
+				},
+			},
+
+			"title_text_size": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The title text size for the theme.").Description,
+				Optional:    true,
+			},
+
+			"title_text_weight": schema.StringAttribute{
+				Description: framework.SchemaAttributeDescriptionFromMarkdown("The title text weight for the theme (range from 100-900).").Description,
+				Optional:    true,
 			},
 		},
 	}
@@ -589,6 +998,194 @@ func (p *brandingThemeResourceModelV1) expand(ctx context.Context) (*management.
 		configuration.SetFooter(p.FooterText.ValueString())
 	}
 
+	if !p.Header.IsNull() && !p.Header.IsUnknown() {
+		configuration.SetHeader(p.Header.ValueString())
+	}
+
+	if !p.ApplicationBackgroundColor.IsNull() && !p.ApplicationBackgroundColor.IsUnknown() {
+		configuration.SetApplicationBackgroundColor(p.ApplicationBackgroundColor.ValueString())
+	}
+
+	if !p.HeaderBackgroundColor.IsNull() && !p.HeaderBackgroundColor.IsUnknown() {
+		configuration.SetHeaderBackgroundColor(p.HeaderBackgroundColor.ValueString())
+	}
+
+	if !p.BodyTextSize.IsNull() && !p.BodyTextSize.IsUnknown() {
+		configuration.SetBodyTextSize(p.BodyTextSize.ValueString())
+	}
+
+	if !p.BodyTextWeight.IsNull() && !p.BodyTextWeight.IsUnknown() {
+		configuration.SetBodyTextWeight(p.BodyTextWeight.ValueString())
+	}
+
+	if !p.ButtonBorderColor.IsNull() && !p.ButtonBorderColor.IsUnknown() {
+		configuration.SetButtonBorderColor(p.ButtonBorderColor.ValueString())
+	}
+
+	if !p.ButtonCornerRadius.IsNull() && !p.ButtonCornerRadius.IsUnknown() {
+		configuration.SetButtonCornerRadius(p.ButtonCornerRadius.ValueString())
+	}
+
+	if !p.ButtonBorderRadius.IsNull() && !p.ButtonBorderRadius.IsUnknown() {
+		configuration.SetButtonBorderRadius(p.ButtonBorderRadius.ValueString())
+	}
+
+	if !p.ButtonBorderWidth.IsNull() && !p.ButtonBorderWidth.IsUnknown() {
+		configuration.SetButtonBorderWidth(p.ButtonBorderWidth.ValueString())
+	}
+
+	if !p.ButtonHoverStateBorderColor.IsNull() && !p.ButtonHoverStateBorderColor.IsUnknown() {
+		configuration.SetButtonHoverStateBorderColor(p.ButtonHoverStateBorderColor.ValueString())
+	}
+
+	if !p.ButtonHoverStateFillColor.IsNull() && !p.ButtonHoverStateFillColor.IsUnknown() {
+		configuration.SetButtonHoverStateFillColor(p.ButtonHoverStateFillColor.ValueString())
+	}
+
+	if !p.ButtonHoverStateTextColor.IsNull() && !p.ButtonHoverStateTextColor.IsUnknown() {
+		configuration.SetButtonHoverStateTextColor(p.ButtonHoverStateTextColor.ValueString())
+	}
+
+	if !p.ButtonTextSize.IsNull() && !p.ButtonTextSize.IsUnknown() {
+		configuration.SetButtonTextSize(p.ButtonTextSize.ValueString())
+	}
+
+	if !p.ButtonTextWeight.IsNull() && !p.ButtonTextWeight.IsUnknown() {
+		configuration.SetButtonTextWeight(p.ButtonTextWeight.ValueString())
+	}
+
+	if !p.CardBorderColor.IsNull() && !p.CardBorderColor.IsUnknown() {
+		configuration.SetCardBorderColor(p.CardBorderColor.ValueString())
+	}
+
+	if !p.CardBorderWidth.IsNull() && !p.CardBorderWidth.IsUnknown() {
+		configuration.SetCardBorderWidth(p.CardBorderWidth.ValueString())
+	}
+
+	if !p.CardCornerRadius.IsNull() && !p.CardCornerRadius.IsUnknown() {
+		configuration.SetCardCornerRadius(p.CardCornerRadius.ValueString())
+	}
+
+	if !p.CardHorizontalAlignment.IsNull() && !p.CardHorizontalAlignment.IsUnknown() {
+		configuration.SetCardHorizontalAlignment(p.CardHorizontalAlignment.ValueString())
+	}
+
+	if !p.CardShadow.IsNull() && !p.CardShadow.IsUnknown() {
+		configuration.SetCardShadow(p.CardShadow.ValueString())
+	}
+
+	if !p.CardVerticalAlignment.IsNull() && !p.CardVerticalAlignment.IsUnknown() {
+		configuration.SetCardVerticalAlignment(p.CardVerticalAlignment.ValueString())
+	}
+
+	if !p.FocusRectangleColor.IsNull() && !p.FocusRectangleColor.IsUnknown() {
+		configuration.SetFocusRectangleColor(p.FocusRectangleColor.ValueString())
+	}
+
+	if !p.GlobalFont.IsNull() && !p.GlobalFont.IsUnknown() {
+		configuration.SetGlobalFont(p.GlobalFont.ValueString())
+	}
+
+	if !p.InputBorderWidth.IsNull() && !p.InputBorderWidth.IsUnknown() {
+		configuration.SetInputBorderWidth(p.InputBorderWidth.ValueString())
+	}
+
+	if !p.InputBoxBorderColor.IsNull() && !p.InputBoxBorderColor.IsUnknown() {
+		configuration.SetInputBoxBorderColor(p.InputBoxBorderColor.ValueString())
+	}
+
+	if !p.InputCornerRadius.IsNull() && !p.InputCornerRadius.IsUnknown() {
+		configuration.SetInputCornerRadius(p.InputCornerRadius.ValueString())
+	}
+
+	if !p.InputLabelPosition.IsNull() && !p.InputLabelPosition.IsUnknown() {
+		configuration.SetInputLabelPosition(p.InputLabelPosition.ValueString())
+	}
+
+	if !p.InputLabelTextColor.IsNull() && !p.InputLabelTextColor.IsUnknown() {
+		configuration.SetInputLabelTextColor(p.InputLabelTextColor.ValueString())
+	}
+
+	if !p.InputLabelTextSize.IsNull() && !p.InputLabelTextSize.IsUnknown() {
+		configuration.SetInputLabelTextSize(p.InputLabelTextSize.ValueString())
+	}
+
+	if !p.InputLabelTextWeight.IsNull() && !p.InputLabelTextWeight.IsUnknown() {
+		configuration.SetInputLabelTextWeight(p.InputLabelTextWeight.ValueString())
+	}
+
+	if !p.InputValueTextColor.IsNull() && !p.InputValueTextColor.IsUnknown() {
+		configuration.SetInputValueTextColor(p.InputValueTextColor.ValueString())
+	}
+
+	if !p.InputValueTextSize.IsNull() && !p.InputValueTextSize.IsUnknown() {
+		configuration.SetInputValueTextSize(p.InputValueTextSize.ValueString())
+	}
+
+	if !p.InputValueTextWeight.IsNull() && !p.InputValueTextWeight.IsUnknown() {
+		configuration.SetInputValueTextWeight(p.InputValueTextWeight.ValueString())
+	}
+
+	if !p.LinkTextHoverColor.IsNull() && !p.LinkTextHoverColor.IsUnknown() {
+		configuration.SetLinkTextHoverColor(p.LinkTextHoverColor.ValueString())
+	}
+
+	if !p.LinkTextSize.IsNull() && !p.LinkTextSize.IsUnknown() {
+		configuration.SetLinkTextSize(p.LinkTextSize.ValueString())
+	}
+
+	if !p.LinkTextWeight.IsNull() && !p.LinkTextWeight.IsUnknown() {
+		configuration.SetLinkTextWeight(p.LinkTextWeight.ValueString())
+	}
+
+	if !p.LogoHeight.IsNull() && !p.LogoHeight.IsUnknown() {
+		configuration.SetLogoHeight(p.LogoHeight.ValueString())
+	}
+
+	if !p.SubTitleTextColor.IsNull() && !p.SubTitleTextColor.IsUnknown() {
+		configuration.SetSubTitleTextColor(p.SubTitleTextColor.ValueString())
+	}
+
+	if !p.SubTitleTextSize.IsNull() && !p.SubTitleTextSize.IsUnknown() {
+		configuration.SetSubTitleTextSize(p.SubTitleTextSize.ValueString())
+	}
+
+	if !p.SubTitleTextWeight.IsNull() && !p.SubTitleTextWeight.IsUnknown() {
+		configuration.SetSubTitleTextWeight(p.SubTitleTextWeight.ValueString())
+	}
+
+	if !p.TitleTextColor.IsNull() && !p.TitleTextColor.IsUnknown() {
+		configuration.SetTitleTextColor(p.TitleTextColor.ValueString())
+	}
+
+	if !p.TitleTextSize.IsNull() && !p.TitleTextSize.IsUnknown() {
+		configuration.SetTitleTextSize(p.TitleTextSize.ValueString())
+	}
+
+	if !p.TitleTextWeight.IsNull() && !p.TitleTextWeight.IsUnknown() {
+		configuration.SetTitleTextWeight(p.TitleTextWeight.ValueString())
+	}
+
+	if !p.HeaderLocalized.IsNull() && !p.HeaderLocalized.IsUnknown() {
+		headerLocalized, d := p.expandLocalizedText(ctx, p.HeaderLocalized)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		configuration.SetHeaderLocalized(*headerLocalized)
+	}
+
+	if !p.FooterLocalized.IsNull() && !p.FooterLocalized.IsUnknown() {
+		footerLocalized, d := p.expandLocalizedText(ctx, p.FooterLocalized)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		configuration.SetFooterLocalized(*footerLocalized)
+	}
+
 	data := management.NewBrandingTheme(
 		configuration,
 		false,
@@ -596,6 +1193,59 @@ func (p *brandingThemeResourceModelV1) expand(ctx context.Context) (*management.
 	)
 
 	return data, diags
+}
+
+func (p *brandingThemeResourceModelV1) expandLocalizedText(ctx context.Context, localized types.Object) (*management.BrandingThemeConfigurationLocalizedText, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var plan brandingThemeLocalizedTextResourceModel
+
+	diags.Append(localized.As(ctx, &plan, basetypes.ObjectAsOptions{
+		UnhandledNullAsEmpty:    false,
+		UnhandledUnknownAsEmpty: false,
+	})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	localizedData := management.NewBrandingThemeConfigurationLocalizedText()
+
+	localizedData.SetEnabled(plan.Enabled.ValueBool())
+	localizedData.SetDefaultLanguage(plan.DefaultLanguage.ValueString())
+	localizedData.SetContentType(management.EnumBrandingThemeLocalizedContentType(plan.ContentType.ValueString()))
+
+	content := make(map[string]management.BrandingThemeConfigurationLocalizedTextContent, len(plan.Content.Elements()))
+
+	for languageCode, contentValue := range plan.Content.Elements() {
+		contentObj, ok := contentValue.(basetypes.ObjectValue)
+		if !ok {
+			diags.AddError(
+				"Unexpected Content Value Type",
+				fmt.Sprintf("Expected an object value for the localized text content, got: %T. Please report this to the provider maintainers.", contentValue),
+			)
+			continue
+		}
+
+		var contentPlan brandingThemeLocalizedTextContentResourceModel
+
+		diags.Append(contentObj.As(ctx, &contentPlan, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
+		})...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		contentData := management.NewBrandingThemeConfigurationLocalizedTextContent()
+
+		contentData.SetInputText(contentPlan.InputText.ValueString())
+
+		content[languageCode] = *contentData
+	}
+
+	localizedData.SetContent(content)
+
+	return localizedData, diags
 }
 
 func (p *brandingThemeResourceModelV1) toState(apiObject *management.BrandingTheme) diag.Diagnostics {
@@ -640,6 +1290,54 @@ func (p *brandingThemeResourceModelV1) toState(apiObject *management.BrandingThe
 		p.FooterText = framework.StringOkToTF(v.GetFooterOk())
 		p.HeadingTextColor = framework.StringOkToTF(v.GetHeadingTextColorOk())
 		p.LinkTextColor = framework.StringOkToTF(v.GetLinkTextColorOk())
+
+		p.Header = framework.StringOkToTF(v.GetHeaderOk())
+		p.ApplicationBackgroundColor = framework.StringOkToTF(v.GetApplicationBackgroundColorOk())
+		p.HeaderBackgroundColor = framework.StringOkToTF(v.GetHeaderBackgroundColorOk())
+		p.BodyTextSize = framework.StringOkToTF(v.GetBodyTextSizeOk())
+		p.BodyTextWeight = framework.StringOkToTF(v.GetBodyTextWeightOk())
+		p.ButtonBorderColor = framework.StringOkToTF(v.GetButtonBorderColorOk())
+		p.ButtonCornerRadius = framework.StringOkToTF(v.GetButtonCornerRadiusOk())
+		p.ButtonBorderRadius = framework.StringOkToTF(v.GetButtonBorderRadiusOk())
+		p.ButtonBorderWidth = framework.StringOkToTF(v.GetButtonBorderWidthOk())
+		p.ButtonHoverStateBorderColor = framework.StringOkToTF(v.GetButtonHoverStateBorderColorOk())
+		p.ButtonHoverStateFillColor = framework.StringOkToTF(v.GetButtonHoverStateFillColorOk())
+		p.ButtonHoverStateTextColor = framework.StringOkToTF(v.GetButtonHoverStateTextColorOk())
+		p.ButtonTextSize = framework.StringOkToTF(v.GetButtonTextSizeOk())
+		p.ButtonTextWeight = framework.StringOkToTF(v.GetButtonTextWeightOk())
+		p.CardBorderColor = framework.StringOkToTF(v.GetCardBorderColorOk())
+		p.CardBorderWidth = framework.StringOkToTF(v.GetCardBorderWidthOk())
+		p.CardCornerRadius = framework.StringOkToTF(v.GetCardCornerRadiusOk())
+		p.CardHorizontalAlignment = framework.StringOkToTF(v.GetCardHorizontalAlignmentOk())
+		p.CardShadow = framework.StringOkToTF(v.GetCardShadowOk())
+		p.CardVerticalAlignment = framework.StringOkToTF(v.GetCardVerticalAlignmentOk())
+		p.FocusRectangleColor = framework.StringOkToTF(v.GetFocusRectangleColorOk())
+		p.GlobalFont = framework.StringOkToTF(v.GetGlobalFontOk())
+		p.InputBorderWidth = framework.StringOkToTF(v.GetInputBorderWidthOk())
+		p.InputBoxBorderColor = framework.StringOkToTF(v.GetInputBoxBorderColorOk())
+		p.InputCornerRadius = framework.StringOkToTF(v.GetInputCornerRadiusOk())
+		p.InputLabelPosition = framework.StringOkToTF(v.GetInputLabelPositionOk())
+		p.InputLabelTextColor = framework.StringOkToTF(v.GetInputLabelTextColorOk())
+		p.InputLabelTextSize = framework.StringOkToTF(v.GetInputLabelTextSizeOk())
+		p.InputLabelTextWeight = framework.StringOkToTF(v.GetInputLabelTextWeightOk())
+		p.InputValueTextColor = framework.StringOkToTF(v.GetInputValueTextColorOk())
+		p.InputValueTextSize = framework.StringOkToTF(v.GetInputValueTextSizeOk())
+		p.InputValueTextWeight = framework.StringOkToTF(v.GetInputValueTextWeightOk())
+		p.LinkTextHoverColor = framework.StringOkToTF(v.GetLinkTextHoverColorOk())
+		p.LinkTextSize = framework.StringOkToTF(v.GetLinkTextSizeOk())
+		p.LinkTextWeight = framework.StringOkToTF(v.GetLinkTextWeightOk())
+		p.LogoHeight = framework.StringOkToTF(v.GetLogoHeightOk())
+		p.SubTitleTextColor = framework.StringOkToTF(v.GetSubTitleTextColorOk())
+		p.SubTitleTextSize = framework.StringOkToTF(v.GetSubTitleTextSizeOk())
+		p.SubTitleTextWeight = framework.StringOkToTF(v.GetSubTitleTextWeightOk())
+		p.TitleTextColor = framework.StringOkToTF(v.GetTitleTextColorOk())
+		p.TitleTextSize = framework.StringOkToTF(v.GetTitleTextSizeOk())
+		p.TitleTextWeight = framework.StringOkToTF(v.GetTitleTextWeightOk())
+
+		p.HeaderLocalized, d = toStateBrandingThemeLocalizedTextOk(v.GetHeaderLocalizedOk())
+		diags.Append(d...)
+		p.FooterLocalized, d = toStateBrandingThemeLocalizedTextOk(v.GetFooterLocalizedOk())
+		diags.Append(d...)
 	} else {
 		p.Name = types.StringNull()
 		p.BackgroundColor = types.StringNull()
@@ -651,7 +1349,103 @@ func (p *brandingThemeResourceModelV1) toState(apiObject *management.BrandingThe
 		p.FooterText = types.StringNull()
 		p.HeadingTextColor = types.StringNull()
 		p.LinkTextColor = types.StringNull()
+
+		p.Header = types.StringNull()
+		p.ApplicationBackgroundColor = types.StringNull()
+		p.HeaderBackgroundColor = types.StringNull()
+		p.BodyTextSize = types.StringNull()
+		p.BodyTextWeight = types.StringNull()
+		p.ButtonBorderColor = types.StringNull()
+		p.ButtonCornerRadius = types.StringNull()
+		p.ButtonBorderRadius = types.StringNull()
+		p.ButtonBorderWidth = types.StringNull()
+		p.ButtonHoverStateBorderColor = types.StringNull()
+		p.ButtonHoverStateFillColor = types.StringNull()
+		p.ButtonHoverStateTextColor = types.StringNull()
+		p.ButtonTextSize = types.StringNull()
+		p.ButtonTextWeight = types.StringNull()
+		p.CardBorderColor = types.StringNull()
+		p.CardBorderWidth = types.StringNull()
+		p.CardCornerRadius = types.StringNull()
+		p.CardHorizontalAlignment = types.StringNull()
+		p.CardShadow = types.StringNull()
+		p.CardVerticalAlignment = types.StringNull()
+		p.FocusRectangleColor = types.StringNull()
+		p.GlobalFont = types.StringNull()
+		p.InputBorderWidth = types.StringNull()
+		p.InputBoxBorderColor = types.StringNull()
+		p.InputCornerRadius = types.StringNull()
+		p.InputLabelPosition = types.StringNull()
+		p.InputLabelTextColor = types.StringNull()
+		p.InputLabelTextSize = types.StringNull()
+		p.InputLabelTextWeight = types.StringNull()
+		p.InputValueTextColor = types.StringNull()
+		p.InputValueTextSize = types.StringNull()
+		p.InputValueTextWeight = types.StringNull()
+		p.LinkTextHoverColor = types.StringNull()
+		p.LinkTextSize = types.StringNull()
+		p.LinkTextWeight = types.StringNull()
+		p.LogoHeight = types.StringNull()
+		p.SubTitleTextColor = types.StringNull()
+		p.SubTitleTextSize = types.StringNull()
+		p.SubTitleTextWeight = types.StringNull()
+		p.TitleTextColor = types.StringNull()
+		p.TitleTextSize = types.StringNull()
+		p.TitleTextWeight = types.StringNull()
+
+		p.HeaderLocalized = types.ObjectNull(brandingThemeLocalizedTextTFObjectTypes)
+		p.FooterLocalized = types.ObjectNull(brandingThemeLocalizedTextTFObjectTypes)
 	}
 
 	return diags
+}
+
+func toStateBrandingThemeLocalizedTextOk(apiObject *management.BrandingThemeConfigurationLocalizedText, ok bool) (types.Object, diag.Diagnostics) {
+	var diags, d diag.Diagnostics
+
+	if !ok || apiObject == nil {
+		return types.ObjectNull(brandingThemeLocalizedTextTFObjectTypes), diags
+	}
+
+	o := map[string]attr.Value{
+		"enabled":          framework.BoolOkToTF(apiObject.GetEnabledOk()),
+		"default_language": framework.StringOkToTF(apiObject.GetDefaultLanguageOk()),
+		"content_type":     framework.EnumOkToTF(apiObject.GetContentTypeOk()),
+	}
+
+	content, contentOk := apiObject.GetContentOk()
+	o["content"], d = toStateBrandingThemeLocalizedTextContentOk(content, contentOk)
+	diags.Append(d...)
+
+	returnVar, d := types.ObjectValue(brandingThemeLocalizedTextTFObjectTypes, o)
+	diags.Append(d...)
+
+	return returnVar, diags
+}
+
+func toStateBrandingThemeLocalizedTextContentOk(apiObject *map[string]management.BrandingThemeConfigurationLocalizedTextContent, ok bool) (types.Map, diag.Diagnostics) {
+	var diags, d diag.Diagnostics
+
+	tfObjType := types.ObjectType{AttrTypes: brandingThemeLocalizedTextContentTFObjectTypes}
+
+	if !ok || apiObject == nil || len(*apiObject) == 0 {
+		return types.MapNull(tfObjType), diags
+	}
+
+	objectMap := map[string]attr.Value{}
+	for languageCode, content := range *apiObject {
+		o := map[string]attr.Value{
+			"input_text": framework.StringOkToTF(content.GetInputTextOk()),
+		}
+
+		objValue, d := types.ObjectValue(brandingThemeLocalizedTextContentTFObjectTypes, o)
+		diags.Append(d...)
+
+		objectMap[languageCode] = objValue
+	}
+
+	returnVar, d := types.MapValue(tfObjType, objectMap)
+	diags.Append(d...)
+
+	return returnVar, diags
 }

--- a/internal/service/base/resource_branding_theme.go
+++ b/internal/service/base/resource_branding_theme.go
@@ -66,7 +66,6 @@ type brandingThemeResourceModelV1 struct {
 	BodyTextWeight              types.String                 `tfsdk:"body_text_weight"`
 	ButtonBorderColor           types.String                 `tfsdk:"button_border_color"`
 	ButtonCornerRadius          types.String                 `tfsdk:"button_corner_radius"`
-	ButtonBorderRadius          types.String                 `tfsdk:"button_border_radius"`
 	ButtonBorderWidth           types.String                 `tfsdk:"button_border_width"`
 	ButtonHoverStateBorderColor types.String                 `tfsdk:"button_hover_state_border_color"`
 	ButtonHoverStateFillColor   types.String                 `tfsdk:"button_hover_state_fill_color"`
@@ -472,11 +471,6 @@ func (r *BrandingThemeResource) Schema(ctx context.Context, req resource.SchemaR
 
 			"button_corner_radius": schema.StringAttribute{
 				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button corner radius for the theme (range from 0-25px).").Description,
-				Optional:    true,
-			},
-
-			"button_border_radius": schema.StringAttribute{
-				Description: framework.SchemaAttributeDescriptionFromMarkdown("The button border radius for the theme (range from 0-25px).").Description,
 				Optional:    true,
 			},
 
@@ -1026,10 +1020,6 @@ func (p *brandingThemeResourceModelV1) expand(ctx context.Context) (*management.
 		configuration.SetButtonCornerRadius(p.ButtonCornerRadius.ValueString())
 	}
 
-	if !p.ButtonBorderRadius.IsNull() && !p.ButtonBorderRadius.IsUnknown() {
-		configuration.SetButtonBorderRadius(p.ButtonBorderRadius.ValueString())
-	}
-
 	if !p.ButtonBorderWidth.IsNull() && !p.ButtonBorderWidth.IsUnknown() {
 		configuration.SetButtonBorderWidth(p.ButtonBorderWidth.ValueString())
 	}
@@ -1298,7 +1288,6 @@ func (p *brandingThemeResourceModelV1) toState(apiObject *management.BrandingThe
 		p.BodyTextWeight = framework.StringOkToTF(v.GetBodyTextWeightOk())
 		p.ButtonBorderColor = framework.StringOkToTF(v.GetButtonBorderColorOk())
 		p.ButtonCornerRadius = framework.StringOkToTF(v.GetButtonCornerRadiusOk())
-		p.ButtonBorderRadius = framework.StringOkToTF(v.GetButtonBorderRadiusOk())
 		p.ButtonBorderWidth = framework.StringOkToTF(v.GetButtonBorderWidthOk())
 		p.ButtonHoverStateBorderColor = framework.StringOkToTF(v.GetButtonHoverStateBorderColorOk())
 		p.ButtonHoverStateFillColor = framework.StringOkToTF(v.GetButtonHoverStateFillColorOk())
@@ -1357,7 +1346,6 @@ func (p *brandingThemeResourceModelV1) toState(apiObject *management.BrandingThe
 		p.BodyTextWeight = types.StringNull()
 		p.ButtonBorderColor = types.StringNull()
 		p.ButtonCornerRadius = types.StringNull()
-		p.ButtonBorderRadius = types.StringNull()
 		p.ButtonBorderWidth = types.StringNull()
 		p.ButtonHoverStateBorderColor = types.StringNull()
 		p.ButtonHoverStateFillColor = types.StringNull()

--- a/internal/service/base/resource_branding_theme_test.go
+++ b/internal/service/base/resource_branding_theme_test.go
@@ -170,6 +170,32 @@ func TestAccBrandingTheme_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "card_horizontal_alignment", "left"),
 					resource.TestCheckResourceAttr(resourceFullName, "card_vertical_alignment", "center"),
 					resource.TestCheckResourceAttr(resourceFullName, "input_label_position", "float"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_border_color", "#112233"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_hover_state_border_color", "#223344"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_hover_state_fill_color", "#334455"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_hover_state_text_color", "#556677"),
+					resource.TestCheckResourceAttr(resourceFullName, "card_border_color", "#CACED3"),
+					resource.TestCheckResourceAttr(resourceFullName, "card_border_width", "2px"),
+					resource.TestCheckResourceAttr(resourceFullName, "card_corner_radius", "4px"),
+					resource.TestCheckResourceAttr(resourceFullName, "card_shadow", "0px 2px 0px 0px rgba(0,0,0,0.1)"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_border_width", "1px"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_box_border_color", "#667788"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_corner_radius", "5px"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_label_text_color", "#798087"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_label_text_size", "14px"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_label_text_weight", "500"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_value_text_color", "#798087"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_value_text_size", "13px"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_value_text_weight", "600"),
+					resource.TestCheckResourceAttr(resourceFullName, "link_text_hover_color", "#007CBA"),
+					resource.TestCheckResourceAttr(resourceFullName, "link_text_size", "15px"),
+					resource.TestCheckResourceAttr(resourceFullName, "link_text_weight", "400"),
+					resource.TestCheckResourceAttr(resourceFullName, "sub_title_text_size", "15px"),
+					resource.TestCheckResourceAttr(resourceFullName, "sub_title_text_weight", "400"),
+					resource.TestCheckResourceAttr(resourceFullName, "title_text_size", "20px"),
+					resource.TestCheckResourceAttr(resourceFullName, "title_text_weight", "600"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_text_size", "16px"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_text_weight", "400"),
 				),
 			},
 			// Test importing the resource
@@ -226,6 +252,8 @@ func TestAccBrandingTheme_FullLocalized(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "header_localized.content.fr.input_text", "<h1>Bienvenue</h1>"),
 					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.default_language", "en"),
+					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.content_type", "HTML"),
+					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.content.%", "1"),
 					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.content.en.input_text", "<p>Copyright</p>"),
 				),
 			},
@@ -557,6 +585,33 @@ resource "pingone_branding_theme" "%[2]s" {
   card_vertical_alignment      = "center"
   input_label_position         = "float"
   header                       = "<h1>Welcome to PingOne</h1>"
+
+  button_border_color             = "#112233"
+  button_hover_state_border_color = "#223344"
+  button_hover_state_fill_color   = "#334455"
+  button_hover_state_text_color   = "#556677"
+  card_border_color               = "#CACED3"
+  card_border_width               = "2px"
+  card_corner_radius              = "4px"
+  card_shadow                     = "0px 2px 0px 0px rgba(0,0,0,0.1)"
+  input_border_width              = "1px"
+  input_box_border_color          = "#667788"
+  input_corner_radius             = "5px"
+  input_label_text_color          = "#798087"
+  input_label_text_size           = "14px"
+  input_label_text_weight         = "500"
+  input_value_text_color          = "#798087"
+  input_value_text_size           = "13px"
+  input_value_text_weight         = "600"
+  link_text_hover_color           = "#007CBA"
+  link_text_size                  = "15px"
+  link_text_weight                = "400"
+  sub_title_text_size             = "15px"
+  sub_title_text_weight           = "400"
+  title_text_size                 = "20px"
+  title_text_weight               = "600"
+  button_text_size                = "16px"
+  button_text_weight              = "400"
 
   // NOTE: header_localized / footer_localized are exercised in TestAccBrandingTheme_FullLocalized.
   // The PingOne API cannot remove these objects once set (see scratch/pingone-branding-theme-api-echo-issues.md),

--- a/internal/service/base/resource_branding_theme_test.go
+++ b/internal/service/base/resource_branding_theme_test.go
@@ -155,6 +155,78 @@ func TestAccBrandingTheme_Full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "footer_text", "What do you call a can opener that doesn't work? A can't opener."),
 					resource.TestCheckResourceAttr(resourceFullName, "heading_text_color", "#FF0005"),
 					resource.TestCheckResourceAttr(resourceFullName, "link_text_color", "#8A7F06"),
+					resource.TestCheckResourceAttr(resourceFullName, "header", "<h1>Welcome to PingOne</h1>"),
+					resource.TestCheckResourceAttr(resourceFullName, "application_background_color", "#F8F8F8"),
+					resource.TestCheckResourceAttr(resourceFullName, "header_background_color", "#4A4A4A"),
+					resource.TestCheckResourceAttr(resourceFullName, "focus_rectangle_color", "#D033FF"),
+					resource.TestCheckResourceAttr(resourceFullName, "title_text_color", "#4A4A4A"),
+					resource.TestCheckResourceAttr(resourceFullName, "sub_title_text_color", "#4A4A4A"),
+					resource.TestCheckResourceAttr(resourceFullName, "body_text_size", "15px"),
+					resource.TestCheckResourceAttr(resourceFullName, "body_text_weight", "400"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_corner_radius", "2px"),
+					resource.TestCheckResourceAttr(resourceFullName, "button_border_width", "1px"),
+					resource.TestCheckResourceAttr(resourceFullName, "global_font", "\"Helvetica Neue\", Helvetica, sans-serif"),
+					resource.TestCheckResourceAttr(resourceFullName, "logo_height", "56px"),
+					resource.TestCheckResourceAttr(resourceFullName, "card_horizontal_alignment", "left"),
+					resource.TestCheckResourceAttr(resourceFullName, "card_vertical_alignment", "center"),
+					resource.TestCheckResourceAttr(resourceFullName, "input_label_position", "float"),
+				),
+			},
+			// Test importing the resource
+			{
+				ResourceName: resourceFullName,
+				ImportStateIdFunc: func() resource.ImportStateIdFunc {
+					return func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources[resourceFullName]
+						if !ok {
+							return "", fmt.Errorf("resource not found: %s", resourceFullName)
+						}
+
+						return fmt.Sprintf("%s/%s", rs.Primary.Attributes["environment_id"], rs.Primary.ID), nil
+					}
+				}(),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccBrandingTheme_FullLocalized exercises header_localized / footer_localized in
+// isolation: the PingOne API cannot remove these objects once configured (see
+// scratch/pingone-branding-theme-api-echo-issues.md), so the config is applied once and
+// never transitioned away from.
+func TestAccBrandingTheme_FullLocalized(t *testing.T) {
+	t.Parallel()
+
+	resourceName := acctest.ResourceNameGen()
+	resourceFullName := fmt.Sprintf("pingone_branding_theme.%s", resourceName)
+
+	name := resourceName
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheckNoTestAccFlaky(t)
+			acctest.PreCheckClient(t)
+			acctest.PreCheckNoBeta(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             base.BrandingTheme_CheckDestroy,
+		ErrorCheck:               acctest.ErrorCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBrandingThemeConfig_FullLocalized(resourceName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(resourceFullName, "id", verify.P1ResourceIDRegexpFullString),
+					resource.TestCheckResourceAttr(resourceFullName, "header_localized.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "header_localized.default_language", "en"),
+					resource.TestCheckResourceAttr(resourceFullName, "header_localized.content_type", "HTML"),
+					resource.TestCheckResourceAttr(resourceFullName, "header_localized.content.%", "2"),
+					resource.TestCheckResourceAttr(resourceFullName, "header_localized.content.en.input_text", "<h1>Welcome</h1>"),
+					resource.TestCheckResourceAttr(resourceFullName, "header_localized.content.fr.input_text", "<h1>Bienvenue</h1>"),
+					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.default_language", "en"),
+					resource.TestCheckResourceAttr(resourceFullName, "footer_localized.content.en.input_text", "<p>Copyright</p>"),
 				),
 			},
 			// Test importing the resource
@@ -214,6 +286,10 @@ func TestAccBrandingTheme_Minimal(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceFullName, "footer_text"),
 					resource.TestCheckResourceAttr(resourceFullName, "heading_text_color", "#FF0005"),
 					resource.TestCheckResourceAttr(resourceFullName, "link_text_color", "#8A7F06"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "header"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "header_localized"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "footer_localized"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "title_text_color"),
 				),
 			},
 		},
@@ -284,10 +360,14 @@ func TestAccBrandingTheme_Change(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceFullName, "button_text_color", "#FF6C6C"),
 					resource.TestCheckResourceAttr(resourceFullName, "card_color", "#0FFF39"),
 					resource.TestCheckNoResourceAttr(resourceFullName, "footer_text"),
+					resource.TestCheckNoResourceAttr(resourceFullName, "header"),
 					resource.TestCheckResourceAttr(resourceFullName, "heading_text_color", "#FF0005"),
 					resource.TestCheckResourceAttr(resourceFullName, "link_text_color", "#8A7F06"),
 				),
 			},
+			// NOTE: no localized-to-unlocalized transition step here — the PingOne API cannot
+			// remove headerLocalized/footerLocalized once set (see scratch/pingone-branding-theme-api-echo-issues.md),
+			// so a config that removes the block would churn indefinitely.
 			{
 				Config: testAccBrandingThemeConfig_Full(resourceName, name, logo, background),
 				Check: resource.ComposeTestCheckFunc(
@@ -338,6 +418,16 @@ func TestAccBrandingTheme_ValidationChecks(t *testing.T) {
 			{
 				Config:      testAccBrandingThemeConfig_BackgroundColorAndBackgroundImageConflict(resourceName, name, background),
 				ExpectError: regexp.MustCompile(`Error: Invalid Attribute Combination`),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccBrandingThemeConfig_InvalidLocalizedContentType(resourceName, name),
+				ExpectError: regexp.MustCompile(`value must be one of`),
+				Destroy:     true,
+			},
+			{
+				Config:      testAccBrandingThemeConfig_InvalidTitleTextColor(resourceName, name),
+				ExpectError: regexp.MustCompile(`Value must be a valid hex color code.`),
 				Destroy:     true,
 			},
 		},
@@ -452,6 +542,26 @@ resource "pingone_branding_theme" "%[2]s" {
 
   footer_text = "What do you call a can opener that doesn't work? A can't opener."
 
+  application_background_color = "#F8F8F8"
+  header_background_color      = "#4A4A4A"
+  focus_rectangle_color        = "#D033FF"
+  title_text_color             = "#4A4A4A"
+  sub_title_text_color         = "#4A4A4A"
+  body_text_size               = "15px"
+  body_text_weight             = "400"
+  button_corner_radius         = "2px"
+  button_border_width          = "1px"
+  global_font                  = "\"Helvetica Neue\", Helvetica, sans-serif"
+  logo_height                  = "56px"
+  card_horizontal_alignment    = "left"
+  card_vertical_alignment      = "center"
+  input_label_position         = "float"
+  header                       = "<h1>Welcome to PingOne</h1>"
+
+  // NOTE: header_localized / footer_localized are exercised in TestAccBrandingTheme_FullLocalized.
+  // The PingOne API cannot remove these objects once set (see scratch/pingone-branding-theme-api-echo-issues.md),
+  // so the full→minimal transitions below must not cross the localized boundary.
+
 }`, acctest.GenericSandboxEnvironment(), resourceName, name, logo, background)
 }
 
@@ -472,6 +582,96 @@ resource "pingone_branding_theme" "%[2]s" {
   body_text_color    = "#8620FF"
   link_text_color    = "#8A7F06"
   button_color       = "#0CFFFB"
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccBrandingThemeConfig_FullLocalized(resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_branding_theme" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name     = "%[3]s"
+  template = "split"
+
+  button_text_color  = "#FF6C6C"
+  heading_text_color = "#FF0005"
+  card_color         = "#0FFF39"
+  body_text_color    = "#8620FF"
+  link_text_color    = "#8A7F06"
+  button_color       = "#0CFFFB"
+
+  header_localized = {
+    enabled          = true
+    default_language = "en"
+    content_type     = "HTML"
+    content = {
+      en = { input_text = "<h1>Welcome</h1>" }
+      fr = { input_text = "<h1>Bienvenue</h1>" }
+    }
+  }
+
+  footer_localized = {
+    enabled          = true
+    default_language = "en"
+    content_type     = "HTML"
+    content = {
+      en = { input_text = "<p>Copyright</p>" }
+    }
+  }
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccBrandingThemeConfig_InvalidLocalizedContentType(resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_branding_theme" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name     = "%[3]s"
+  template = "split"
+
+  button_text_color  = "#FF6C6C"
+  heading_text_color = "#FF0005"
+  card_color         = "#0FFF39"
+  body_text_color    = "#8620FF"
+  link_text_color    = "#8A7F06"
+  button_color       = "#0CFFFB"
+
+  header_localized = {
+    enabled          = true
+    default_language = "en"
+    content_type     = "Markdown"
+    content = {
+      en = { input_text = "<h1>Welcome</h1>" }
+    }
+  }
+
+}`, acctest.GenericSandboxEnvironment(), resourceName, name)
+}
+
+func testAccBrandingThemeConfig_InvalidTitleTextColor(resourceName, name string) string {
+	return fmt.Sprintf(`
+		%[1]s
+
+resource "pingone_branding_theme" "%[2]s" {
+  environment_id = data.pingone_environment.general_test.id
+
+  name     = "%[3]s"
+  template = "split"
+
+  background_color   = "#FF00F0"
+  button_text_color  = "#FF6C6C"
+  heading_text_color = "#FF0005"
+  card_color         = "#0FFF39"
+  body_text_color    = "#8620FF"
+  link_text_color    = "#8A7F06"
+  button_color       = "#0CFFFB"
+  title_text_color   = "red"
 
 }`, acctest.GenericSandboxEnvironment(), resourceName, name)
 }


### PR DESCRIPTION
## Change Description
- Add many new branding themes in management client v0.71.0 to align with the API, including localized header and footer fields
- Add test coverage for all fields

## Change Characteristics

- [ ] **This PR contains beta functionality**
- [ ] **This PR requires introduction of breaking changes**
- [ ] **No changelog entry is needed**

## Checklist
<!-- Please check off completed items. -->

_All full (or complete) PRs that need review prior to merge should have the following box checked._

_If contributing a partial or incomplete change (expecting the development team to complete the remaining work) please leave the box unchecked_

- [x] **Check to confirm**: I have performed a review of my PR against the [PR checklist](../contributing/pr-checklist.md) and confirm that:
  - The changelog entry has been included according to the [changelog process](../contributing/changelog-process.md)
  - Changes have proper test coverage (including regression tests)
  - Impacted resource, data source and schema descriptions have been reviewed and updated
  - Impacted resource and data source documentation HCL examples have been reviewed and updated
  - Does not introduce breaking changes (unless required to do so)
  - I am aware that changes to generated code may not be merged

## Required SDK Upgrades
<!-- Use this section to describe or list any dependencies, and the required version, that need upgrading in the provider prior to merge. -->

<!--
N/a

- github.com/patrickcping/pingone-go-sdk-v2 v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/authorize v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/credentials v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/management v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/mfa v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/risk v0.5.0
- github.com/patrickcping/pingone-go-sdk-v2/verify v0.5.0
-->

## Testing

This PR has been tested with:

- [ ] Unit tests _(please paste commands and results below)_
- [ ] Acceptance tests _(please paste commands and results below)_
- [ ] End-to-end tests _(please paste the link to the actions workflow runs)_
- [ ] Not applicable _(no evidences needed)_

### Shell Command(s)
<!-- Use the following shell block to paste the command used when testing.  An example of a testing command could be: -->
<!-- TF_ACC=1 go test -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
<!-- An example of a test against beta functionality might be: -->
<!-- TF_ACC=1 TESTACC_BETA=true go test -tags=beta -v -timeout 240s -run ^TestAccBrandingTheme $(go list ./internal/service/...) -->
```shell
TF_ACC=1 go test -count=1 -v -timeout 600s -run '^TestAccBrandingTheme_' ./internal/service/base/
```

### Testing Results
<!-- Use the following shell block to paste the results from the testing command(s) used above -->

<details>
  <summary>Expand Results</summary>

```shell
--- PASS: TestAccBrandingTheme_ValidationChecks (2.90s)
--- PASS: TestAccBrandingTheme_Minimal (7.89s)
--- PASS: TestAccBrandingTheme_FullLocalized (9.69s)
--- PASS: TestAccBrandingTheme_Full (10.30s)
--- PASS: TestAccBrandingTheme_BadParameters (12.61s)
--- PASS: TestAccBrandingTheme_Change (16.66s)
--- PASS: TestAccBrandingTheme_NewEnv (42.75s)
--- PASS: TestAccBrandingTheme_RemovalDrift (76.78s)
PASS
ok      github.com/pingidentity/terraform-provider-pingone/internal/service/base 77.642s
```

</details>
